### PR TITLE
**rudimentary** cumulative universes

### DIFF
--- a/abt-lib/abt-lib.cm
+++ b/abt-lib/abt-lib.cm
@@ -11,6 +11,7 @@ Library
   functor Abt
   functor AbtUtil
   functor Variable
+  structure StringVariable
   functor ParseAbt
   structure VectorUtil
   structure PrintMode

--- a/abt-lib/abt.fun
+++ b/abt-lib/abt.fun
@@ -2,8 +2,8 @@ functor Abt
   (structure Operator : OPERATOR
    structure Variable : VARIABLE) : ABT =
 struct
-  structure Operator : OPERATOR = Operator
-  structure Variable : VARIABLE = Variable
+  structure Operator = Operator
+  structure Variable = Variable
 
   infix 5 \
   infix 5 $
@@ -55,10 +55,7 @@ struct
     | BOUND n => raise Malformed "bound variable occured in out"
     | ABS (x, e') =>
       let
-        val v =
-          case Variable.name x of
-               SOME str => Variable.named str
-             | NONE => Variable.new ()
+        val v = Variable.clone x
       in
         v \ addvar v 0 e'
       end

--- a/abt-lib/abt_util.fun
+++ b/abt-lib/abt_util.fun
@@ -14,7 +14,7 @@ struct
   fun subst e v e' =
     case out e' of
       ` v' => if Variable.eq v v' then e else e'
-    | v' \ e'' => v' \\ subst e v e''
+    | v' \ e'' => if Variable.eq v v' then e' else (v' \\ subst e v e'')
     | p $ es => p $$ Vector.map (subst e v) es
 
   fun to_string mode e =

--- a/abt-lib/variable.fun
+++ b/abt-lib/variable.fun
@@ -1,8 +1,6 @@
 functor Variable () :> VARIABLE =
 struct
-
   type t = string option * int
-  type ord_key = t
 
   val counter = ref 0
 
@@ -20,22 +18,47 @@ struct
       (counter := n + 1 ; (SOME s, n))
     end
 
-  fun eq (_, n : int) (_, m) = (n = m)
+  fun compare ((SOME str, n), (SOME str', m)) =
+    (case Int.compare (n, m) of
+         EQUAL => String.compare (str, str')
+       | order => order)
+    | compare ((_, n), (_,m)) = Int.compare (n,m)
 
-  fun compare ((_, n), (_, m)) = Int.compare (n, m)
+  fun eq (x : t) y = compare (x,y) = EQUAL
 
-  fun name (s, x) = s
+  fun clone (SOME s, _) = named s
+    | clone _ = new ()
 
-  fun to_string mode (s, x) =
-    case mode of
-         PrintMode.User =>
-           (case s of
-                 NONE => "@" ^ Int.toString x
-               | SOME s' => s')
-       | PrintMode.Debug =>
-           (case s of
-                 NONE => "@"
-               | SOME s' => s')
-            ^ Int.toString x
+  val prime = clone
+
+  local
+    fun print_num i = Int.toString i
+  in
+    fun name (SOME s, x) = s
+      | name (NONE, x) = "@" ^ print_num x
+
+    fun to_string mode (s, x) =
+      case mode of
+           PrintMode.User =>
+             (case s of
+                   NONE => "@" ^ print_num x
+                 | SOME s' => s')
+         | PrintMode.Debug =>
+             (case s of
+                   NONE => "@"
+                 | SOME s' => s')
+              ^ print_num x
+  end
 end
 
+structure StringVariable : VARIABLE =
+struct
+  type t = string
+  fun named x = x
+  fun eq (x : string) y = x = y
+  val compare = String.compare
+  fun name x = x
+  fun to_string _ x = x
+  fun clone x = x
+  fun prime x = x ^ "'"
+end

--- a/abt-lib/variable.sig
+++ b/abt-lib/variable.sig
@@ -1,15 +1,15 @@
 signature VARIABLE =
 sig
   type t
-  type ord_key
-
-  val new : unit -> t
   val named : string -> t
 
   val eq : t -> t -> bool
   val compare : t * t -> order
 
-  val name : t -> string option
+  val name : t -> string
   val to_string : PrintMode.t -> t -> string
+
+  val clone : t -> t
+  val prime : t -> t
 end
 

--- a/context.fun
+++ b/context.fun
@@ -15,7 +15,11 @@ struct
 
   val empty = M.empty
 
-  fun insert ctx k v = M.insert (ctx, k, v)
+  fun insert ctx k v =
+    case M.find (ctx, k) of
+         NONE => M.insert (ctx, k, v)
+       | _ => raise Fail "variable already bound"
+
   fun remove ctx k = M.remove (ctx, k)
 
   exception NotFound of name

--- a/context.fun
+++ b/context.fun
@@ -1,10 +1,11 @@
-functor Context (V : VARIABLE) :> CONTEXT where type name = V.t =
+functor Context (V : VARIABLE) :> CONTEXT where Name = V =
 struct
   structure M = BinaryMapFn
     (struct type ord_key = V.t
      val compare = V.compare end)
 
-  type name = V.t
+  structure Name = V
+  type name = Name.t
 
   type 'a context = ('a * int) M.map
   structure Key = M.Key
@@ -14,7 +15,7 @@ struct
   fun insert ctx k v =
     case M.find (ctx, k) of
          NONE => M.insert (ctx, k, (v, M.numItems ctx))
-       | _ => raise Fail "variable already bound"
+       | _ => insert ctx (Name.prime k) v
 
   fun remove (ctx : 'a context) (k : V.t) =
     let

--- a/context.fun
+++ b/context.fun
@@ -1,53 +1,62 @@
 functor Context (V : VARIABLE) :> CONTEXT where type name = V.t =
 struct
   structure M = BinaryMapFn
-    (struct type ord_key = V.t val compare = V.compare end)
+    (struct type ord_key = V.t
+     val compare = V.compare end)
 
   type name = V.t
 
-  fun list_search xs p =
-    case xs of
-      nil => NONE
-    | ((i,x) :: ys) => if p x then SOME (i,x) else list_search ys p
-
-  type 'a context = 'a M.map
+  type 'a context = ('a * int) M.map
   structure Key = M.Key
 
   val empty = M.empty
 
   fun insert ctx k v =
     case M.find (ctx, k) of
-         NONE => M.insert (ctx, k, v)
+         NONE => M.insert (ctx, k, (v, M.numItems ctx))
        | _ => raise Fail "variable already bound"
 
-  fun remove ctx k = M.remove (ctx, k)
+  fun remove (ctx : 'a context) (k : V.t) =
+    let
+      val (ctx', (a, _)) = M.remove (ctx, k)
+    in
+      (ctx', a)
+    end
 
   exception NotFound of name
   fun lookup ctx k =
     case M.find (ctx, k) of
-         SOME v => v
+         SOME (v, _) => v
        | NONE => raise NotFound k
 
+  val list_items : 'a context -> (V.t * 'a) list = fn ctx =>
+    List.map (fn (v, (a, _)) => (v, a))
+     ((ListMergeSort.sort (fn ((_, (_, i)), (_, (_, j))) => i > j))
+      (M.listItemsi ctx))
+
   (* Needs to be made more lazy *)
-  fun search ctx p = list_search (M.listItemsi ctx) p
+  fun search (ctx : 'a context) p = list_search (M.listItemsi ctx) p
+  and list_search xs p =
+    case xs of
+      nil => NONE
+    | ((i,(x, _)) :: ys) => if p x then SOME (i,x) else list_search ys p
 
-  val map = M.map
-  val mapi = M.mapi
-  val foldri = M.foldri
+  fun map f = M.map (fn (v, i) => (f v, i))
+  fun foldri f = M.foldri (fn (v, (a, i), m) => f (v, a, m))
 
-  fun to_string (mode, printer) ctx =
+  fun to_string (mode, printer) =
     let
-      fun welp (x, a, r) =
-        r ^ ", " ^ V.to_string mode x ^ ":" ^ printer mode a
+      fun welp ((x, a), r) =
+        r ^ ", " ^ V.to_string mode x ^ " : " ^ printer mode a
     in
-      M.foldli welp "◊" ctx
+      foldl welp "◊" o list_items
     end
 
   fun subcontext test (G, G') =
     let
-      fun probe (x, a, r) =
+      fun probe (x, (a, _), r) =
         case M.find (G', x) of
-             SOME b => r andalso test (a,b)
+             SOME (b, _) => r andalso test (a,b)
            | NONE => false
     in
       M.foldli probe true G

--- a/context.sig
+++ b/context.sig
@@ -1,7 +1,8 @@
 signature CONTEXT =
 sig
+  structure Name : VARIABLE
 
-  type name
+  type name = Name.t
   type 'a context
 
   val empty : 'a context

--- a/context.sig
+++ b/context.sig
@@ -15,7 +15,6 @@ sig
   val search : 'a context -> ('a -> bool) -> (name * 'a) option
 
   val map : ('a -> 'b) -> 'a context -> 'b context
-  val mapi : (name * 'a -> 'b) -> 'a context -> 'b context
   val foldri : ((name * 'a * 'b) -> 'b) -> 'b -> 'a context -> 'b
 
   val to_string : PrintMode.t * (PrintMode.t -> 'a -> string) -> 'a context -> string

--- a/core_tactics.fun
+++ b/core_tactics.fun
@@ -58,6 +58,9 @@ struct
   fun REPEAT tac =
     THEN_LAZY (tac, fn () => REPEAT tac)
 
+  fun REPEAT0 tac =
+    ORELSE ((REPEAT tac), ID)
+
   fun TRY tac =
     ORELSE(tac, ID)
 end

--- a/core_tactics.fun
+++ b/core_tactics.fun
@@ -55,13 +55,9 @@ struct
   fun ORELSE (tac1, tac2) =
     ORELSE_LAZY (tac1, fn () => tac2)
 
-  fun REPEAT tac =
-    THEN_LAZY (tac, fn () => REPEAT tac)
-
-  fun REPEAT0 tac =
-    ORELSE ((REPEAT tac), ID)
-
   fun TRY tac =
     ORELSE(tac, ID)
+
+  fun REPEAT tac = TRY (THEN_LAZY (tac, fn () => TRY (REPEAT tac)))
 end
 

--- a/core_tactics.sig
+++ b/core_tactics.sig
@@ -8,6 +8,7 @@ sig
   val THEN_LAZY : tactic * (unit -> tactic) -> tactic
   val THENL_LAZY : tactic * (unit -> tactic list) -> tactic
   val REPEAT : tactic -> tactic
+  val REPEAT0 : tactic -> tactic
 
   val ORELSE : tactic * tactic -> tactic
   val ORELSE_LAZY : tactic * (unit -> tactic) -> tactic

--- a/core_tactics.sig
+++ b/core_tactics.sig
@@ -8,7 +8,6 @@ sig
   val THEN_LAZY : tactic * (unit -> tactic) -> tactic
   val THENL_LAZY : tactic * (unit -> tactic list) -> tactic
   val REPEAT : tactic -> tactic
-  val REPEAT0 : tactic -> tactic
 
   val ORELSE : tactic * tactic -> tactic
   val ORELSE_LAZY : tactic * (unit -> tactic) -> tactic

--- a/extract.fun
+++ b/extract.fun
@@ -15,6 +15,7 @@ struct
          UNIV_EQ $ _ => ax
        | VOID_EQ $ _ => ax
        | VOID_ELIM $ _ => ax
+       | CUM $ _ => ax
 
        | UNIT_EQ $ _ => ax
        | UNIT_INTRO $ _ => ax

--- a/extract.fun
+++ b/extract.fun
@@ -12,7 +12,8 @@ struct
 
   fun extract E =
     case out E of
-         VOID_EQ $ _ => ax
+         UNIV_EQ $ _ => ax
+       | VOID_EQ $ _ => ax
        | VOID_ELIM $ _ => ax
 
        | UNIT_EQ $ _ => ax

--- a/extract.fun
+++ b/extract.fun
@@ -26,10 +26,18 @@ struct
        | PROD_INTRO $ #[W, D, E] => PAIR $$ #[W, extract E]
        | PROD_ELIM $ #[R, xyD] => SPREAD $$ #[R, extract xyD]
        | PAIR_EQ $ _ => ax
+       | SPREAD_EQ $ _ => ax
 
        | FUN_EQ $ _ => ax
        | FUN_INTRO $ #[xE, _] => LAM $$ #[extract xE]
+       | FUN_ELIM $ #[f, s, D, yzE] =>
+           let
+             val t = extract yzE
+           in
+             (t // (AP $$ #[f,s])) // ax
+           end
        | LAM_EQ $ _ => ax
+       | AP_EQ $ _ => ax
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M

--- a/level.sig
+++ b/level.sig
@@ -1,0 +1,11 @@
+signature LEVEL =
+sig
+  type t
+  val to_string : t -> string
+
+  exception LevelError
+  val assert_lt : t * t -> unit
+  val unify : t * t -> t
+  val max : t * t -> t
+end
+

--- a/level.sml
+++ b/level.sml
@@ -1,0 +1,11 @@
+structure Level :> LEVEL where type t = int =
+struct
+  type t = int
+
+  fun to_string i = Int.toString i
+
+  exception LevelError
+  fun assert_lt (i, j) = if i < j then () else raise LevelError
+  fun unify (i, j) = if i = j then i else raise LevelError
+  fun max (i, j) = Int.max (i, j)
+end

--- a/library.fun
+++ b/library.fun
@@ -17,7 +17,7 @@ struct
         then Susp.delay (fn () => validation [])
         else
           let
-            val readout = List.foldl (fn (g,r) => r ^ "\n" ^ R.goal_to_string g) "" subgoals
+            val readout = List.foldl (fn (g,r) => r ^ "\n" ^ R.goal_to_string PrintMode.User g) "" subgoals
           in
             raise Fail ("Remaining subgoals: " ^ readout ^ "\n")
           end

--- a/operator.sml
+++ b/operator.sml
@@ -5,8 +5,8 @@ struct
       UNIV_EQ | CUM
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
-    | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ
-    | FUN_EQ | FUN_INTRO | LAM_EQ
+    | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
+    | FUN_EQ | FUN_INTRO | FUN_ELIM | LAM_EQ | AP_EQ
     | WITNESS | HYP_EQ
 
       (* Level expressions *)
@@ -40,10 +40,13 @@ struct
        | PROD_INTRO => #[0,0,0]
        | PROD_ELIM => #[0,2]
        | PAIR_EQ => #[0,0,1]
+       | SPREAD_EQ => #[0,3]
 
        | FUN_EQ => #[0,1]
        | FUN_INTRO => #[1,0]
+       | FUN_ELIM => #[0,0,0,2]
        | LAM_EQ => #[1,0]
+       | AP_EQ => #[0,0]
 
        | WITNESS => #[0,0]
        | HYP_EQ => #[0]
@@ -81,10 +84,13 @@ struct
        | PROD_INTRO => "prod-intro"
        | PROD_ELIM => "prod-elim"
        | PAIR_EQ => "pair="
+       | SPREAD_EQ => "spread="
 
        | FUN_EQ => "fun="
        | FUN_INTRO => "fun-intro"
+       | FUN_ELIM => "fun-elim"
        | LAM_EQ => "lam="
+       | AP_EQ => "ap="
 
        | WITNESS => "witness"
        | HYP_EQ => "hyp="

--- a/operator.sml
+++ b/operator.sml
@@ -9,11 +9,8 @@ struct
     | FUN_EQ | FUN_INTRO | FUN_ELIM | LAM_EQ | AP_EQ
     | WITNESS | HYP_EQ
 
-      (* Level expressions *)
-    | LSUCC
-
       (* Computational Type Theory *)
-    | UNIV
+    | UNIV of Level.t
     | VOID
     | UNIT | AX | MATCH_UNIT
     | PROD | PAIR | SPREAD
@@ -52,9 +49,7 @@ struct
        | HYP_EQ => #[0]
 
 
-       | LSUCC => #[0]
-
-       | UNIV => #[0]
+       | UNIV i => #[]
        | VOID => #[]
        | UNIT => #[]
        | AX => #[]
@@ -95,9 +90,7 @@ struct
        | WITNESS => "witness"
        | HYP_EQ => "hyp="
 
-       | LSUCC => "s"
-
-       | UNIV => "𝕌"
+       | UNIV i => "U<" ^ Level.to_string i ^ ">"
        | VOID => "void"
        | UNIT => "unit"
        | AX => "•"

--- a/operator.sml
+++ b/operator.sml
@@ -2,7 +2,7 @@ structure Operator =
 struct
   datatype t
     = (* Derivations *)
-      UNIV_EQ
+      UNIV_EQ | CUM
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
     | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ
@@ -27,6 +27,7 @@ struct
   fun arity O =
     case O of
          UNIV_EQ => #[]
+       | CUM => #[0]
        | VOID_EQ => #[]
        | VOID_ELIM => #[0]
 
@@ -67,6 +68,7 @@ struct
   fun to_string O =
     case O of
          UNIV_EQ => "univ="
+       | CUM => "cum"
        | VOID_EQ => "void="
        | VOID_ELIM => "void-elim"
 

--- a/operator.sml
+++ b/operator.sml
@@ -2,11 +2,15 @@ structure Operator =
 struct
   datatype t
     = (* Derivations *)
-      VOID_EQ | VOID_ELIM
+      UNIV_EQ
+    | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
     | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ
     | FUN_EQ | FUN_INTRO | LAM_EQ
     | WITNESS | HYP_EQ
+
+      (* Level expressions *)
+    | LSUCC
 
       (* Computational Type Theory *)
     | UNIV
@@ -22,7 +26,8 @@ struct
 
   fun arity O =
     case O of
-         VOID_EQ => #[]
+         UNIV_EQ => #[]
+       | VOID_EQ => #[]
        | VOID_ELIM => #[0]
 
        | UNIT_EQ => #[]
@@ -42,7 +47,10 @@ struct
        | WITNESS => #[0,0]
        | HYP_EQ => #[0]
 
-       | UNIV => #[]
+
+       | LSUCC => #[0]
+
+       | UNIV => #[0]
        | VOID => #[]
        | UNIT => #[]
        | AX => #[]
@@ -58,7 +66,8 @@ struct
 
   fun to_string O =
     case O of
-         VOID_EQ => "void="
+         UNIV_EQ => "univ="
+       | VOID_EQ => "void="
        | VOID_ELIM => "void-elim"
 
        | UNIT_EQ => "unit="
@@ -77,6 +86,8 @@ struct
 
        | WITNESS => "witness"
        | HYP_EQ => "hyp="
+
+       | LSUCC => "s"
 
        | UNIV => "𝕌"
        | VOID => "void"

--- a/refiner.fun
+++ b/refiner.fun
@@ -338,7 +338,7 @@ struct
               (fn () => FunIntro (Variable.new ()) (`` i)) ORELSE
                 UnitIntro
     in
-      val Auto = REPEAT intro_rules
+      val Auto = REPEAT0 intro_rules
     end
   end
 end

--- a/refiner.fun
+++ b/refiner.fun
@@ -19,6 +19,7 @@ sig
 
   structure InferenceRules :
   sig
+    val Cum : Syn.t -> tactic
     val UnivEq : tactic
     val VoidEq : tactic
     val VoidElim : tactic
@@ -101,6 +102,17 @@ struct
       case out k of
            LSUCC $ #[k'] => if Syn.eq (l, k') then () else assert_level_lt (l, k')
          | _ => raise Refine
+
+    fun Cum k : tactic =
+      named "Cum" (fn (G >> P) =>
+        case out P of
+             EQ $ #[A, B, univ] =>
+             (case out univ of
+                   UNIV $ #[l] =>
+                    (assert_level_lt (k,l);
+                     [G >> EQ $$ #[A,B,UNIV $$ #[k]]] BY mk_evidence CUM)
+                 | _ => raise Refine)
+           | _ => raise Refine)
 
     val UnivEq : tactic =
       named "UnivEq" (fn (G >> P) =>

--- a/refiner.fun
+++ b/refiner.fun
@@ -2,7 +2,7 @@ functor Refiner
   (structure Syn : ABT_UTIL where Operator = Operator
    structure Sequent : SEQUENT
      where type term = Syn.t
-     and type name = Syn.Variable.t
+     where Name = Syn.Variable
    val print_mode : PrintMode.t) :>
 sig
   type evidence = Syn.t

--- a/refiner.fun
+++ b/refiner.fun
@@ -251,7 +251,7 @@ struct
     fun ProdEq z : tactic =
       named "ProdEq" (fn (G >> P) =>
         case out P of
-             CAN_EQ $ #[prod1, prod2, univ] =>
+             EQ $ #[prod1, prod2, univ] =>
                (case (out prod1, out prod2, out univ) of
                     (PROD $ #[A,xB], PROD $ #[A',yB'], UNIV $ #[k]) =>
                       [ G >> EQ $$ #[A,A',univ]
@@ -288,7 +288,7 @@ struct
     fun PairEq z k : tactic =
       named "PairEq" (fn (G >> P) =>
         case out P of
-             CAN_EQ $ #[pair, pair', prod] =>
+             EQ $ #[pair, pair', prod] =>
                (case (out pair, out pair', out prod) of
                      (PAIR $ #[M,N], PAIR $ #[M', N'], PROD $ #[A,xB]) =>
                        [ G >> EQ $$ #[M, M', A]

--- a/refiner_types.fun
+++ b/refiner_types.fun
@@ -6,6 +6,6 @@ struct
   type evidence = evidence
   type validation = evidence list -> evidence
   type tactic = goal -> (goal list * validation)
-  val goal_to_string = Sequent.to_string PrintMode.User
+  val goal_to_string = Sequent.to_string
 end
 

--- a/refiner_types.sig
+++ b/refiner_types.sig
@@ -6,6 +6,6 @@ sig
   type validation = evidence list -> evidence
   type tactic = goal -> goal list * validation
 
-  val goal_to_string : goal -> string
+  val goal_to_string : PrintMode.t -> goal -> string
 end
 

--- a/sequent.fun
+++ b/sequent.fun
@@ -1,12 +1,12 @@
 functor Sequent
   (structure Syntax : ABT_UTIL
-   structure Context : CONTEXT
-     where type name = Syntax.Variable.t) : SEQUENT =
+   structure Context : CONTEXT) : SEQUENT where Name = Context.Name =
 struct
   type term = Syntax.t
-  type name = Syntax.Variable.t
 
+  structure Name = Context.Name
   structure Context = Context
+  type name = Name.t
 
   type context = term Context.context
   datatype sequent = >> of context * term

--- a/sequent.sig
+++ b/sequent.sig
@@ -1,10 +1,10 @@
 signature SEQUENT =
 sig
   type term
-  type name
 
-  structure Context : CONTEXT
-    where type name = name
+  structure Name : VARIABLE
+  structure Context : CONTEXT where Name = Name
+  type name = Name.t
 
   type context = term Context.context
 

--- a/sources.cm
+++ b/sources.cm
@@ -32,6 +32,8 @@ group is
   core_tactics.sig
   core_tactics.fun
 
+  level.sig
+  level.sml
   refiner.fun
 
   test.sml

--- a/test.sml
+++ b/test.sml
@@ -50,6 +50,16 @@ struct
       FUN $$ #[a, x \\ b x]
     end
 
+  fun sg a b =
+    let
+      val x = Var.named "x"
+    in
+      PROD $$ #[a, x \\ b x]
+    end
+
+  fun ap m n =
+    AP $$ #[m, n]
+
   fun ~> (a, b) = FUN $$ #[a,Variable.named "x" \\ b]
   infixr 5 ~>
 
@@ -109,6 +119,86 @@ struct
     Library.save "test9" (Emp >> (univ (`` i) & unit) mem (univ (lsuc (`` i))))
       Auto
 
+  local
+    val univi = univ (`` i)
+    val A = Variable.named "A"
+    val B = Variable.named "B"
+    val Q = Variable.named "Q"
+    val a = Variable.named "a"
+    val b = Variable.named "b"
+    val q = Variable.named "q"
+    val f = Variable.named "f"
+    val x = Variable.named "x"
+    val s = Variable.named "s"
+    val t = Variable.named "t"
+    val y = Variable.named "y"
+    val qa = Variable.named "qa"
+    val qa' = Variable.named "qa~"
+    val qa1 = Variable.named "qa1"
+    val qa2 = Variable.named "qa2"
+
+    exception XXX
+  in
+    val ac_premise =
+      FUN $$ #[ `` A, a \\
+        PROD $$ #[ `` B, b \\
+          ap (ap (`` Q) (`` a)) (`` b)]]
+
+    val ac_conclusion =
+      PROD $$ #[ `` A ~> `` B, f \\
+        FUN $$ #[ `` A, a \\
+          ap (ap (`` Q) (`` a)) (ap (`` f) (`` a))]]
+
+    val ac_prop =
+      FUN $$ #[univi, A \\
+        FUN $$ #[univi, B \\
+          FUN $$ #[ (`` A ~> (``B ~> univi)), Q \\
+            ac_premise ~> ac_conclusion ]]]
+
+    fun fst m =
+    let
+      val x = Variable.named "x"
+      val y = Variable.named "y"
+    in
+      SPREAD $$ #[ m, x \\ (y \\ `` x) ]
+    end
+
+    fun snd m =
+    let
+      val x = Variable.named "x"
+      val y = Variable.named "y"
+    in
+      SPREAD $$ #[ m, x \\ (y \\ `` y) ]
+    end
+
+    (*
+    val _ =
+      Library.save "ac" (Emp >> ac_prop)
+        (FunIntro A (lsuc (`` i)) THEN Auto
+         THEN FunIntro B (lsuc (`` i)) THEN Auto
+         THEN FunIntro Q (lsuc (`` i))
+         THENL
+           [ FunIntro q (`` i) THENL
+             [ ProdIntro (lam (fn x => fst (ap (`` q) (`` x)))) THENL
+               [ MemUnfold THEN (LamEq a (`` i)) THEN Auto
+                 THEN SpreadEq (z \\ `` B) (PROD $$ #[``B, b \\ (ap (ap (``Q) (``a)) (``b))]) (s, t, y) THEN Auto
+                 THEN ApEq (FUN $$ #[``A, a \\ PROD $$ #[``B, b \\ ap (ap (``Q) (``a)) (``b) ]]) THEN Auto
+               , FunIntro a (`` i) THEN Auto
+                 THEN FunElim q (``a) (qa, qa') THEN Auto
+                 THEN ProdElim qa (qa1, qa2)
+                 THEN Witness (``qa2)
+               ]
+             , MemUnfold THEN FunEq a THEN Auto THEN ProdEq b THEN Auto THEN ApEq (``B ~> univi) THEN Auto THEN ApEq (``A ~> (``B ~> univi)) THEN Auto
+             ]
+           , MemUnfold THEN (FunEq a) THENL
+             [ Cum (`` i)
+             , FunEq b THEN Auto THEN Cum (`` i)
+             ] THEN Auto
+           ])
+
+           *)
+  end
+
   fun print_lemma lemma =
     let
       val gl = Library.goal lemma
@@ -125,4 +215,3 @@ struct
   val _ =
     List.map print_lemma (Library.all ())
 end
-

--- a/test.sml
+++ b/test.sml
@@ -110,6 +110,7 @@ struct
     Library.save "test9" (Emp >> (univ 0 & unit) mem (univ 1))
       Auto
 
+      (*
   local
     val ac_premise =
       FUN $$ #[ ``"A", "a" \\
@@ -131,6 +132,7 @@ struct
       Library.save "ac" (Emp >> ac_prop)
       Auto
   end
+  *)
 
   fun print_lemma lemma =
     let

--- a/test.sml
+++ b/test.sml
@@ -1,6 +1,6 @@
 structure Test =
 struct
-  val print_mode = PrintMode.User
+  val print_mode = PrintMode.Debug
 
   structure Var = Variable ()
   structure Syn =
@@ -26,8 +26,7 @@ struct
   infix 7 $$
   infix \\ THEN THENL ORELSE
 
-  fun univ i = UNIV $$ #[i]
-  fun lsuc i = LSUCC $$ #[i]
+  fun univ i = UNIV i $$ #[]
   val void = VOID $$ #[]
   val unit = UNIT $$ #[]
   val ax = AX $$ #[]
@@ -76,12 +75,9 @@ struct
     Library.save "test1'" (Emp >> unit & (unit & unit))
       (Lemma test1)
 
-  val z = Variable.named "z"
-  val i = Variable.named "i"
-
   val test2 =
     Library.save "test2" (Emp >> unit ~> (unit & unit))
-      (FunIntro z (`` i) THEN Auto THEN ProdIntro ax THEN Auto)
+      (FunIntro NONE NONE THEN Auto THEN ProdIntro ax THEN Auto)
 
   val test3 =
     Library.save "test3" (Emp >> lam (fn x => `` x) mem (unit ~> unit))
@@ -89,36 +85,37 @@ struct
 
   val test4 =
     Library.save "test4" (Emp >> lam (fn x => pair ax ax) mem (void ~> void))
-      (MemUnfold THEN LamEq z (`` i) THEN Auto THEN VoidElim THEN Auto)
+      (MemUnfold THEN LamEq NONE NONE THEN Auto THEN VoidElim THEN Auto)
 
   val test5 =
     Library.save "test5" (Emp >> void ~> (unit & unit))
-      (FunIntro z (`` i) THEN Auto THEN VoidElim THEN Auto)
+      (FunIntro NONE NONE THEN Auto THEN VoidElim THEN Auto)
 
   val test6 =
     Library.save "test6" (Emp >> unit ~> (unit & unit))
       (Witness (lam (fn x => pair (`` x) (`` x))) THEN Auto)
 
- local
-   val x = Variable.named "x"
-   val y = Variable.named "y"
+  local
+    val x = Variable.named "x"
+    val y = Variable.named "y"
+    val z = Variable.named "z"
   in
     val test7 =
       Library.save "test7" (Emp >> (void & unit) ~> void)
-        (FunIntro z (`` i) THEN Auto THEN ProdElim z (x, y) THEN Auto)
+        (FunIntro (SOME z) NONE THEN Auto THEN ProdElim z (x, y) THEN Auto)
   end
 
   val test8 =
-    Library.save "test8" (Emp >> (univ (`` i)) mem (univ (lsuc (lsuc (`` i)))))
+    Library.save "test8" (Emp >> (univ 0) mem (univ 2))
       Auto
 
   val test9 =
-    Library.save "test9" (Emp >> (univ (`` i) & unit) mem (univ (lsuc (`` i))))
+    Library.save "test9" (Emp >> (univ 0 & unit) mem (univ 1))
       Auto
 
-    (*
+      (*
   local
-    val univi = univ (`` i)
+    val univi = univ 0
     val A = Variable.named "A"
     val B = Variable.named "B"
     val Q = Variable.named "Q"
@@ -171,30 +168,13 @@ struct
 
     val _ =
       Library.save "ac" (Emp >> ac_prop)
-        (FunIntro A (lsuc (`` i)) THEN Auto
-         THEN FunIntro B (lsuc (`` i)) THEN Auto
-         THEN FunIntro Q (lsuc (`` i))
-         THENL
-           [ FunIntro q (`` i) THENL
-             [ ProdIntro (lam (fn x => fst (ap (`` q) (`` x)))) THENL
-               [ MemUnfold THEN (LamEq a (`` i)) THEN Auto
-                 THEN SpreadEq (z \\ `` B) (PROD $$ #[``B, b \\ (ap (ap (``Q) (``a)) (``b))]) (s, t, y) THEN Auto
-                 THEN ApEq (FUN $$ #[``A, a \\ PROD $$ #[``B, b \\ ap (ap (``Q) (``a)) (``b) ]]) THEN Auto
-               , FunIntro a (`` i) THEN Auto
-                 THEN FunElim q (``a) (qa, qa') THEN Auto
-                 THEN ProdElim qa (qa1, qa2)
-                 THEN Witness (``qa2)
-               ]
-             , MemUnfold THEN FunEq a THEN Auto THEN ProdEq b THEN Auto THEN ApEq (``B ~> univi) THEN Auto THEN ApEq (``A ~> (``B ~> univi)) THEN Auto
-             ]
-           , MemUnfold THEN (FunEq a) THENL
-             [ Cum (`` i)
-             , FunEq b THEN Auto THEN Cum (`` i)
-             ] THEN Auto
-           ])
+        (Auto THENL
+          [ ID
+          , ID
+          ])
 
   end
-           *)
+  *)
 
   fun print_lemma lemma =
     let

--- a/test.sml
+++ b/test.sml
@@ -26,6 +26,8 @@ struct
   infix 7 $$
   infix \\ THEN THENL ORELSE
 
+  fun univ i = UNIV $$ #[i]
+  fun lsuc i = LSUCC $$ #[i]
   val void = VOID $$ #[]
   val unit = UNIT $$ #[]
   val ax = AX $$ #[]
@@ -65,10 +67,11 @@ struct
       (Lemma test1)
 
   val z = Variable.named "z"
+  val i = Variable.named "i"
 
   val test2 =
     Library.save "test2" (Emp >> unit ~> (unit & unit))
-      (FunIntro z THENL [ProdIntro ax THEN Auto, Auto])
+      (FunIntro z (`` i) THENL [ProdIntro ax THEN Auto, Auto])
 
   val test3 =
     Library.save "test3" (Emp >> lam (fn x => `` x) mem (unit ~> unit))
@@ -76,11 +79,11 @@ struct
 
   val test4 =
     Library.save "test4" (Emp >> lam (fn x => pair ax ax) mem (void ~> void))
-      (MemUnfold THEN LamEq z THENL [VoidElim, Auto] THEN Assumption)
+      (MemUnfold THEN LamEq z (`` i) THENL [VoidElim, Auto] THEN Assumption)
 
   val test5 =
     Library.save "test5" (Emp >> void ~> (unit & unit))
-      (FunIntro z THENL [VoidElim THEN Auto, Auto])
+      (FunIntro z (`` i) THENL [VoidElim THEN Auto, Auto])
 
   val test6 =
     Library.save "test6" (Emp >> unit ~> (unit & unit))
@@ -92,11 +95,19 @@ struct
   in
     val test7 =
       Library.save "test7" (Emp >> (void & unit) ~> void)
-        (FunIntro z THENL
+        (FunIntro z (`` i) THENL
           [ ProdElim z (x, y) THEN Assumption
           , Auto
           ])
   end
+
+  val test8 =
+    Library.save "test8" (Emp >> (univ (`` i)) mem (univ (lsuc (lsuc (`` i)))))
+      Auto
+
+  val test9 =
+    Library.save "test9" (Emp >> (univ (`` i) & unit) mem (univ (lsuc (`` i))))
+      Auto
 
   fun print_lemma lemma =
     let
@@ -109,6 +120,7 @@ struct
       print ("Evidence: " ^ Syn.to_string print_mode evidence ^ "\n");
       print ("Extract: " ^ Syn.to_string print_mode (Extract.extract evidence) ^ "\n\n")
     end
+
 
   val _ =
     List.map print_lemma (Library.all ())

--- a/test.sml
+++ b/test.sml
@@ -2,7 +2,7 @@ structure Test =
 struct
   val print_mode = PrintMode.Debug
 
-  structure Var = Variable ()
+  structure Var = StringVariable
   structure Syn =
     AbtUtil (Abt (structure Operator = Operator and Variable = Var))
 
@@ -34,10 +34,12 @@ struct
   fun & (a, b) = PROD $$ #[a, Variable.named "x" \\ b]
   infix 6 &
 
+  val % = Variable.named
+
   fun pair m n = PAIR $$ #[m,n]
   fun lam e =
     let
-      val x = Var.named "x"
+      val x = %"x"
     in
       LAM $$ #[x \\ e x]
     end
@@ -93,17 +95,12 @@ struct
 
   val test6 =
     Library.save "test6" (Emp >> unit ~> (unit & unit))
-      (Witness (lam (fn x => pair (`` x) (`` x))) THEN Auto)
+      (Witness (lam (fn x => pair (`` x) (`` x))) THEN Auto
+       THEN PairEq NONE NONE)
 
-  local
-    val x = Variable.named "x"
-    val y = Variable.named "y"
-    val z = Variable.named "z"
-  in
-    val test7 =
-      Library.save "test7" (Emp >> (void & unit) ~> void)
-        (FunIntro (SOME z) NONE THEN Auto THEN ProdElim z (x, y) THEN Auto)
-  end
+  val test7 =
+    Library.save "test7" (Emp >> (void & unit) ~> void)
+      (FunIntro (SOME "z") NONE THEN Auto THEN ProdElim "z" ("x", "y") THEN Auto)
 
   val test8 =
     Library.save "test8" (Emp >> (univ 0) mem (univ 2))
@@ -113,68 +110,27 @@ struct
     Library.save "test9" (Emp >> (univ 0 & unit) mem (univ 1))
       Auto
 
-      (*
   local
-    val univi = univ 0
-    val A = Variable.named "A"
-    val B = Variable.named "B"
-    val Q = Variable.named "Q"
-    val a = Variable.named "a"
-    val b = Variable.named "b"
-    val q = Variable.named "q"
-    val f = Variable.named "f"
-    val x = Variable.named "x"
-    val s = Variable.named "s"
-    val t = Variable.named "t"
-    val y = Variable.named "y"
-    val qa = Variable.named "qa"
-    val qa' = Variable.named "qa~"
-    val qa1 = Variable.named "qa1"
-    val qa2 = Variable.named "qa2"
-
-    exception XXX
-  in
     val ac_premise =
-      FUN $$ #[ `` A, a \\
-        PROD $$ #[ `` B, b \\
-          ap (ap (`` Q) (`` a)) (`` b)]]
+      FUN $$ #[ ``"A", "a" \\
+        PROD $$ #[ ``"B", "b" \\
+          ap (ap (``"Q") (``"a")) (``"b")]]
 
     val ac_conclusion =
-      PROD $$ #[ `` A ~> `` B, f \\
-        FUN $$ #[ `` A, a \\
-          ap (ap (`` Q) (`` a)) (ap (`` f) (`` a))]]
+      PROD $$ #[ ``"A" ~> ``"B", "f" \\
+        FUN $$ #[ ``"A", "a" \\
+          ap (ap (``"A") (``"a")) (ap (``"f") (``"a"))]]
 
     val ac_prop =
-      FUN $$ #[univi, A \\
-        FUN $$ #[univi, B \\
-          FUN $$ #[ (`` A ~> (``B ~> univi)), Q \\
+      FUN $$ #[univ 0, "A" \\
+        FUN $$ #[univ 0, "B" \\
+          FUN $$ #[ (``"A" ~> (``"B" ~> univ 0)), "Q" \\
             ac_premise ~> ac_conclusion ]]]
-
-    fun fst m =
-    let
-      val x = Variable.named "x"
-      val y = Variable.named "y"
-    in
-      SPREAD $$ #[ m, x \\ (y \\ `` x) ]
-    end
-
-    fun snd m =
-    let
-      val x = Variable.named "x"
-      val y = Variable.named "y"
-    in
-      SPREAD $$ #[ m, x \\ (y \\ `` y) ]
-    end
-
+  in
     val _ =
       Library.save "ac" (Emp >> ac_prop)
-        (Auto THENL
-          [ ID
-          , ID
-          ])
-
+      Auto
   end
-  *)
 
   fun print_lemma lemma =
     let
@@ -187,7 +143,6 @@ struct
       print ("Evidence: " ^ Syn.to_string print_mode evidence ^ "\n");
       print ("Extract: " ^ Syn.to_string print_mode (Extract.extract evidence) ^ "\n\n")
     end
-
 
   val _ =
     List.map print_lemma (Library.all ())

--- a/test.sml
+++ b/test.sml
@@ -81,7 +81,7 @@ struct
 
   val test2 =
     Library.save "test2" (Emp >> unit ~> (unit & unit))
-      (FunIntro z (`` i) THENL [ProdIntro ax THEN Auto, Auto])
+      (FunIntro z (`` i) THEN Auto THEN ProdIntro ax THEN Auto)
 
   val test3 =
     Library.save "test3" (Emp >> lam (fn x => `` x) mem (unit ~> unit))
@@ -89,11 +89,11 @@ struct
 
   val test4 =
     Library.save "test4" (Emp >> lam (fn x => pair ax ax) mem (void ~> void))
-      (MemUnfold THEN LamEq z (`` i) THENL [VoidElim, Auto] THEN Assumption)
+      (MemUnfold THEN LamEq z (`` i) THEN Auto THEN VoidElim THEN Auto)
 
   val test5 =
     Library.save "test5" (Emp >> void ~> (unit & unit))
-      (FunIntro z (`` i) THENL [VoidElim THEN Auto, Auto])
+      (FunIntro z (`` i) THEN Auto THEN VoidElim THEN Auto)
 
   val test6 =
     Library.save "test6" (Emp >> unit ~> (unit & unit))
@@ -105,10 +105,7 @@ struct
   in
     val test7 =
       Library.save "test7" (Emp >> (void & unit) ~> void)
-        (FunIntro z (`` i) THENL
-          [ ProdElim z (x, y) THEN Assumption
-          , Auto
-          ])
+        (FunIntro z (`` i) THEN Auto THEN ProdElim z (x, y) THEN Auto)
   end
 
   val test8 =
@@ -119,6 +116,7 @@ struct
     Library.save "test9" (Emp >> (univ (`` i) & unit) mem (univ (lsuc (`` i))))
       Auto
 
+    (*
   local
     val univi = univ (`` i)
     val A = Variable.named "A"
@@ -171,7 +169,6 @@ struct
       SPREAD $$ #[ m, x \\ (y \\ `` y) ]
     end
 
-    (*
     val _ =
       Library.save "ac" (Emp >> ac_prop)
         (FunIntro A (lsuc (`` i)) THEN Auto
@@ -196,8 +193,8 @@ struct
              ] THEN Auto
            ])
 
-           *)
   end
+           *)
 
   fun print_lemma lemma =
     let

--- a/whnf.fun
+++ b/whnf.fun
@@ -18,15 +18,15 @@ struct
                   in
                     whnf N'
                   end
-              | _ => raise Stuck x)
+              | _ => x)
        | AP $ #[M,N] =>
            (case out (whnf M) of
                  LAM $ #[xE] => whnf (subst1 xE N)
-               | _ => raise Stuck x)
+               | _ => x)
        | MATCH_UNIT $ #[M,N] =>
            (case out (whnf M) of
                  AX $ #[] => whnf N
-               | _ => raise Stuck x)
+               | _ => x)
        | _ => x
 
 


### PR DESCRIPTION
resolves #18, #20, #21 

This PR sort of turned into a grab-bag of changes, since I took this opportunity to see how much was still missing from me being able to prove something like AC. 

Summary:
1. Introduce a cumulative hierarchy of universes. Currently there is no polymorphism or universe variables: I am hoping to defer figuring out what to do there until later. Probably I can get pretty far without dealing with it explicitly, so I'd like to avoid fixing in advance the solution.
2. Correct the broken `REPEAT` tactical.
3. Correct the broken `Auto` tactic.
4. Add unfinished `AC` proof; add some rules that I needed when I was playing with that.
5. Remove reduction tactics until I replace them with something more advance.
6. Switch to plain old strings as variable names, and explicitly handle shadowing. The gensym-style names were great, but they are not really suitable for use in an _interactive_ proof assistant, since the user expects to just type something in and have it work, without regard for the intensional identity of the symbol that they are seeing in the proof assistant's output. A few changes had to be made to `AbtFun` and `Context` to support this.
7. Clean up the code of the refiner by replacing nested pattern matches with some compositional kit.
