### PR TITLE
Simple-minded level polymorphism?

### DIFF
--- a/context.fun
+++ b/context.fun
@@ -1,36 +1,36 @@
 functor Context (V : VARIABLE) :> CONTEXT where type name = V.t =
 struct
 
-  structure Tel = Telescope (V)
+  structure Telescope = Telescope (V)
   type name = V.t
 
-  type 'a context = ('a * Visibility.t) Tel.telescope
+  type 'a context = ('a * Visibility.t) Telescope.telescope
 
-  val empty = Tel.empty
+  val empty = Telescope.empty
   fun insert H k vis v =
-    Tel.snoc H (k, (v, vis))
+    Telescope.snoc H (k, (v, vis))
 
-  val interpose_after = Tel.interpose_after
-  val fresh = Tel.fresh
+  val interpose_after = Telescope.interpose_after
+  val fresh = Telescope.fresh
 
   exception NotFound of name
 
   fun modify (ctx : 'a context) (k : V.t) f =
-    Tel.modify ctx (k, fn (a, vis) => (f a, vis))
+    Telescope.modify ctx (k, fn (a, vis) => (f a, vis))
 
   fun lookup_visibility (ctx : 'a context) k =
-    (Tel.lookup ctx k)
+    (Telescope.lookup ctx k)
 
   fun lookup ctx k = #1 (lookup_visibility ctx k)
 
   fun search ctx phi =
-    case Tel.search ctx (phi o #1) of
+    case Telescope.search ctx (phi o #1) of
          SOME (lbl, (a, vis)) => SOME (lbl, a)
        | NONE => NONE
 
   fun list_items ctx =
     let
-      open Tel.SnocView
+      open Telescope.SnocView
       fun go Empty r = r
         | go (Snoc (tele', lbl, (a, vis))) r = go (out tele') ((lbl, vis, a) :: r)
     in
@@ -38,14 +38,14 @@ struct
     end
 
   fun map f ctx =
-    Tel.map ctx (fn (a, vis) => (f a, vis))
+    Telescope.map ctx (fn (a, vis) => (f a, vis))
 
   fun map_after k f ctx =
-    Tel.map_after ctx (k, fn (a, vis) => (f a, vis))
+    Telescope.map_after ctx (k, fn (a, vis) => (f a, vis))
 
   fun to_string f tele =
     let
-      open Tel.ConsView
+      open Telescope.ConsView
       fun go Empty r = r
         | go (Cons (lbl, (a, vis), tele')) r =
             let
@@ -61,9 +61,9 @@ struct
     end
 
   fun eq test =
-    Tel.eq (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
+    Telescope.eq (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
   fun subcontext test =
-    Tel.subtelescope (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
+    Telescope.subtelescope (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
 end
 
 structure Context = Context(Syntax.Variable)

--- a/context.sig
+++ b/context.sig
@@ -1,7 +1,11 @@
 signature CONTEXT =
 sig
   type name
-  type 'a context
+
+  structure Telescope : TELESCOPE
+    where type Label.t = name
+
+  type 'a context = ('a * Visibility.t) Telescope.telescope
 
   val fresh : 'a context * name -> name
 

--- a/ctt.fun
+++ b/ctt.fun
@@ -709,22 +709,26 @@ struct
              SOME (x, _) => Hypothesis x (H >> P)
            | NONE => raise Refine)
 
-    fun Unfold (development, lem) : tactic =
-      named "Unfold" (fn (H >> P) =>
-        let
-          val definiens = Development.lookup_definition development lem
-          val rewrite = subst definiens lem
-        in
-          [ Context.map rewrite H >> rewrite P
-          ] BY (fn [D] => D
-                 | _ => raise Refine)
-        end)
 
     structure UnifyLevel = UnifyLevel (SyntaxWithUniverses(Syntax))
     structure UnifyLevelSequent = UnifyLevelSequent
       (structure Unify = UnifyLevel
        structure Abt = Syntax
        structure Sequent = Sequent)
+
+    fun Unfold (development, lem) ok : tactic =
+      named "Unfold" (fn (H >> P) =>
+        let
+          val k = case ok of SOME k => k | NONE => 0
+          val definiens =
+            UnifyLevel.subst (UnifyLevel.yank k)
+              (Development.lookup_definition development lem)
+          val rewrite = subst definiens lem
+        in
+          [ Context.map rewrite H >> rewrite P
+          ] BY (fn [D] => D
+                 | _ => raise Refine)
+        end)
 
     fun Lemma (development, lem) : tactic =
       named "Lemma" (fn (H >> P) =>

--- a/ctt.sig
+++ b/ctt.sig
@@ -97,7 +97,7 @@ sig
     val Hypothesis : name -> Lcf.tactic
     val HypEq : Lcf.tactic
 
-    val Unfold : Development.t * Development.label -> Lcf.tactic
+    val Unfold : Development.t * Development.label -> Level.t option -> Lcf.tactic
     val Lemma : Development.t * Development.label -> Lcf.tactic
 
     val RewriteGoal : ConvTypes.conv -> Lcf.tactic

--- a/ctt_rule_parser.fun
+++ b/ctt_rule_parser.fun
@@ -179,7 +179,8 @@ struct
   val parse_unfold =
     symbol "unfold"
       >> brackets parse_name
-      wth (fn lbl => fn st => Unfold (st, lbl))
+      && opt parse_level
+      wth (fn (lbl, k) => fn st => Unfold (st, lbl) k)
 
   val parse_custom_tactic =
     symbol "refine"

--- a/ctt_rule_parser.fun
+++ b/ctt_rule_parser.fun
@@ -42,10 +42,9 @@ struct
 
   exception XXX
 
-  val parse_level =
+  val parse_level_ann =
     symbol "@"
-      >> repeat1 digit
-        wth valOf o Int.fromString o String.implode
+      >> braces Level.parse
 
   fun parse_opt p =
     symbol "_" return NONE
@@ -57,7 +56,7 @@ struct
 
   val parse_cum =
     symbol "cum"
-      >> opt parse_level
+      >> opt parse_level_ann
       wth Cum
 
   val parse_tm =
@@ -78,7 +77,7 @@ struct
     symbol "prod-intro"
       >> parse_tm
       && opt (brackets parse_name)
-      && opt parse_level
+      && opt parse_level_ann
       wth (fn (M, (k, z)) => ProdIntro M k z)
 
   val parse_prod_elim =
@@ -88,7 +87,7 @@ struct
 
   val parse_pair_eq =
     symbol "pair-eq"
-      >> opt (brackets parse_name) && opt parse_level
+      >> opt (brackets parse_name) && opt parse_level_ann
       wth (fn (z, k) => PairEq z k)
 
   val parse_spread_eq =
@@ -105,7 +104,7 @@ struct
 
   val parse_fun_intro =
     symbol "fun-intro"
-      >> opt (brackets parse_name) && opt parse_level
+      >> opt (brackets parse_name) && opt parse_level_ann
       wth (fn (z,k) => FunIntro z k)
 
   val parse_fun_elim =
@@ -118,7 +117,7 @@ struct
   val parse_lam_eq =
     symbol "lam-eq"
       >> opt (brackets parse_name)
-         && opt parse_level
+         && opt parse_level_ann
       wth (fn (z,k) => LamEq z k)
 
   val parse_ap_eq =
@@ -133,7 +132,7 @@ struct
 
   val parse_isect_intro =
     symbol "isect-intro"
-      >> opt (brackets parse_name) && opt parse_level
+      >> opt (brackets parse_name) && opt parse_level_ann
       wth (fn (z,k) => IsectIntro z k)
 
   val parse_isect_elim =
@@ -145,7 +144,7 @@ struct
 
   val parse_isect_member_eq =
     symbol "isect-member-eq"
-      >> opt (brackets parse_name) && opt parse_level
+      >> opt (brackets parse_name) && opt parse_level_ann
       wth (fn (z,k) => IsectMemberEq z k)
 
   val parse_isect_member_case_eq =
@@ -166,7 +165,7 @@ struct
 
   val parse_eq_subst =
     symbol "subst"
-      >> parse_tm && parse_tm && opt parse_level
+      >> parse_tm && parse_tm && opt parse_level_ann
       wth (fn (M, (N, k)) => EqSubst M N k)
 
   type state = Development.t
@@ -179,7 +178,7 @@ struct
   val parse_unfold =
     symbol "unfold"
       >> brackets parse_name
-      && opt parse_level
+      && opt parse_level_ann
       wth (fn (lbl, k) => fn st => Unfold (st, lbl) k)
 
   val parse_custom_tactic =
@@ -196,7 +195,7 @@ struct
     symbol "subset-intro"
       >> parse_tm
       && opt (brackets parse_name)
-      && opt parse_level
+      && opt parse_level_ann
       wth (fn (M, (z, k)) => SubsetIntro M z k)
 
   val parse_subset_elim =
@@ -208,11 +207,12 @@ struct
   val parse_subset_member_eq =
     symbol "subset-member-eq"
       >> opt (brackets parse_name)
-      && opt parse_level
+      && opt parse_level_ann
       wth (fn (z, k) => SubsetMemberEq z k)
 
   val extensional_parse =
     symbol "auto" return Auto
+      || symbol "reduce" return DeepReduce
       || parse_cum
       || symbol "eq-eq" return EqEq
       || symbol "univ-eq" return UnivEq

--- a/ctt_util.fun
+++ b/ctt_util.fun
@@ -43,10 +43,10 @@ struct
     infix CORELSE
 
     val Reduce = ApBeta CORELSE SpreadBeta
-    val DeepReduce = RewriteGoal (CDEEP Reduce)
   in
+    val DeepReduce = RewriteGoal (CDEEP Reduce)
     val Auto =
-      LIMIT (IntroRules ORELSE EqRules ORELSE PROGRESS DeepReduce)
+      LIMIT (PROGRESS DeepReduce ORELSE IntroRules ORELSE EqRules)
   end
 end
 

--- a/ctt_util.sig
+++ b/ctt_util.sig
@@ -2,4 +2,5 @@ signature CTT_UTIL =
 sig
   include CTT
   val Auto : Lcf.tactic
+  val DeepReduce : Lcf.tactic
 end

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -1,6 +1,6 @@
 RawCatSig =def= [
-  Σ(U<0>; Obj.
-  Σ(Π(Obj; A. Π(Obj; B. U<0>)); Hom.
+  Σ(U{i}; Obj.
+  Σ(Π(Obj; A. Π(Obj; B. U{i})); Hom.
   Σ(Π(Obj; A.
     ap(ap(Hom; A); A)); idn.
   Σ(Π(Obj; A. Π(Obj; B. Π(Obj; C.
@@ -15,11 +15,11 @@ hom =def= [λ(C. spread(spread(C; x.y.y); x.y.x))].
 idn =def= [λ(C. spread(spread(spread(C; x.y.y); x.y.y); x.y.x))].
 cmp =def= [λ(C. spread(spread(spread(spread(C; x.y.y); x.y.y); x.y.y); x.y.x))].
 
-Theorem RawCatSig_wf : [∈(RawCatSig; U<1>)] {
+Theorem RawCatSig_wf : [∈(RawCatSig; U{i'})] {
   unfold <RawCatSig>; auto.
 }.
 
-Theorem obj_wf : [∀(RawCatSig; RC. ∈(ap(obj; RC); U<0>))] {
+Theorem obj_wf : [∀(RawCatSig; RC. ∈(ap(obj; RC); U{i}))] {
   unfold <RawCatSig>; unfold <obj>;
   auto.
 }.
@@ -28,7 +28,7 @@ Theorem hom_wf : [
   ∀(RawCatSig; RC.
   ∀(ap(obj; RC); A.
   ∀(ap(obj; RC); B.
-    ∈(ap(ap(ap(hom; RC); A); B); U<0>))))
+    ∈(ap(ap(ap(hom; RC); A); B); U{i}))))
 ] {
   unfold <RawCatSig>; unfold <hom>; unfold <obj>;
   auto.

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -1,4 +1,4 @@
-MonoidSig =def= [Σ(U<0>; A. Σ(A; zero. Π(A; m. Π(A; n. A))))].
+MonoidSig =def= [Σ(U{i}; A. Σ(A; zero. Π(A; m. Π(A; n. A))))].
 car =def= [λ(M. spread(M; x.y.x))].
 ze =def= [λ(M. spread(spread(M; x.y.y); x.y.x))].
 op =def= [λ(M. spread(spread(M; x.y.y); x.y.y))].
@@ -10,21 +10,21 @@ Tactic monoid-unfold {
   unfold <MonoidSig>; unfold <car>; unfold <op>; unfold <ze>.
 }.
 
-Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
+Theorem MonoidSig-wf : [∈(MonoidSig; U{i'})] {
   refine <monoid-unfold>; auto.
 }.
 
-Theorem car-wf : [∀(MonoidSig; M. ∈(ap(car;M); U<0>))] {
+Theorem car-wf : [∀(MonoidSig; M. ∈(ap(car;M); U{i}))] {
   refine <monoid-unfold>; auto;
   prod-elim <M>; auto.
 }.
 
-Theorem LeftUnit-wf : [∀(MonoidSig; M. ∈(ap(LeftUnit;M);U<0>))] {
+Theorem LeftUnit-wf : [∀(MonoidSig; M. ∈(ap(LeftUnit;M);U{i}))] {
   unfold <LeftUnit>; auto; refine <monoid-unfold>;
   auto; prod-elim <M>; auto .
 }.
 
-Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(ap(RightUnit;M);U<0>))] {
+Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(ap(RightUnit;M);U{i}))] {
   unfold <RightUnit>; auto; refine <monoid-unfold>;
   auto; prod-elim <M>; auto .
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -4,19 +4,7 @@ Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
   unfold <squash>; auto.
 }.
 
-Theorem squash-wf2 : [∀(U<10>; A. ∈(ap(squash;A); U<10>))] {
-  lemma <squash-wf>.
-}.
-
-Theorem squash-wf3 : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
-  lemma <squash-wf>.
-}.
-
 Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
   auto; unfold <squash>; auto;
   subset-intro [<>]; auto.
-}.
-
-Theorem obv : [∀(U<0>; A. ∈(A; U<1>))] {
-  auto.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -9,6 +9,6 @@ Theorem squash-intro : [∀(U{i}; A. Π(A; M. ap(squash; A)))] {
   subset-intro [<>]; auto.
 }.
 
-Theorem sq-test : [∀(U{i}; A. ∈(ap(squash;A);U{i'}))] {
+Theorem sq-test : [∀(U{i'}; A. ∈(ap(squash;A);U{i'}))] {
   lemma <squash-wf>.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -1,10 +1,14 @@
 squash =def= [λ(A. subset(unit; _. A))].
 
-Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
-  unfold <squash>; auto.
+Theorem squash-wf : [∀(U{i}; A. ∈(ap(squash;A); U{i}))] {
+  unfold <squash>; auto; cum.
 }.
 
-Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
-  auto; unfold <squash>; auto;
+Theorem squash-intro : [∀(U{i}; A. Π(A; M. ap(squash; A)))] {
+  unfold <squash>; auto;
   subset-intro [<>]; auto.
+}.
+
+Theorem sq-test : [∀(U{i}; A. ∈(ap(squash;A);U{i'}))] {
+  lemma <squash-wf>.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -4,7 +4,19 @@ Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
   unfold <squash>; auto.
 }.
 
+Theorem squash-wf2 : [∀(U<10>; A. ∈(ap(squash;A); U<10>))] {
+  lemma <squash-wf>.
+}.
+
+Theorem squash-wf3 : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
+  lemma <squash-wf>.
+}.
+
 Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
   auto; unfold <squash>; auto;
   subset-intro [<>]; auto.
+}.
+
+Theorem obv : [∀(U<0>; A. ∈(A; U<1>))] {
+  auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -41,7 +41,7 @@ Theorem test7 : ⌊Π(Σ(void;_.unit); z. void)⌋ {
   auto.
 }.
 
-Theorem axiom-of-choice : ⌊∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
+Theorem axiom-of-choice : ⌊∀(U{i}; A. ∀(U{i}; B. ∀(Π(A; _. Π(B; _. U{i})); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
   auto; prod-intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
   fun-elim <φ> ⌊a⌋; auto;
   subst ⌊=(ap(φ;a); y; Σ(B;b. ap(ap(Q;a);b)))⌋ ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;

--- a/extract.fun
+++ b/extract.fun
@@ -12,7 +12,7 @@ struct
 
   fun extract E =
     case out E of
-         UNIV_EQ $ _ => ax
+         UNIV_EQ _ $ _ => ax
        | VOID_EQ $ _ => ax
        | VOID_ELIM $ _ => ax
        | CUM $ _ => ax

--- a/level.sig
+++ b/level.sig
@@ -1,12 +1,27 @@
 signature LEVEL =
 sig
-  type t
-  val to_string : t -> string
+  eqtype t
 
   exception LevelError
+
+  val base : t
+  val prime : t -> t
+  val pred : t -> t
+  val max : t * t -> t
+
+  type constraint
+  type substitution
+
+  val yank : t -> substitution
+  val unify : t * t -> constraint
+  val resolve : constraint list -> substitution
+  val subst : substitution -> t -> t
+
   val compare : t * t -> order
   val assert_lt : t * t -> unit
-  val unify : t * t -> t
-  val max : t * t -> t
-  val prime : t -> t
+  val assert_lte : t * t -> unit
+  val assert_eq : t * t -> t
+
+  val to_string : t -> string
+  val parse : t CharParser.charParser
 end

--- a/level.sig
+++ b/level.sig
@@ -4,8 +4,9 @@ sig
   val to_string : t -> string
 
   exception LevelError
+  val compare : t * t -> order
   val assert_lt : t * t -> unit
   val unify : t * t -> t
   val max : t * t -> t
+  val prime : t -> t
 end
-

--- a/level.sml
+++ b/level.sml
@@ -25,18 +25,14 @@ struct
   end
 
   local
-    fun go [] R = R
-      | go (0 :: xs) R = go xs R
-      | go (x :: xs) 0 = go xs x
-      | go (x :: xs) R =
-          if (x > 0) andalso (R > 0) then
-            go xs (Int.max (x, R))
-          else if (x < 0) andalso (R < 0) then
-            go xs (Int.min (x, R))
+    fun go [] = 0
+      | go (x :: xs) =
+          if (foldl (fn (y, b) => b andalso x = y) true xs) then
+            x
           else
             raise LevelError
   in
-    fun resolve xs = fn x => x + go xs 0
+    fun resolve xs = fn x => x + go xs
   end
 
   fun subst f x = f x

--- a/level.sml
+++ b/level.sml
@@ -5,7 +5,9 @@ struct
   fun to_string i = Int.toString i
 
   exception LevelError
+  val compare = Int.compare
   fun assert_lt (i, j) = if i < j then () else raise LevelError
   fun unify (i, j) = if i = j then i else raise LevelError
   fun max (i, j) = Int.max (i, j)
+  fun prime i = i + 1
 end

--- a/level.sml
+++ b/level.sml
@@ -1,13 +1,51 @@
-structure Level :> LEVEL where type t = int =
+structure Level :> LEVEL =
 struct
   type t = int
-
-  fun to_string i = Int.toString i
-
+  type constraint = int
+  type substitution = int -> int
   exception LevelError
+
+  fun yank x = fn y => x + y
+  fun pred x = x - 1
+  fun unify (x, y) = y - x
+
+  local
+    fun ticks 0 R = R
+      | ticks n R = ticks (n - 1) (#"'" :: R)
+  in
+    fun to_string i =
+      "i" ^ String.implode (ticks i [])
+  end
+
+  local
+    open ParserCombinators CharParser
+    infix wth >>
+  in
+    val parse : t charParser = char #"i" >> repeat (char #"'") wth length
+  end
+
+  local
+    fun go [] R = R
+      | go (0 :: xs) R = go xs R
+      | go (x :: xs) 0 = go xs x
+      | go (x :: xs) R =
+          if (x > 0) andalso (R > 0) then
+            go xs (Int.max (x, R))
+          else if (x < 0) andalso (R < 0) then
+            go xs (Int.min (x, R))
+          else
+            raise LevelError
+  in
+    fun resolve xs = fn x => x + go xs 0
+  end
+
+  fun subst f x = f x
+
   val compare = Int.compare
   fun assert_lt (i, j) = if i < j then () else raise LevelError
-  fun unify (i, j) = if i = j then i else raise LevelError
+  fun assert_lte (i, j) = if i <= j then () else raise LevelError
+  fun assert_eq (i, j) = if i = j then i else raise LevelError
   fun max (i, j) = Int.max (i, j)
   fun prime i = i + 1
+  val base = 0
 end

--- a/operator.sml
+++ b/operator.sml
@@ -90,7 +90,7 @@ struct
 
   fun to_string O =
     case O of
-         UNIV_EQ i => "U⁼<" ^ Int.toString i ^ ">"
+         UNIV_EQ i => "U⁼<" ^ Level.to_string i ^ ">"
        | CUM => "cum"
        | VOID_EQ => "void⁼"
        | VOID_ELIM => "void-elim"
@@ -152,11 +152,8 @@ struct
     infixr 1 ||
     infixr 4 << >>
   in
-    val parse_int =
-      repeat1 digit wth valOf o Int.fromString o String.implode
-
     val parse_univ =
-      string "U<" >> parse_int << string ">" wth UNIV
+      string "U{" >> Level.parse << string "}" wth UNIV
 
     val parse_operator =
       parse_univ

--- a/operator.sml
+++ b/operator.sml
@@ -2,7 +2,7 @@ structure Operator =
 struct
   datatype t
     = (* Derivations *)
-      UNIV_EQ | CUM
+      UNIV_EQ of Level.t | CUM
     | EQ_EQ
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
@@ -28,7 +28,7 @@ struct
 
   fun arity O =
     case O of
-         UNIV_EQ => #[]
+         UNIV_EQ _ => #[]
        | CUM => #[0]
        | EQ_EQ => #[0,0,0]
        | VOID_EQ => #[]
@@ -90,7 +90,7 @@ struct
 
   fun to_string O =
     case O of
-         UNIV_EQ => "U⁼"
+         UNIV_EQ i => "U⁼<" ^ Int.toString i ^ ">"
        | CUM => "cum"
        | VOID_EQ => "void⁼"
        | VOID_ELIM => "void-elim"

--- a/sources.cm
+++ b/sources.cm
@@ -28,6 +28,10 @@ group is
 
   level.sig
   level.sml
+
+  unify_level.sig
+  unify_level.fun
+
   ctt.sig
   ctt.fun
   ctt_util.sig

--- a/syntax.sml
+++ b/syntax.sml
@@ -84,7 +84,7 @@ struct
                display M ^ " = " ^ display N ^ " ∈ " ^ display A
 
            | UNIV i $ #[] =>
-               "U" ^ subscript i
+               "U{" ^ Level.to_string i ^ "}"
 
            | SPREAD $ #[M, xyN] =>
                let
@@ -95,7 +95,7 @@ struct
                end
 
            | UNIV_EQ i $ #[] =>
-               "U⁼" ^ subscript i
+               "U⁼{" ^ Level.to_string i ^ "}"
 
            | EQ_EQ $ #[A,M,N] =>
                display M ^ " =⁼ " ^ display N ^ " ∈⁼ " ^ display A
@@ -219,20 +219,6 @@ struct
 
       and dvar (x, E) =
         if has_free (E, x) then Variable.to_string x else "_"
-
-      and subscript i =
-        case i of
-             0 => "₀"
-           | 1 => "₁"
-           | 2 => "₂"
-           | 3 => "₃"
-           | 4 => "₄"
-           | 5 => "₅"
-           | 6 => "₆"
-           | 7 => "₇"
-           | 8 => "₈"
-           | 9 => "₉"
-           | _ => let val m = i mod 10 in subscript ((i - m) div 10) ^ subscript m end
     in
       display
     end

--- a/syntax.sml
+++ b/syntax.sml
@@ -94,6 +94,8 @@ struct
                  "let " ^ dvar (x, yN) ^ "," ^ dvar (y, N) ^ " = " ^ display M ^ " in " ^ display N
                end
 
+           | UNIV_EQ i $ #[] =>
+               "U⁼" ^ subscript i
 
            | EQ_EQ $ #[A,M,N] =>
                display M ^ " =⁼ " ^ display N ^ " ∈⁼ " ^ display A

--- a/unify_level.fun
+++ b/unify_level.fun
@@ -28,7 +28,6 @@ struct
       | go H (O1 $ ES1, O2 $ ES2) R =
           (case (View.out O1, View.out O2) of
                 (View.UNIV k, View.UNIV l) => goes H (ES1, ES2) (Level.unify (k,l) :: R)
-                (* (l - k) :: R*)
               | (View.OTHER O1', View.OTHER O2') =>
                   if Operator.eq (O1', O2') then
                     goes H (ES1, ES2) R

--- a/unify_level.fun
+++ b/unify_level.fun
@@ -1,4 +1,7 @@
-functor UnifyLevel (Syntax : SYNTAX_WITH_UNIVERSES where type Level.t = int) :> UNIFY_LEVEL where type term = Syntax.Abt.t =
+functor UnifyLevel (Syntax : SYNTAX_WITH_UNIVERSES where type Level.t = int) :>
+  UNIFY_LEVEL
+    where type term = Syntax.Abt.t
+    where Level = Syntax.Level =
 struct
   structure Syntax = Syntax
   open Syntax Syntax.Abt
@@ -8,6 +11,8 @@ struct
   type term = Syntax.Abt.t
   type constraint = int
   type substitution = Level.t -> Level.t
+
+  fun yank k l = k + l
 
   exception UnifyLevel
 

--- a/unify_level.fun
+++ b/unify_level.fun
@@ -1,0 +1,131 @@
+functor UnifyLevel (Syntax : SYNTAX_WITH_UNIVERSES where type Level.t = int) :> UNIFY_LEVEL where type term = Syntax.Abt.t =
+struct
+  structure Syntax = Syntax
+  open Syntax Syntax.Abt
+
+  infix $ \
+
+  type term = Syntax.Abt.t
+  type constraint = int
+  type substitution = Level.t -> Level.t
+
+  exception UnifyLevel
+
+  local
+    structure Dict = SplayDict(structure Key = Variable)
+    open Dict
+
+    fun go H (` x, ` y) R =
+          let
+            open Variable
+          in
+            if eq (x, y) orelse eq (lookup H x, y) orelse eq (lookup H y, x) then
+              R
+            else
+              raise UnifyLevel
+          end
+      | go H (x \ E, y \ F) R = go (insert H x y) (out E, out F) R
+      | go H (O1 $ ES1, O2 $ ES2) R =
+          (case (View.out O1, View.out O2) of
+                (View.UNIV k, View.UNIV l) => goes H (ES1, ES2) ((l - k) :: R)
+              | (View.OTHER O1', View.OTHER O2') =>
+                  if Operator.eq (O1', O2') then
+                    goes H (ES1, ES2) R
+                  else
+                    raise UnifyLevel
+              | _ => raise UnifyLevel)
+      | go _ _ _ = raise UnifyLevel
+    and goes H (xs, ys) R =
+          let
+            val length = Vector.length xs
+            val _ = if Vector.length ys <> length then raise UnifyLevel else ()
+            val xsys = Vector.tabulate (length, fn n => (Vector.sub (xs, n), Vector.sub (ys, n)))
+          in
+            Vector.foldl (fn ((M,N), R') => go H (out M, out N) R') R xsys
+          end
+  in
+    fun unify_level (M, N) = go empty (out M, out N) []
+  end
+
+  local
+    fun go [] R = R
+      | go (0 :: xs) R = go xs R
+      | go (x :: xs) 0 = go xs x
+      | go (x :: xs) R =
+          if (x > 0) andalso (R > 0) then
+            go xs (Int.max (x, R))
+          else if (x < 0) andalso (R < 0) then
+            go xs (Int.min (x, R))
+          else
+            raise UnifyLevel
+  in
+    fun resolve xs = fn x => x + go xs 0
+  end
+
+  fun subst f M =
+    case out M of
+         ` x => into (` x)
+       | O $ ES => into (map_level f O $ Vector.map (subst f) ES)
+       | x \ E => into (x \ subst f E)
+end
+
+functor UnifyLevelSequent
+  (structure Unify : UNIFY_LEVEL
+   structure Abt : ABT
+   structure Sequent : SEQUENT
+   sharing type Abt.t = Unify.term
+   sharing type Sequent.term = Unify.term) : UNIFY_LEVEL =
+struct
+  structure Level = Unify.Level
+  structure Unify = Unify
+  structure Sequent = Sequent
+
+  open Sequent
+  infix >>
+
+  open Unify
+  type term = Sequent.sequent
+
+  local
+    open Context.Telescope
+    fun go (H, H') R =
+      case ConsView.out H of
+           ConsView.Empty => R
+         | ConsView.Cons (lbl, (A, vis), tel) =>
+             go (tel, H') (R @ Unify.unify_level (A, Context.lookup H lbl))
+  in
+    fun ctx_unify_level (H, H') = go (H, H') []
+  end
+
+  fun unify_level (H >> C, H' >> C') =
+    Unify.unify_level (C, C')
+      @ ctx_unify_level (H, H')
+
+  fun subst f (H >> C) =
+    Context.map (Unify.subst f) H >> Unify.subst f C
+end
+
+functor SyntaxWithUniverses
+  (Syntax : ABT where Operator = Operator)
+    :> SYNTAX_WITH_UNIVERSES where Level = Level and Abt = Syntax =
+struct
+  structure Level = Level
+  structure Abt = Syntax
+
+  fun map_level f O =
+    case O of
+         Operator.UNIV k => Operator.UNIV (f k)
+       | Operator.UNIV_EQ k => Operator.UNIV_EQ (f k)
+       | _ => O
+
+  structure View =
+  struct
+    datatype 'a operator =
+        UNIV of Level.t
+      | OTHER of 'a
+
+    fun out (Operator.UNIV k) = UNIV k
+      | out (Operator.UNIV_EQ k) = UNIV k
+      | out O = OTHER O
+  end
+end

--- a/unify_level.sig
+++ b/unify_level.sig
@@ -3,16 +3,10 @@ sig
   structure Level : LEVEL
   type term
 
-  type constraint
-  type substitution
-
-  val yank : Level.t -> substitution
-
   exception UnifyLevel
 
-  val unify_level : term * term -> constraint list
-  val resolve : constraint list -> substitution
-  val subst : substitution -> term -> term
+  val unify_level : term * term -> Level.constraint list
+  val subst : Level.substitution -> term -> term
 end
 
 signature SYNTAX_WITH_UNIVERSES =
@@ -20,7 +14,7 @@ sig
   structure Level : LEVEL
   structure Abt : ABT
 
-  val map_level : (Level.t -> Level.t) -> Abt.Operator.t -> Abt.Operator.t
+  val map_level : Level.substitution -> Abt.Operator.t -> Abt.Operator.t
 
   structure View :
   sig

--- a/unify_level.sig
+++ b/unify_level.sig
@@ -1,0 +1,31 @@
+signature UNIFY_LEVEL =
+sig
+  structure Level : LEVEL
+  type term
+
+  type constraint
+  type substitution
+  exception UnifyLevel
+
+  val unify_level : term * term -> constraint list
+  val resolve : constraint list -> substitution
+  val subst : substitution -> term -> term
+end
+
+signature SYNTAX_WITH_UNIVERSES =
+sig
+  structure Level : LEVEL
+  structure Abt : ABT
+
+  val map_level : (Level.t -> Level.t) -> Abt.Operator.t -> Abt.Operator.t
+
+  structure View :
+  sig
+    datatype 'a operator =
+        UNIV of Level.t
+      | OTHER of 'a
+
+    val out : Abt.Operator.t -> Abt.Operator.t operator
+  end
+end
+

--- a/unify_level.sig
+++ b/unify_level.sig
@@ -5,6 +5,9 @@ sig
 
   type constraint
   type substitution
+
+  val yank : Level.t -> substitution
+
   exception UnifyLevel
 
   val unify_level : term * term -> constraint list


### PR DESCRIPTION
@freebroccolo I had a thought about a really simple form of universe polymorphism, and I wanted to see if it sounded plausible to you, or if you could think of a counterexample.

Anyway, right now there is a fixed, cumulative hierarchy of universes. I would like to change this slightly by having every definition and lemma parameterized over some arbitrary hierarchy; essentially, this means that `U<0>` becomes `U<i>` and `U<1>` becomes `U<i'>`, where `i' > i`.

Then, it should become safe to take any definition or lemma and perform any substitution of some other level expression for `i`, since everything is _general_ in the single variable `i`. First sanity check: is this actually a valid transformation? If not, what do we need to do to make it valid?

If this does work out, it does seem a little surprising, but I think the well-behavedness comes from the fact that there would never be any more than one free level variable. If it does work, the other question is, does it suffice?
