### PR TITLE
Add subset types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ smlnj:
 	bin/mkexec.sh `which sml` `pwd` jonprl
 
 test:
-	bin/jonprl example/test.jonprl example/monoid.jonprl
+	bin/jonprl example/test.jonprl example/monoid.jonprl example/squash.jonprl
 
 clean:
 	rm -f bin/.heapimg.*

--- a/context.fun
+++ b/context.fun
@@ -43,7 +43,22 @@ struct
   fun map_after k f ctx =
     Tel.map_after ctx (k, fn (a, vis) => (f a, vis))
 
-  fun to_string f ctx = Tel.to_string (fn (x, _) => f x) ctx
+  fun to_string f tele =
+    let
+      open Tel.ConsView
+      fun go Empty r = r
+        | go (Cons (lbl, (a, vis), tele')) r =
+            let
+              val pretty_lbl =
+                case vis of
+                     Visibility.Visible => V.to_string lbl
+                   | Visibility.Hidden => "[" ^ V.to_string lbl ^ "]"
+            in
+              go (out tele') (r ^ ", " ^ pretty_lbl ^ " : " ^ f a)
+            end
+    in
+      go (out tele) "·"
+    end
 
   fun eq test =
     Tel.eq (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))

--- a/ctt.fun
+++ b/ctt.fun
@@ -531,6 +531,8 @@ struct
                  | _ => raise Refine)
         end)
 
+    (* !!! TODO !!! This can be used to use an irrelevant/hidden hypothesis in a
+     * relevant position. FIX!!! *)
     fun Witness M : tactic =
       named "Witness" (fn (H >> P) =>
         [ H >> MEM $$ #[M, P]

--- a/ctt.sig
+++ b/ctt.sig
@@ -52,21 +52,6 @@ sig
     (* H >> Ax = Ax ∈ Unit *)
     val AxEq : Lcf.tactic
 
-    (* H >> !A = !B ∈ U{k} by SquashEq
-     * 1. H >> A = B ∈ U{k}
-     *)
-    val SquashEq : Lcf.tactic
-
-    (* H >> !A by SquashIntro
-     * 1. H >> A
-     *)
-    val SquashIntro : Lcf.tactic
-
-    (* H, x : !A, H'[x] >> P[x] by SquashElim x
-     * 1. H, x : !A, H'[Ax] >> P[Ax]
-     *)
-    val SquashElim : name -> Lcf.tactic
-
     (* H >> (Σx:A)B[x] = (Σx:A')B'[x] ∈ U{k} by ProdEq z
      * 1. H >> A = A' ∈ U{k}
      * 2. H, z : A >> B[z] = B'[z] ∈ U{k}

--- a/ctt.sig
+++ b/ctt.sig
@@ -100,6 +100,11 @@ sig
     val IsectMemberEq : name option -> Level.t option -> Lcf.tactic
     val IsectMemberCaseEq : term option -> term -> Lcf.tactic
 
+    val SubsetEq : name option -> Lcf.tactic
+    val SubsetIntro : term -> name option -> Level.t option -> Lcf.tactic
+    val SubsetElim : name -> (name * name) option -> Lcf.tactic
+    val SubsetMemberEq : name option -> Level.t option -> Lcf.tactic
+
     val MemUnfold : Lcf.tactic
     val Witness : term -> Lcf.tactic
 

--- a/ctt_rule_parser.fun
+++ b/ctt_rule_parser.fun
@@ -191,6 +191,30 @@ struct
       >> brackets parse_name
       wth (fn lbl => fn st => Development.lookup_tactic st lbl)
 
+  val parse_subset_eq =
+    symbol "subset-eq"
+      >> opt (brackets parse_name)
+      wth SubsetEq
+
+  val parse_subset_intro =
+    symbol "subset-intro"
+      >> parse_tm
+      && opt (brackets parse_name)
+      && opt parse_level
+      wth (fn (M, (z, k)) => SubsetIntro M z k)
+
+  val parse_subset_elim =
+    symbol "subset-elim"
+      >> brackets parse_name
+      && opt (brackets (parse_name << comma && parse_name))
+      wth (fn (z, st) => SubsetElim z st)
+
+  val parse_subset_member_eq =
+    symbol "subset-member-eq"
+      >> opt (brackets parse_name)
+      && opt parse_level
+      wth (fn (z, k) => SubsetMemberEq z k)
+
   val extensional_parse =
     symbol "auto" return Auto
       || parse_cum
@@ -214,6 +238,10 @@ struct
       || symbol "hyp-eq" return HypEq
       || parse_witness
       || parse_eq_subst
+      || parse_subset_eq
+      || parse_subset_intro
+      || parse_subset_elim
+      || parse_subset_member_eq
 
   val intensional_parse =
     parse_lemma

--- a/ctt_rule_parser.fun
+++ b/ctt_rule_parser.fun
@@ -69,11 +69,6 @@ struct
       >> brackets parse_name
       wth UnitElim
 
-  val parse_squash_elim =
-    symbol "squash-elim"
-      >> brackets parse_name
-      wth SquashElim
-
   val parse_prod_eq =
     symbol "prod-eq"
       >> opt (brackets parse_name)
@@ -226,9 +221,6 @@ struct
       || symbol "unit-intro" return UnitIntro
       || parse_unit_elim
       || symbol "ax-eq" return AxEq
-      || symbol "squash-eq" return SquashEq
-      || symbol "squash-intro" return SquashIntro
-      || parse_squash_elim
       || parse_prod_eq || parse_prod_intro || parse_prod_elim || parse_pair_eq || parse_spread_eq
       || parse_fun_eq || parse_fun_intro || parse_fun_elim || parse_lam_eq || parse_ap_eq
       || parse_isect_eq || parse_isect_intro || parse_isect_elim || parse_isect_member_eq || parse_isect_member_case_eq

--- a/ctt_util.fun
+++ b/ctt_util.fun
@@ -17,7 +17,6 @@ struct
     val EqRules =
       AxEq
       ORELSE EqEq
-      ORELSE SquashEq
       ORELSE FunEq NONE
       ORELSE IsectEq NONE
       ORELSE PairEq NONE NONE
@@ -26,7 +25,6 @@ struct
       ORELSE ProdEq NONE
       ORELSE VoidEq
       ORELSE UnivEq
-      ORELSE SquashEq
       ORELSE HypEq
       ORELSE ApEq NONE
       ORELSE SpreadEq NONE NONE NONE
@@ -40,7 +38,6 @@ struct
       ORELSE FunIntro NONE NONE
       ORELSE IsectIntro NONE NONE
       ORELSE UnitIntro
-      ORELSE SquashIntro
 
     open Conversions Conversionals
     infix CORELSE

--- a/ctt_util.fun
+++ b/ctt_util.fun
@@ -14,7 +14,7 @@ struct
   infix ORELSE ORELSE_LAZY THEN
 
   local
-    val EqAuto =
+    val EqRules =
       AxEq
       ORELSE EqEq
       ORELSE SquashEq
@@ -28,30 +28,28 @@ struct
       ORELSE UnivEq
       ORELSE SquashEq
       ORELSE HypEq
+      ORELSE ApEq NONE
+      ORELSE SpreadEq NONE NONE NONE
       ORELSE Cum NONE
+      ORELSE SubsetEq NONE
+      ORELSE SubsetMemberEq NONE NONE
 
-    val intro_rules =
+    val IntroRules =
       MemUnfold
-      ORELSE EqAuto
       ORELSE Assumption
       ORELSE FunIntro NONE NONE
       ORELSE IsectIntro NONE NONE
       ORELSE UnitIntro
       ORELSE SquashIntro
 
-    val elim_rules =
-      ApEq NONE
-      ORELSE SpreadEq NONE NONE NONE
-
     open Conversions Conversionals
     infix CORELSE
 
-    val whnf = ApBeta CORELSE SpreadBeta
-    val DeepReduce = RewriteGoal (CDEEP whnf)
-    val IntroElim = intro_rules ORELSE elim_rules
+    val Reduce = ApBeta CORELSE SpreadBeta
+    val DeepReduce = RewriteGoal (CDEEP Reduce)
   in
     val Auto =
-      LIMIT (IntroElim ORELSE PROGRESS DeepReduce)
+      LIMIT (IntroRules ORELSE EqRules ORELSE PROGRESS DeepReduce)
   end
 end
 

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -1,0 +1,10 @@
+squash =def= [λ(A. subset(unit; _. A))].
+
+Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
+  unfold <squash>; auto.
+}.
+
+Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
+  auto; unfold <squash>; auto;
+  subset-intro [<>]; auto.
+}.

--- a/extract.fun
+++ b/extract.fun
@@ -55,10 +55,6 @@ struct
        | WITNESS $ #[M, _] => M
        | EQ_SUBST $ #[_, D, _] => extract D
 
-       | SQUASH_EQ $ _ => ax
-       | SQUASH_INTRO $ _ => ax
-       | SQUASH_ELIM $ _ => ax
-
        | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
 
        | ` x => `` x

--- a/extract.fun
+++ b/extract.fun
@@ -46,6 +46,11 @@ struct
        | ISECT_MEMBER_EQ $ _ => ax
        | ISECT_MEMBER_CASE_EQ $ _ => ax
 
+       | SUBSET_EQ $ _ => ax
+       | SUBSET_INTRO $ #[w,_,_,_] => w
+       | SUBSET_ELIM $ #[R, stD] => extract (stD // R) // ax
+       | SUBSET_MEMBER_EQ $ _ => ax
+
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M
        | EQ_SUBST $ #[_, D, _] => extract D

--- a/operator.sml
+++ b/operator.sml
@@ -10,7 +10,6 @@ struct
     | FUN_EQ | FUN_INTRO | FUN_ELIM | LAM_EQ | AP_EQ
     | ISECT_EQ | ISECT_INTRO | ISECT_ELIM | ISECT_MEMBER_EQ | ISECT_MEMBER_CASE_EQ
     | WITNESS | HYP_EQ | EQ_SUBST | EQ_SYM
-    | SQUASH_EQ | SQUASH_INTRO | SQUASH_ELIM
     | SUBSET_EQ | SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
 
     | ADMIT
@@ -23,7 +22,6 @@ struct
     | FUN | LAM | AP
     | ISECT
     | EQ | MEM
-    | SQUASH
     | SUBSET
 
   val eq = op=
@@ -64,10 +62,6 @@ struct
        | EQ_SUBST => #[0,0,1]
        | EQ_SYM => #[0]
 
-       | SQUASH_EQ => #[0]
-       | SQUASH_INTRO => #[0]
-       | SQUASH_ELIM => #[0]
-
        | SUBSET_EQ => #[0,1]
        | SUBSET_INTRO => #[0,0,0,1]
        | SUBSET_ELIM => #[0,2]
@@ -92,7 +86,6 @@ struct
        | EQ => #[0,0,0]
        | MEM => #[0,0]
 
-       | SQUASH => #[0]
        | SUBSET => #[0,1]
 
   fun to_string O =
@@ -132,10 +125,6 @@ struct
        | EQ_SYM => "sym"
        | ADMIT => "<<<<<ADMIT>>>>>"
 
-       | SQUASH_EQ => "squash="
-       | SQUASH_INTRO => "squash-intro"
-       | SQUASH_ELIM => "squash-elim"
-
        | SUBSET_EQ => "subset⁼"
        | SUBSET_INTRO => "subset-intro"
        | SUBSET_ELIM => "subset-elim"
@@ -155,7 +144,6 @@ struct
        | EQ => "="
        | MEM => "∈"
 
-       | SQUASH => "↓"
        | SUBSET => "subset"
 
   local
@@ -185,8 +173,6 @@ struct
         || string "⋂" return ISECT
         || string "=" return EQ
         || string "∈" return MEM
-        || string "!" return SQUASH
-        || string "↓" return SQUASH
         || string "subset" return SUBSET
   end
 end

--- a/operator.sml
+++ b/operator.sml
@@ -11,6 +11,7 @@ struct
     | ISECT_EQ | ISECT_INTRO | ISECT_ELIM | ISECT_MEMBER_EQ | ISECT_MEMBER_CASE_EQ
     | WITNESS | HYP_EQ | EQ_SUBST | EQ_SYM
     | SQUASH_EQ | SQUASH_INTRO | SQUASH_ELIM
+    | SUBSET_EQ | SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
 
     | ADMIT
 
@@ -23,6 +24,7 @@ struct
     | ISECT
     | EQ | MEM
     | SQUASH
+    | SUBSET
 
   val eq = op=
 
@@ -66,6 +68,11 @@ struct
        | SQUASH_INTRO => #[0]
        | SQUASH_ELIM => #[0]
 
+       | SUBSET_EQ => #[0,1]
+       | SUBSET_INTRO => #[0,0,0,1]
+       | SUBSET_ELIM => #[0,2]
+       | SUBSET_MEMBER_EQ => #[0,0,1]
+
        | ADMIT => #[]
 
 
@@ -86,6 +93,7 @@ struct
        | MEM => #[0,0]
 
        | SQUASH => #[0]
+       | SUBSET => #[0,1]
 
   fun to_string O =
     case O of
@@ -128,6 +136,11 @@ struct
        | SQUASH_INTRO => "squash-intro"
        | SQUASH_ELIM => "squash-elim"
 
+       | SUBSET_EQ => "subset⁼"
+       | SUBSET_INTRO => "subset-intro"
+       | SUBSET_ELIM => "subset-elim"
+       | SUBSET_MEMBER_EQ => "subset-member-eq"
+
        | UNIV i => "U<" ^ Level.to_string i ^ ">"
        | VOID => "void"
        | UNIT => "unit"
@@ -143,6 +156,7 @@ struct
        | MEM => "∈"
 
        | SQUASH => "↓"
+       | SUBSET => "subset"
 
   local
     open ParserCombinators CharParser
@@ -173,5 +187,6 @@ struct
         || string "∈" return MEM
         || string "!" return SQUASH
         || string "↓" return SQUASH
+        || string "subset" return SUBSET
   end
 end

--- a/syntax.sml
+++ b/syntax.sml
@@ -53,6 +53,17 @@ struct
                    enclose A ^ " × " ^ display B
                end
 
+           | SUBSET $ #[A, xB] =>
+               let
+                 val (x, B) = unbind xB
+               in
+                 if has_free (B, x) then
+                   "{" ^ Variable.to_string x ^ " ∈ " ^ display A ^ " | " ^ display B ^ "}"
+                 else
+                   "{" ^ display A ^ " | " ^ display B ^ "}"
+               end
+
+
            | LAM $ #[xE] =>
                let
                  val (x, E) = unbind xE
@@ -65,9 +76,6 @@ struct
 
            | PAIR $ #[M, N] =>
                "⟨" ^ display M ^ ", " ^ display N ^ "⟩"
-
-           | SQUASH $ #[A] =>
-               "‖" ^ display A ^ "‖"
 
            | MEM $ #[M, A] =>
                display M ^ " ∈ " ^ display A
@@ -137,9 +145,6 @@ struct
                in
                  "let⁼ " ^ dvar (x, yzE) ^ "," ^ dvar (y, zE) ^ " = " ^ display D ^ " by " ^ dvar (z, E) ^ " in " ^ display E
                end
-
-           | SQUASH_INTRO $ #[M] =>
-               "[" ^ display M ^ "]"
 
            | FUN_EQ $ #[D, xE] =>
                let


### PR DESCRIPTION
- added subset types
- removed squash types, which are subsumed by subset types
- fixed printing of hidden/irrelevant hypotheses in context
- fixed the broken `Witness` rule, which was allowing hidden variables into witnesses in relevant positions
