### PR TITLE
Add Squash Type

### DIFF
--- a/abt-lib/abt_util.sig
+++ b/abt-lib/abt_util.sig
@@ -7,6 +7,7 @@ sig
   val $$ : Operator.t * t vector -> t
 
   val free_variables : t -> Variable.t list
+  val has_free : t * Variable.t -> bool
 
   val subst : t -> Variable.t -> t -> t
   val to_string : PrintMode.t -> t -> string

--- a/abt-lib/abt_util.sig
+++ b/abt-lib/abt_util.sig
@@ -6,6 +6,8 @@ sig
   val \\ : Variable.t * t -> t
   val $$ : Operator.t * t vector -> t
 
+  val free_variables : t -> Variable.t list
+
   val subst : t -> Variable.t -> t -> t
   val to_string : PrintMode.t -> t -> string
 

--- a/context.fun
+++ b/context.fun
@@ -30,6 +30,12 @@ struct
     end
 
   exception NotFound of name
+
+  fun modify (ctx : 'a context) (k : V.t) f =
+    case M.find (ctx, k) of
+         NONE => raise NotFound k
+       | SOME (a, i) => M.insert (ctx, k, (f a, i))
+
   fun lookup ctx k =
     case M.find (ctx, k) of
          SOME (v, _) => v
@@ -48,7 +54,6 @@ struct
     | ((i,(x, _)) :: ys) => if p x then SOME (i,x) else list_search ys p
 
   fun map f = M.map (fn (v, i) => (f v, i))
-  fun foldri f = M.foldri (fn (v, (a, i), m) => f (v, a, m))
 
   fun to_string (mode, printer) =
     let

--- a/context.sig
+++ b/context.sig
@@ -12,13 +12,14 @@ sig
   val insert : 'a context -> name -> 'a -> 'a context
   val remove : 'a context -> name -> 'a context * 'a
 
+  val modify : 'a context -> name -> ('a -> 'a) -> 'a context
+
   exception NotFound of name
   val lookup : 'a context -> name -> 'a
-
   val search : 'a context -> ('a -> bool) -> (name * 'a) option
 
   val map : ('a -> 'b) -> 'a context -> 'b context
-  val foldri : ((name * 'a * 'b) -> 'b) -> 'b -> 'a context -> 'b
+  val list_items : 'a context -> (name * 'a) list
 
   val to_string : PrintMode.t * (PrintMode.t -> 'a -> string) -> 'a context -> string
 

--- a/context_util.fun
+++ b/context_util.fun
@@ -1,0 +1,22 @@
+functor ContextUtil
+  (structure Context : CONTEXT
+   structure Syntax : ABT_UTIL
+   sharing Context.Name = Syntax.Variable) : CONTEXT_UTIL =
+struct
+  open Context
+  structure Syntax = Syntax
+
+  local
+    datatype Mode = Scan | Check
+    fun go _ [] x = true
+      | go Scan ((y, _) :: ys) x =
+        if Context.Name.eq x y
+        then go Check ys x
+        else go Scan ys x
+      | go Check ((_, A) :: ys) x =
+        not (Syntax.has_free (A, x)) andalso go Check ys x
+  in
+    fun is_irrelevant (H, x) =
+      go Scan (list_items H) x
+  end
+end

--- a/context_util.sig
+++ b/context_util.sig
@@ -1,0 +1,7 @@
+signature CONTEXT_UTIL =
+sig
+  include CONTEXT
+  structure Syntax : ABT_UTIL
+
+  val is_irrelevant : Syntax.t context * name -> bool
+end

--- a/extract.fun
+++ b/extract.fun
@@ -41,6 +41,11 @@ struct
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M
+
+       | SQUASH_EQ $ _ => ax
+       | SQUASH_INTRO $ #[D] => extract D
+       | SQUASH_ELIM $ _ => ax
+
        | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
 
        | ` x => `` x

--- a/library.fun
+++ b/library.fun
@@ -17,7 +17,7 @@ struct
         then Susp.delay (fn () => validation [])
         else
           let
-            val readout = List.foldl (fn (g,r) => r ^ "\n" ^ R.goal_to_string PrintMode.User g) "" subgoals
+            val readout = List.foldl (fn (g,r) => r ^ "\n" ^ R.goal_to_string PrintMode.Debug g) "" subgoals
           in
             raise Fail ("Remaining subgoals: " ^ readout ^ "\n")
           end
@@ -27,7 +27,10 @@ struct
       key
     end
 
-  fun all () = C.foldri (fn (k, _, memo) => k :: memo) [] (! library)
+  fun all () =
+    List.foldr (fn ((k, _), memo) => k :: memo) []
+    (C.list_items (!  library))
+
   val name = V.to_string PrintMode.User
   fun lookup k = C.lookup (! library) k
   val goal = #goal o lookup

--- a/operator.sml
+++ b/operator.sml
@@ -7,7 +7,10 @@ struct
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
     | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
     | FUN_EQ | FUN_INTRO | FUN_ELIM | LAM_EQ | AP_EQ
-    | WITNESS | HYP_EQ | ADMIT
+    | WITNESS | HYP_EQ
+    | SQUASH_EQ | SQUASH_INTRO | SQUASH_ELIM
+
+    | ADMIT
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -16,6 +19,7 @@ struct
     | PROD | PAIR | SPREAD
     | FUN | LAM | AP
     | EQ | MEM
+    | SQUASH
 
   fun eq O1 (O2 : t) = O1 = O2
 
@@ -47,6 +51,11 @@ struct
 
        | WITNESS => #[0,0]
        | HYP_EQ => #[0]
+
+       | SQUASH_EQ => #[0]
+       | SQUASH_INTRO => #[0]
+       | SQUASH_ELIM => #[0]
+
        | ADMIT => #[]
 
 
@@ -63,6 +72,8 @@ struct
        | AP => #[0,0]
        | EQ => #[0,0,0]
        | MEM => #[0,0]
+
+       | SQUASH => #[0]
 
   fun to_string O =
     case O of
@@ -92,6 +103,10 @@ struct
        | HYP_EQ => "hyp="
        | ADMIT => "<<<<<ADMIT>>>>>"
 
+       | SQUASH_EQ => "squash="
+       | SQUASH_INTRO => "squash-intro"
+       | SQUASH_ELIM => "squash-elim"
+
        | UNIV i => "U<" ^ Level.to_string i ^ ">"
        | VOID => "void"
        | UNIT => "unit"
@@ -105,4 +120,6 @@ struct
        | AP => "ap"
        | EQ => "="
        | MEM => "∈"
+
+       | SQUASH => "↓"
 end

--- a/refiner.fun
+++ b/refiner.fun
@@ -292,12 +292,16 @@ struct
       named "SquashElim" (fn (H >> P) =>
         let
           val #[M, N, A] = P ^! EQ
+
+          fun unsquash Z =
+            let val #[Z'] = Z ^! SQUASH in Z' end
+
+          val H' = Context.modify H z unsquash
+
           val _ =
             if has_free (P, z) orelse not (Context.is_irrelevant (H, z))
             then raise Refine
             else ()
-
-          val H' = Context.modify H z (fn Z => SQUASH $$ #[Z])
         in
           [ H' >> P
           ] BY mk_evidence SQUASH_ELIM

--- a/sequent.fun
+++ b/sequent.fun
@@ -1,12 +1,11 @@
 functor Sequent
   (structure Syntax : ABT_UTIL
-   structure Context : CONTEXT) : SEQUENT where Name = Context.Name =
+   structure Context : CONTEXT) : SEQUENT =
 struct
   type term = Syntax.t
 
-  structure Name = Context.Name
   structure Context = Context
-  type name = Name.t
+  type name = Context.Name.t
 
   type context = term Context.context
   datatype sequent = >> of context * term

--- a/sequent.sig
+++ b/sequent.sig
@@ -2,9 +2,8 @@ signature SEQUENT =
 sig
   type term
 
-  structure Name : VARIABLE
-  structure Context : CONTEXT where Name = Name
-  type name = Name.t
+  structure Context : CONTEXT
+  type name = Context.Name.t
 
   type context = term Context.context
 

--- a/sources.cm
+++ b/sources.cm
@@ -20,6 +20,9 @@ group is
   context.sig
   context.fun
 
+  context_util.sig
+  context_util.fun
+
   sequent.sig
   sequent.fun
 

--- a/test.sml
+++ b/test.sml
@@ -30,6 +30,7 @@ struct
   val void = VOID $$ #[]
   val unit = UNIT $$ #[]
   val ax = AX $$ #[]
+  fun squash A = SQUASH $$ #[A]
 
   fun & (a, b) = PROD $$ #[a, Variable.named "x" \\ b]
   infix 6 &
@@ -110,6 +111,10 @@ struct
   val test9 =
     Library.save "test9" (Emp >> (univ 0 & unit) mem (univ 1))
       Auto
+
+  val squash_test =
+    Library.save "squash_test" (Emp >> squash (unit & unit))
+      (Auto THEN ProdIntro ax THEN Auto)
 
   local
     val ac_premise =


### PR DESCRIPTION
This adds an intensional squash type as described in http://files.metaprl.org/papers/quotients.pdf.

I intend to implement the rest of the "special" types (intersection (#23), subset, quotient, etc.) in terms of this squash type in the MetaPRL style. (In Nuprl, it is done the other way around: the squash type is defined in terms of the subset, or the quotient.)

This PR makes it possible to address #23.
