### PR TITLE
[abt-lib] add generic parsing into abts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cm
+.smackage

--- a/abt-lib/abt-lib.cm
+++ b/abt-lib/abt-lib.cm
@@ -1,27 +1,40 @@
 Library
   signature VARIABLE
   signature OPERATOR
+  signature PARSE_OPERATOR
+
   signature ABT
-  signature ABTUTIL
+  signature ABT_UTIL
+  signature PARSE_ABT
   signature VECTORUTIL
 
   functor Abt
   functor AbtUtil
   functor Variable
+  functor ParseAbt
   structure VectorUtil
   structure PrintMode
+
+  (* examples *)
+  functor ParseAbtTest
 is
   variable.sig
   operator.sig
-  abt.sig
-  abtutil.sig
+  parse_operator.sig
+
   vectorutil.sig
+
+  abt.sig
+  abt_util.sig
   abt.fun
-  abtutil.fun
+  abt_util.fun
+  parse_abt.sig
+  parse_abt.fun
   vectorutil.sml
   print_mode.sml
   variable.fun
 
-  $/basis.cm
-  $/smlnj-lib.cm
+  parse_abt_test.fun
 
+  $SMACKAGE/parcom/v1/parcom.cm
+  $SMACKAGE/cmlib/v1/cmlib.cm

--- a/abt-lib/abt.fun
+++ b/abt-lib/abt.fun
@@ -1,9 +1,6 @@
 functor Abt
   (structure Operator : OPERATOR
-   structure Variable : VARIABLE) :> ABT
-  where Operator = Operator
-    and Variable = Variable
-  =
+   structure Variable : VARIABLE) : ABT =
 struct
   structure Operator : OPERATOR = Operator
   structure Variable : VARIABLE = Variable
@@ -11,16 +8,16 @@ struct
   infix 5 \
   infix 5 $
 
-  datatype t =
-    FREE of Variable.t
-  | BOUND of int
-  | ABS of Variable.t * t
-  | APP of Operator.t * t vector
+  datatype t
+    = FREE of Variable.t
+    | BOUND of int
+    | ABS of Variable.t * t
+    | APP of Operator.t * t vector
 
-  datatype 'a view =
-    ` of Variable.t
-  | \ of Variable.t * 'a
-  | $ of Operator.t * 'a vector
+  datatype 'a view
+    = ` of Variable.t
+    | \ of Variable.t * 'a
+    | $ of Operator.t * 'a vector
 
   fun map f (` v) = ` v
     | map f (v \ e') = v \ f e'

--- a/abt-lib/abt.sig
+++ b/abt-lib/abt.sig
@@ -5,10 +5,10 @@ sig
 
   type t
 
-  datatype 'a view =
-    ` of Variable.t
-  | \ of Variable.t * 'a
-  | $ of Operator.t * 'a vector
+  datatype 'a view
+    = ` of Variable.t
+    | \ of Variable.t * 'a
+    | $ of Operator.t * 'a vector
 
   exception Malformed of string
 

--- a/abt-lib/abt_util.fun
+++ b/abt-lib/abt_util.fun
@@ -1,6 +1,5 @@
-functor AbtUtil (A : ABT) : ABTUTIL =
+functor AbtUtil (A : ABT) : ABT_UTIL =
 struct
-
   open A
 
   infix 5 $

--- a/abt-lib/abt_util.sig
+++ b/abt-lib/abt_util.sig
@@ -1,6 +1,5 @@
-signature ABTUTIL =
+signature ABT_UTIL =
 sig
-
   include ABT
 
   val `` : Variable.t -> t

--- a/abt-lib/parse_abt.fun
+++ b/abt-lib/parse_abt.fun
@@ -1,0 +1,73 @@
+functor ParseAbt
+  (structure Syntax : ABT_UTIL
+   structure Operator : PARSE_OPERATOR
+   sharing Syntax.Operator = Operator) : PARSE_ABT =
+struct
+  structure ParseOp = Operator
+
+  val force = ParserCombinators.$
+  open ParserCombinators CharParser Syntax
+
+  infix 5 $$ \\
+
+  infixr 4 << >>
+  infixr 3 &&
+  infix 2 -- ##
+  infix 2 wth suchthat return guard when
+  infixr 1 || <|> ??
+
+  structure LangDef :> LANGUAGE_DEF =
+  struct
+    type scanner = char CharParser.charParser
+    val commentStart = NONE
+    val commentEnd = NONE
+    val commentLine = NONE
+    val nestedComments = false
+
+    val identLetter = CharParser.letter
+    val identStart = identLetter
+    val opStart = fail "Operators not supported" : scanner
+    val opLetter = opStart
+    val reservedNames = []
+    val reservedOpNames = []
+    val caseSensitive = true
+  end
+
+  structure TP = TokenParser (LangDef)
+  open TP
+
+  structure SymbolTable =
+  struct
+    type t = Variable.t StringListDict.dict
+    fun bind H (n, v) = StringListDict.insert H n v
+    fun named H n = StringListDict.lookup H n handle _ => Variable.named n
+    val empty = StringListDict.empty
+  end
+
+  fun parens p = (symbol "(" >> spaces) >> p << (spaces >> symbol ")")
+  fun >>= (p : 'a charParser, q : 'a -> 'b charParser) : 'b charParser = join (p wth q)
+  infix >>=
+
+  local
+    val new_variable = identifier wth (fn x => (x, Variable.named x))
+    fun var sigma = identifier wth (fn x => `` (SymbolTable.named sigma x))
+
+    fun abt sigma () = force (app sigma) || force (abs sigma) || var sigma ?? "abt"
+    and app sigma () =
+      ParseOp.parse_operator
+        && opt (parens (force (args sigma)))
+        wth (fn (O, ES) => O $$ (getOpt (ES, #[]))) ?? "app"
+    and abs sigma () =
+      (new_variable << spaces << symbol "." << spaces >>= (fn (n,v) =>
+        let
+          val sigma' = SymbolTable.bind sigma (n,v)
+        in
+          force (abt sigma') wth (fn E => v \\ E)
+        end)) ?? "abs"
+
+    and args sigma () = separate (force (abt sigma)) (symbol ";") wth Vector.fromList ?? "args"
+
+  in
+    val parse_abt : t charParser = force (abt SymbolTable.empty)
+  end
+end

--- a/abt-lib/parse_abt.sig
+++ b/abt-lib/parse_abt.sig
@@ -1,0 +1,7 @@
+signature PARSE_ABT =
+sig
+  include ABT_UTIL
+
+  val parse_abt : t CharParser.charParser
+end
+

--- a/abt-lib/parse_abt_test.fun
+++ b/abt-lib/parse_abt_test.fun
@@ -1,0 +1,37 @@
+functor ParseAbtTest () =
+struct
+  datatype oper = LAM | AX | AP
+
+  structure O : PARSE_OPERATOR =
+  struct
+    type t = oper
+    fun eq x (y : oper) = x = y
+    fun arity LAM = #[1]
+      | arity AX = #[]
+      | arity AP = #[0,0]
+    fun to_string LAM = "λ"
+      | to_string AX = "<>"
+      | to_string AP = "ap"
+
+    open ParserCombinators CharParser
+    infix 2 return
+    infixr 1 ||
+
+    val parse_operator =
+      string "λ" return LAM
+        || string "<>" return AX
+        || string "ap" return AP
+  end
+
+  structure Syn = AbtUtil(Abt(structure Operator = O and Variable = Variable()))
+  structure ParseSyn = ParseAbt(structure Syntax = Syn and Operator = O)
+
+  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string PrintMode.Debug b ^ "\n") pr)
+  fun doit s = print_res (CharParser.parseString ParseSyn.parse_abt s)
+
+  val _ =
+    (doit "λ(x.λ(x.ap(x;<>)))";
+     doit "ap(λ(x.x);x)")
+end
+
+structure T  = ParseAbtTest ()

--- a/abt-lib/parse_operator.sig
+++ b/abt-lib/parse_operator.sig
@@ -1,0 +1,6 @@
+signature PARSE_OPERATOR =
+sig
+  include OPERATOR
+
+  val parse_operator : t CharParser.charParser
+end

--- a/extract.fun
+++ b/extract.fun
@@ -1,4 +1,4 @@
-functor Extract (Syn : ABTUTIL where Operator = Operator) : EXTRACT =
+functor Extract (Syn : ABT_UTIL where Operator = Operator) : EXTRACT =
 struct
   type evidence = Syn.t
   type term = Syn.t

--- a/refiner.fun
+++ b/refiner.fun
@@ -1,5 +1,5 @@
 functor Refiner
-  (structure Syn : ABTUTIL where Operator = Operator
+  (structure Syn : ABT_UTIL where Operator = Operator
    structure Sequent : SEQUENT
      where type term = Syn.t
      and type name = Syn.Variable.t

--- a/sequent.fun
+++ b/sequent.fun
@@ -1,5 +1,5 @@
 functor Sequent
-  (structure Syntax : ABTUTIL
+  (structure Syntax : ABT_UTIL
    structure Context : CONTEXT
      where type name = Syntax.Variable.t) : SEQUENT =
 struct

--- a/syntax.sml
+++ b/syntax.sml
@@ -1,4 +1,4 @@
-structure Syntax : ABTUTIL =
+structure Syntax : ABT_UTIL =
 struct
   structure V = Variable ()
   structure Abt = Abt

--- a/test.sml
+++ b/test.sml
@@ -76,7 +76,7 @@ struct
 
   val test4 =
     Library.save "test4" (Emp >> lam (fn x => pair ax ax) mem (void ~> void))
-      (MemUnfold THEN ReduceGoal THEN LamEq z THENL [VoidElim THEN Auto, Auto])
+      (MemUnfold THEN LamEq z THENL [VoidElim, Auto] THEN Assumption)
 
   val test5 =
     Library.save "test5" (Emp >> void ~> (unit & unit))
@@ -100,11 +100,10 @@ struct
 
   fun print_lemma lemma =
     let
-      open Library
-      val gl = goal lemma
-      val evidence = validate lemma
+      val gl = Library.goal lemma
+      val evidence = Library.validate lemma
     in
-      print ("\n" ^ name lemma ^ "\n");
+      print ("\n" ^ Library.name lemma ^ "\n");
       print "----------------------------------------\n";
       print ("Goal: " ^ Sequent.to_string print_mode gl ^ "\n");
       print ("Evidence: " ^ Syn.to_string print_mode evidence ^ "\n");

--- a/whnf.fun
+++ b/whnf.fun
@@ -1,4 +1,4 @@
-functor Whnf (Syn : ABTUTIL where Operator = Operator) : WHNF =
+functor Whnf (Syn : ABT_UTIL where Operator = Operator) : WHNF =
 struct
   type term = Syn.t
   exception Stuck of term


### PR DESCRIPTION
Originally, I planned to parse asts and then parse these into abts, but there's no real reason to do it that way. It's easy enough to just parse directly to abt, and more efficient too.
