### PR TITLE
Annotated tactics, miscellaneous overhaul

### DIFF
--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -63,9 +63,9 @@ LawCat =def= [
 ].
 
 Theorem LawCat_wf : [∀(RawCat; RC. ∈(ap(LawCat; RC); U<1>))] {
-  isect-intro @1;
+  intro @1;
   [ unfold <LawCat>; auto; refine <rawcat_unfold>; auto;
-    prod-elim <RC>; auto; prod-elim <t>; auto; prod-elim <t'>; auto; prod-elim <t''>; auto;
+    elim <RC>; auto; elim <t>; auto; elim <t'>; auto; elim <t''>; auto;
     [ id
     , id
     , id
@@ -90,10 +90,10 @@ Theorem InitialRawCat : [RawCat] {
 
 Theorem TerminalRawCat : [RawCat] {
   unfold <RawCat>;
-  prod-intro [unit]; auto;
-  prod-intro [λ(A. λ(B. unit))]; auto;
-  prod-intro [λ(A. <>)]; auto;
-  prod-intro [λ(A. λ(B. λ(C. λ(g. λ(f. <>)))))];
+  intro [unit]; auto;
+  intro [λ(A. λ(B. unit))]; auto;
+  intro [λ(A. <>)]; auto;
+  intro [λ(A. λ(B. λ(C. λ(g. λ(f. <>)))))];
   auto.
 }.
 

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -83,9 +83,9 @@ law_cmp_ass =def= [λ(RC. spread(spread(spread(ap(LawCat; RC); x.y.y); x.y.y); x
 
 Theorem InitialRawCat : [RawCat] {
   unfold <RawCat>;
-  prod-intro [void]; auto;
-  prod-intro [λ(A. λ(B. void))]; auto;
-  witness [pair(λ(A. <>); pair(λ(A. <>); <>))]; auto; void-elim; auto.
+  intro [void]; auto;
+  intro [λ(A. λ(B. void))]; auto;
+  witness [pair(λ(A. <>); pair(λ(A. <>); <>))]; auto.
 }.
 
 Theorem TerminalRawCat : [RawCat] {

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -16,31 +16,32 @@ Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
 
 Theorem car-wf : [∀(MonoidSig; M. ∈(ap(car;M); U<0>))] {
   refine <monoid-unfold>; auto;
-  prod-elim <M>; auto.
+  elim <M>; auto.
 }.
 
 Theorem LeftUnit-wf : [∀(MonoidSig; M. ∈(ap(LeftUnit;M);U<0>))] {
   unfold <LeftUnit>; auto; refine <monoid-unfold>;
-  auto; prod-elim <M>; auto .
+  auto; elim <M>; auto .
 }.
 
 Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(ap(RightUnit;M);U<0>))] {
   unfold <RightUnit>; auto; refine <monoid-unfold>;
-  auto; prod-elim <M>; auto .
+  auto; elim <M>; auto .
 }.
 
 Theorem UnitMonoidStruct : [MonoidSig] {
   unfold <MonoidSig>;
-  prod-intro [unit]; auto;
-  prod-intro [<>] ; auto.
+  intro [unit]; auto;
+  intro [<>] ; auto.
 }.
 
 Theorem UnitMonoid-LeftUnit : [ap(LeftUnit;UnitMonoidStruct)] {
-  unfold <UnitMonoidStruct>; unfold <LeftUnit>; refine <monoid-unfold>; auto.
+  unfold <UnitMonoidStruct>; unfold <LeftUnit>; refine <monoid-unfold>; auto;
+  elim <m>; auto.
 }.
 
 
 Theorem UnitMonoid-RightUnit : [ap(RightUnit;UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>; unfold <RightUnit>; refine <monoid-unfold>; auto;
-  unit-elim <m>; auto.
+  elim <m>; auto.
 }.

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -1,47 +1,46 @@
-MonoidSig =def= [Σ(U<0>; A. Σ(A; zero. Π(A; m. Π(A; n. A))))].
-car =def= [λ(M. spread(M; x.y.x))].
-ze =def= [λ(M. spread(spread(M; x.y.y); x.y.x))].
-op =def= [λ(M. spread(spread(M; x.y.y); x.y.y))].
+MonoidSig =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
+car =def= ⌊λ(M. spread(M; x.y.x))⌋.
+ze =def= ⌊λ(M. spread(spread(M; x.y.y); x.y.x))⌋.
+op =def= ⌊λ(M. spread(spread(M; x.y.y); x.y.y))⌋.
 
-LeftUnit =def= [λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); ap(ze;M)); m) ;ap(car;M))))].
-RightUnit =def= [λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); m); ap(ze;M));ap(car;M))))].
+LeftUnit =def= ⌊λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); ap(ze;M)); m) ;ap(car;M))))⌋.
+RightUnit =def= ⌊λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); m); ap(ze;M));ap(car;M))))⌋.
 
 Tactic monoid-unfold {
-  unfold <MonoidSig>; unfold <car>; unfold <op>; unfold <ze>.
+  unfold 〈MonoidSig〉; unfold 〈car〉; unfold 〈op〉; unfold 〈ze〉.
 }.
 
-Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
-  refine <monoid-unfold>; auto.
+Theorem MonoidSig-wf : ⌊∈(MonoidSig; U〈1〉)⌋ {
+  refine 〈monoid-unfold〉; auto.
 }.
 
-Theorem car-wf : [∀(MonoidSig; M. ∈(ap(car;M); U<0>))] {
-  refine <monoid-unfold>; auto;
-  elim <M>; auto.
+Theorem car-wf : ⌊∀(MonoidSig; M. ∈(ap(car;M); U〈0〉))⌋ {
+  refine 〈monoid-unfold〉; auto;
+  elim 〈M〉; auto.
 }.
 
-Theorem LeftUnit-wf : [∀(MonoidSig; M. ∈(ap(LeftUnit;M);U<0>))] {
-  unfold <LeftUnit>; auto; refine <monoid-unfold>;
-  auto; elim <M>; auto .
+Theorem LeftUnit-wf : ⌊∀(MonoidSig; M. ∈(ap(LeftUnit;M);U〈0〉))⌋ {
+  unfold 〈LeftUnit〉; auto; refine 〈monoid-unfold〉;
+  auto; elim 〈M〉; auto .
 }.
 
-Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(ap(RightUnit;M);U<0>))] {
-  unfold <RightUnit>; auto; refine <monoid-unfold>;
-  auto; elim <M>; auto .
+Theorem RightUnit-wf : ⌊∀(MonoidSig; M. ∈(ap(RightUnit;M);U〈0〉))⌋ {
+  unfold 〈RightUnit〉; auto; refine 〈monoid-unfold〉;
+  auto; elim 〈M〉; auto .
 }.
 
-Theorem UnitMonoidStruct : [MonoidSig] {
-  unfold <MonoidSig>;
-  intro [unit]; auto;
-  intro [<>] ; auto.
+Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
+  unfold 〈MonoidSig〉;
+  intro ⌊unit⌋; auto;
+  intro ⌊<>⌋ ; auto.
 }.
 
-Theorem UnitMonoid-LeftUnit : [ap(LeftUnit;UnitMonoidStruct)] {
-  unfold <UnitMonoidStruct>; unfold <LeftUnit>; refine <monoid-unfold>; auto;
-  elim <m>; auto.
+Theorem UnitMonoid-LeftUnit : ⌊ap(LeftUnit;UnitMonoidStruct)⌋ {
+  unfold 〈UnitMonoidStruct〉; unfold 〈LeftUnit〉; refine 〈monoid-unfold〉; auto;
+  elim 〈m〉; auto.
 }.
 
-
-Theorem UnitMonoid-RightUnit : [ap(RightUnit;UnitMonoidStruct)] {
-  unfold <UnitMonoidStruct>; unfold <RightUnit>; refine <monoid-unfold>; auto;
-  elim <m>; auto.
+Theorem UnitMonoid-RightUnit : ⌊ap(RightUnit;UnitMonoidStruct)⌋ {
+  unfold 〈UnitMonoidStruct〉; unfold 〈RightUnit〉; refine 〈monoid-unfold〉; auto;
+  elim 〈m〉; auto.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -6,5 +6,5 @@ Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
 
 Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
   auto; unfold <squash>; auto;
-  subset-intro [<>]; auto.
+  intro [<>]; auto.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -6,5 +6,5 @@ Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
 
 Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
   auto; unfold <squash>; auto;
-  intro [<>]; auto.
+  intro; auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -2,7 +2,7 @@ welp =def= ⌊unit⌋.
 welp2 =def= ⌊unit⌋.
 
 Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
-  *{ intro ⌊<>⌋; auto }.
+  *{ intro ⌊<>⌋ ; auto }.
 }.
 
 ||| Lemmas defined earlier in the development may be used later on using the 'lemma' tactic.
@@ -26,7 +26,7 @@ Theorem test4 : ⌊∈(λ(x.pair(x;x)); Π(void;_.void))⌋ {
 }.
 
 Theorem test5 : ⌊Π(void; _. Σ(unit; _.unit))⌋ {
-  fun-intro; auto.
+  intro; auto.
 }.
 
 Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -7,13 +7,12 @@ Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
 
 ||| Lemmas defined earlier in the development may be used later on using the 'lemma' tactic.
 Theorem test1' : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
-  lemma <test1>.
+  lemma 〈test1〉.
 }.
 
 ||| Abstractions may be unfolded using the 'unfold' tactic.
 Theorem test2 : ⌊Π(unit; _. Σ(unit; _. welp))⌋ {
-  intro; auto; unfold <welp>;
-  intro; unfold <welp>; auto.
+  unfold 〈welp〉; auto
 }.
 
 Theorem test3 : ⌊∈(λ(x. x); Π(unit; _. unit))⌋ {
@@ -34,13 +33,13 @@ Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {
 
 Theorem test7 : ⌊Π(Σ(void;_.unit); z. void)⌋ {
   auto;
-  elim <z>;
+  elim 〈z〉;
   auto.
 }.
 
-Theorem axiom-of-choice : ⌊∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
+Theorem axiom-of-choice : ⌊∀(U〈0〉; A. ∀(U〈0〉; B. ∀(Π(A; _. Π(B; _. U〈0〉)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
   auto; intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
-  elim <φ> ⌊a⌋; auto;
-  hyp-subst ← <z> ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
-  elim <y>; auto.
+  elim 〈φ〉 ⌊a⌋; auto;
+  hyp-subst ← 〈z〉 ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
+  elim 〈y〉; auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -2,7 +2,7 @@ welp =def= ⌊unit⌋.
 welp2 =def= ⌊unit⌋.
 
 Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
-  *{ intro ⌊<>⌋ ; auto }.
+  *{ intro ; auto }.
 }.
 
 ||| Lemmas defined earlier in the development may be used later on using the 'lemma' tactic.
@@ -13,8 +13,7 @@ Theorem test1' : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
 ||| Abstractions may be unfolded using the 'unfold' tactic.
 Theorem test2 : ⌊Π(unit; _. Σ(unit; _. welp))⌋ {
   intro; auto; unfold <welp>;
-  intro ⌊<>⌋;
-  unfold <welp>; auto.
+  intro; unfold <welp>; auto.
 }.
 
 Theorem test3 : ⌊∈(λ(x. x); Π(unit; _. unit))⌋ {
@@ -26,7 +25,7 @@ Theorem test4 : ⌊∈(λ(x.pair(x;x)); Π(void;_.void))⌋ {
 }.
 
 Theorem test5 : ⌊Π(void; _. Σ(unit; _.unit))⌋ {
-  intro; auto.
+  auto.
 }.
 
 Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -44,7 +44,6 @@ Theorem test7 : ⌊Π(Σ(void;_.unit); z. void)⌋ {
 Theorem axiom-of-choice : ⌊∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
   auto; prod-intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
   fun-elim <φ> ⌊a⌋; auto;
-  subst ⌊=(ap(φ;a); y; Σ(B;b. ap(ap(Q;a);b)))⌋ ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
-  ?{ symmetry }; auto;
+  hyp-subst ← <z> ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
   prod-elim <y>; auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -2,9 +2,8 @@ welp =def= ⌊unit⌋.
 welp2 =def= ⌊unit⌋.
 
 Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
-  *{ prod-intro ⌊<>⌋; auto }.
+  *{ intro ⌊<>⌋; auto }.
 }.
-
 
 ||| Lemmas defined earlier in the development may be used later on using the 'lemma' tactic.
 Theorem test1' : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
@@ -13,8 +12,8 @@ Theorem test1' : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
 
 ||| Abstractions may be unfolded using the 'unfold' tactic.
 Theorem test2 : ⌊Π(unit; _. Σ(unit; _. welp))⌋ {
-  fun-intro; auto; unfold <welp>;
-  prod-intro ⌊<>⌋;
+  intro; auto; unfold <welp>;
+  intro ⌊<>⌋;
   unfold <welp>; auto.
 }.
 
@@ -23,11 +22,11 @@ Theorem test3 : ⌊∈(λ(x. x); Π(unit; _. unit))⌋ {
 }.
 
 Theorem test4 : ⌊∈(λ(x.pair(x;x)); Π(void;_.void))⌋ {
-  auto; void-elim; auto.
+  auto.
 }.
 
 Theorem test5 : ⌊Π(void; _. Σ(unit; _.unit))⌋ {
-  fun-intro; auto; void-elim; auto.
+  fun-intro; auto.
 }.
 
 Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {
@@ -36,14 +35,13 @@ Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {
 
 Theorem test7 : ⌊Π(Σ(void;_.unit); z. void)⌋ {
   auto;
-  prod-elim <z>;
-  void-elim;
+  elim <z>;
   auto.
 }.
 
 Theorem axiom-of-choice : ⌊∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
-  auto; prod-intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
-  fun-elim <φ> ⌊a⌋; auto;
+  auto; intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
+  elim <φ> ⌊a⌋; auto;
   hyp-subst ← <z> ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
-  prod-elim <y>; auto.
+  elim <y>; auto.
 }.

--- a/src/context.fun
+++ b/src/context.fun
@@ -66,7 +66,7 @@ struct
               go (out tele') (r ^ "\n" ^ pretty_lbl ^ " : " ^ f a)
             end
     in
-      go (out tele) "·"
+      go (out tele) ""
     end
 
   fun eq test =

--- a/src/context.fun
+++ b/src/context.fun
@@ -13,6 +13,15 @@ struct
   val interpose_after = Tel.interpose_after
   val fresh = Tel.fresh
 
+  fun is_empty (ctx : 'a context) =
+    let
+      open Tel.SnocView
+    in
+      case out ctx of
+           Empty => true
+         | _ => false
+    end
+
   exception NotFound of name
 
   fun modify (ctx : 'a context) (k : V.t) f =

--- a/src/context.sig
+++ b/src/context.sig
@@ -6,6 +6,7 @@ sig
   val fresh : 'a context * name -> name
 
   val empty : 'a context
+  val is_empty : 'a context -> bool
 
   val insert : 'a context -> name -> Visibility.t -> 'a -> 'a context
   val interpose_after : 'a context -> name * 'a context -> 'a context

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -238,11 +238,11 @@ struct
         [] BY mk_evidence AX_EQ
       end
 
-    fun FunEq oz (H >> P) =
+    fun QuantifierEq (Q, Q_EQ) oz (H >> P) =
       let
-        val #[fun1, fun2, univ] = P ^! EQ
-        val #[A, xB] = fun1 ^! FUN
-        val #[A', yB'] = fun2 ^! FUN
+        val #[q1, q2, univ] = P ^! EQ
+        val #[A, xB] = q1 ^! Q
+        val #[A', yB'] = q2 ^! Q
         val (UNIV _, #[]) = as_app univ
 
         val z =
@@ -253,9 +253,11 @@ struct
       in
         [ H >> EQ $$ #[A,A',univ]
         , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
-        ] BY (fn [D, E] => FUN_EQ $$ #[D, z \\ E]
+        ] BY (fn [D, E] => Q_EQ $$ #[D, z \\ E]
                | _ => raise Refine)
       end
+
+    val FunEq = QuantifierEq (FUN, FUN_EQ)
 
     fun FunIntro oz ok (H >> P) =
       let
@@ -417,23 +419,7 @@ struct
         ] BY mk_evidence ISECT_MEMBER_CASE_EQ
       end
 
-    fun SubsetEq oz (H >> P) =
-      let
-        val #[subset1, subset2, univ] = P ^! EQ
-        val (UNIV k, #[]) = as_app univ
-        val #[A,xB] = subset1 ^! SUBSET
-        val #[A',yB'] = subset2 ^! SUBSET
-        val z =
-          Context.fresh (H,
-            case oz of
-                 NONE => #1 (unbind xB)
-               | SOME z => z)
-      in
-        [ H >> EQ $$ #[A,A',univ]
-        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
-        ] BY (fn [D, E] => SUBSET_EQ $$ #[D, z \\ E]
-               | _ => raise Refine)
-      end
+    val SubsetEq = QuantifierEq (SUBSET, SUBSET_EQ)
 
     fun SubsetIntro w oz ok (H >> P) =
       let
@@ -490,7 +476,6 @@ struct
                | _ => raise Refine)
       end
 
-
     fun MemUnfold (H >> P) =
       let
         val #[M, A] = P ^! MEM
@@ -527,23 +512,7 @@ struct
         [] BY (fn _ => HYP_EQ $$ #[`` x])
       end
 
-    fun ProdEq oz (H >> P) =
-      let
-        val #[prod1, prod2, univ] = P ^! EQ
-        val #[A, xB] = prod1 ^! PROD
-        val #[A', yB'] = prod2 ^! PROD
-        val (UNIV _, #[]) = as_app univ
-        val z =
-          Context.fresh (H,
-            case oz of
-                 NONE => #1 (unbind xB)
-               | SOME z => z)
-      in
-        [ H >> EQ $$ #[A,A',univ]
-        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // ``z, univ]
-        ] BY (fn [D, E] => PROD_EQ $$ #[D, z \\ E]
-               | _ => raise Refine)
-      end
+    val ProdEq = QuantifierEq (PROD, PROD_EQ)
 
     fun ProdIntro w oz ok : tactic =
       fn (H >> P) =>

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -161,415 +161,389 @@ struct
           [H >> EQ $$ #[A,B, UNIV k $$ #[]]] BY mk_evidence CUM
         end
 
-    val UnivEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[univ1, univ2, univ3] = P ^! EQ
-          val (UNIV l, #[]) = as_app univ1
-          val (UNIV l', #[]) = as_app univ2
-          val (UNIV k, #[]) = as_app univ3
-          val _ = Level.assert_lt (Level.unify (l, l'), k)
-        in
-          [] BY mk_evidence UNIV_EQ
-        end
+    fun UnivEq (H >> P) =
+      let
+        val #[univ1, univ2, univ3] = P ^! EQ
+        val (UNIV l, #[]) = as_app univ1
+        val (UNIV l', #[]) = as_app univ2
+        val (UNIV k, #[]) = as_app univ3
+        val _ = Level.assert_lt (Level.unify (l, l'), k)
+      in
+        [] BY mk_evidence UNIV_EQ
+      end
 
-    val EqEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[E1, E2, univ] = P ^! EQ
-          val (UNIV k, #[]) = as_app univ
-          val #[M,N,A] = E1 ^! EQ
-          val #[M',N',A'] = E2 ^! EQ
-        in
-          [ H >> EQ $$ #[A,A',univ]
-          , H >> EQ $$ #[M,M',A]
-          , H >> EQ $$ #[N,N',A]
-          ] BY mk_evidence EQ_EQ
-        end
+    fun EqEq (H >> P) =
+      let
+        val #[E1, E2, univ] = P ^! EQ
+        val (UNIV k, #[]) = as_app univ
+        val #[M,N,A] = E1 ^! EQ
+        val #[M',N',A'] = E2 ^! EQ
+      in
+        [ H >> EQ $$ #[A,A',univ]
+        , H >> EQ $$ #[M,M',A]
+        , H >> EQ $$ #[N,N',A]
+        ] BY mk_evidence EQ_EQ
+      end
 
-    val UnitIntro : tactic =
-      fn (H >> P) =>
-        let
-          val #[] = P ^! UNIT
-        in
-          [] BY mk_evidence UNIT_INTRO
-        end
+    fun UnitIntro (H >> P) =
+      let
+        val #[] = P ^! UNIT
+      in
+        [] BY mk_evidence UNIT_INTRO
+      end
 
-    fun UnitElim x : tactic =
-      fn (H >> P) =>
-        let
-          val #[] = Context.lookup H x ^! UNIT
-          val ax = AX $$ #[]
-          val H' = ctx_subst H ax x
-          val P' = subst ax x P
-        in
-          [ H' >> P'
-          ] BY (fn [D] => UNIT_ELIM $$ #[`` x, D]
-                 | _ => raise Refine)
-        end
+    fun UnitElim x (H >> P) =
+      let
+        val #[] = Context.lookup H x ^! UNIT
+        val ax = AX $$ #[]
+        val H' = ctx_subst H ax x
+        val P' = subst ax x P
+      in
+        [ H' >> P'
+        ] BY (fn [D] => UNIT_ELIM $$ #[`` x, D]
+               | _ => raise Refine)
+      end
 
-    val UnitEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[unit, unit', univ] = P ^! EQ
-          val #[] = unit ^! UNIT
-          val #[] = unit' ^! UNIT
-          val (UNIV _, #[]) = as_app univ
-        in
-          [] BY mk_evidence UNIT_EQ
-        end
+    fun UnitEq (H >> P) =
+      let
+        val #[unit, unit', univ] = P ^! EQ
+        val #[] = unit ^! UNIT
+        val #[] = unit' ^! UNIT
+        val (UNIV _, #[]) = as_app univ
+      in
+        [] BY mk_evidence UNIT_EQ
+      end
 
-    val VoidEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[void, void', univ] = P ^! EQ
-          val #[] = void ^! VOID
-          val #[] = void' ^! VOID
-          val (UNIV _, #[]) = as_app univ
-        in
-          [] BY mk_evidence VOID_EQ
-        end
+    fun VoidEq (H >> P) =
+      let
+        val #[void, void', univ] = P ^! EQ
+        val #[] = void ^! VOID
+        val #[] = void' ^! VOID
+        val (UNIV _, #[]) = as_app univ
+      in
+        [] BY mk_evidence VOID_EQ
+      end
 
-    val VoidElim : tactic =
-      fn (H >> P) =>
+    fun VoidElim (H >> P) =
         [ H >> VOID $$ #[]
         ] BY mk_evidence VOID_ELIM
 
-    val AxEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[ax, ax', unit] = P ^! EQ
-          val #[] = ax ^! AX
-          val #[] = ax' ^! AX
-          val #[] = unit ^! UNIT
-        in
-          [] BY mk_evidence AX_EQ
-        end
+    fun AxEq (H >> P) =
+      let
+        val #[ax, ax', unit] = P ^! EQ
+        val #[] = ax ^! AX
+        val #[] = ax' ^! AX
+        val #[] = unit ^! UNIT
+      in
+        [] BY mk_evidence AX_EQ
+      end
 
-    fun FunEq oz : tactic =
-      fn (H >> P) =>
-        let
-          val #[fun1, fun2, univ] = P ^! EQ
-          val #[A, xB] = fun1 ^! FUN
-          val #[A', yB'] = fun2 ^! FUN
-          val (UNIV _, #[]) = as_app univ
+    fun FunEq oz (H >> P) =
+      let
+        val #[fun1, fun2, univ] = P ^! EQ
+        val #[A, xB] = fun1 ^! FUN
+        val #[A', yB'] = fun2 ^! FUN
+        val (UNIV _, #[]) = as_app univ
 
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xB)
-                 | SOME z => z)
-        in
-          [ H >> EQ $$ #[A,A',univ]
-          , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
-          ] BY (fn [D, E] => FUN_EQ $$ #[D, z \\ E]
-                 | _ => raise Refine)
-        end
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xB)
+               | SOME z => z)
+      in
+        [ H >> EQ $$ #[A,A',univ]
+        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
+        ] BY (fn [D, E] => FUN_EQ $$ #[D, z \\ E]
+               | _ => raise Refine)
+      end
 
-    fun FunIntro oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[P1, xP2] = P ^! FUN
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xP2)
-                 | SOME z => z)
-          val k = case ok of NONE => infer_level (H, P1) | SOME k => k
-        in
-          [ H @@ (z,P1) >> xP2 // `` z
-          , H >> MEM $$ #[P1, UNIV k $$ #[]]
-          ] BY (fn [D,E] => FUN_INTRO $$ #[z \\ D, E]
-                 | _ => raise Refine)
-        end
+    fun FunIntro oz ok (H >> P) =
+      let
+        val #[P1, xP2] = P ^! FUN
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xP2)
+               | SOME z => z)
+        val k = case ok of NONE => infer_level (H, P1) | SOME k => k
+      in
+        [ H @@ (z,P1) >> xP2 // `` z
+        , H >> MEM $$ #[P1, UNIV k $$ #[]]
+        ] BY (fn [D,E] => FUN_INTRO $$ #[z \\ D, E]
+               | _ => raise Refine)
+      end
 
-    fun FunElim f s onames : tactic =
-      fn (H >> P) =>
-        let
-          val #[S, xT] = Context.lookup H f ^! FUN
-          val Ts = xT // s
-          val (y, z) =
-            case onames of
-                 SOME names => names
-               | NONE =>
-                   (Context.fresh (H, Variable.named "y"),
-                    Context.fresh (H, Variable.named "z"))
+    fun FunElim f s onames (H >> P) =
+      let
+        val #[S, xT] = Context.lookup H f ^! FUN
+        val Ts = xT // s
+        val (y, z) =
+          case onames of
+               SOME names => names
+             | NONE =>
+                 (Context.fresh (H, Variable.named "y"),
+                  Context.fresh (H, Variable.named "z"))
 
-          val fsTs = EQ $$ #[``y, AP $$ #[``f, s], Ts]
-        in
-          [ H >> MEM $$ #[s, S]
-          , H @@ (y, Ts) @@ (z, fsTs) >> P
-          ] BY (fn [D, E] => FUN_ELIM $$ #[``f, s, D, y \\ (z \\ E)]
-                  | _ => raise Refine)
-        end
+        val fsTs = EQ $$ #[``y, AP $$ #[``f, s], Ts]
+      in
+        [ H >> MEM $$ #[s, S]
+        , H @@ (y, Ts) @@ (z, fsTs) >> P
+        ] BY (fn [D, E] => FUN_ELIM $$ #[``f, s, D, y \\ (z \\ E)]
+                | _ => raise Refine)
+      end
 
-    fun LamEq oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[lam, lam', func] = P ^! EQ
-          val #[aE] = lam ^! LAM
-          val #[bE'] = lam' ^! LAM
-          val #[A, cB] = func ^! FUN
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind cB)
-                 | SOME z => z)
-          val k = case ok of NONE => infer_level (H, A) | SOME k => k
-        in
-          [ H @@ (z,A) >> EQ $$ #[aE // ``z, bE' // ``z, cB // ``z]
-          , H >> MEM $$ #[A, UNIV k $$ #[]]
-          ] BY (fn [D, E] => LAM_EQ $$ #[z \\ D, E]
-                  | _ => raise Refine)
-        end
+    fun LamEq oz ok (H >> P) =
+      let
+        val #[lam, lam', func] = P ^! EQ
+        val #[aE] = lam ^! LAM
+        val #[bE'] = lam' ^! LAM
+        val #[A, cB] = func ^! FUN
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind cB)
+               | SOME z => z)
+        val k = case ok of NONE => infer_level (H, A) | SOME k => k
+      in
+        [ H @@ (z,A) >> EQ $$ #[aE // ``z, bE' // ``z, cB // ``z]
+        , H >> MEM $$ #[A, UNIV k $$ #[]]
+        ] BY (fn [D, E] => LAM_EQ $$ #[z \\ D, E]
+                | _ => raise Refine)
+      end
 
-    fun ApEq ofunty : tactic =
-      fn (H >> P) =>
-        let
-          val #[f1t1, f2t2, Tt1] = P ^! EQ
-          val #[f1, t1] = f1t1 ^! AP
-          val #[f2, t2] = f2t2 ^! AP
-          val funty =
-            case ofunty of
-                 NONE => unify (infer_type (H, f1)) (infer_type (H, f2))
-               | SOME funty => funty
-          val #[S, xT] = funty ^! FUN
-          val Tt1' = unify Tt1 (xT // t1)
-        in
-          [ H >> EQ $$ #[f1, f2, funty]
-          , H >> EQ $$ #[t1, t2, S]
-          ] BY mk_evidence AP_EQ
-        end
+    fun ApEq ofunty (H >> P) =
+      let
+        val #[f1t1, f2t2, Tt1] = P ^! EQ
+        val #[f1, t1] = f1t1 ^! AP
+        val #[f2, t2] = f2t2 ^! AP
+        val funty =
+          case ofunty of
+               NONE => unify (infer_type (H, f1)) (infer_type (H, f2))
+             | SOME funty => funty
+        val #[S, xT] = funty ^! FUN
+        val Tt1' = unify Tt1 (xT // t1)
+      in
+        [ H >> EQ $$ #[f1, f2, funty]
+        , H >> EQ $$ #[t1, t2, S]
+        ] BY mk_evidence AP_EQ
+      end
 
-    fun IsectEq oz : tactic =
-      fn (H >> P) =>
-        let
-          val #[isect1, isect2, univ] = P ^! EQ
-          val #[A, xB] = isect1 ^! ISECT
-          val #[A', yB'] = isect2 ^! ISECT
-          val (UNIV _, #[]) = as_app univ
+    fun IsectEq oz (H >> P) =
+      let
+        val #[isect1, isect2, univ] = P ^! EQ
+        val #[A, xB] = isect1 ^! ISECT
+        val #[A', yB'] = isect2 ^! ISECT
+        val (UNIV _, #[]) = as_app univ
 
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xB)
-                 | SOME z => z)
-        in
-          [ H >> EQ $$ #[A,A',univ]
-          , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
-          ] BY (fn [D, E] => ISECT_EQ $$ #[D, z \\ E]
-                 | _ => raise Refine)
-        end
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xB)
+               | SOME z => z)
+      in
+        [ H >> EQ $$ #[A,A',univ]
+        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
+        ] BY (fn [D, E] => ISECT_EQ $$ #[D, z \\ E]
+               | _ => raise Refine)
+      end
 
-    fun IsectIntro oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[P1, xP2] = P ^! ISECT
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xP2)
-                 | SOME z => z)
-          val k = case ok of NONE => infer_level (H, P1) | SOME k => k
-          val H' = Context.insert H z Visibility.Hidden P1
-        in
-          [ H' >> xP2 // `` z
-          , H >> MEM $$ #[P1, UNIV k $$ #[]]
-          ] BY (fn [D,E] => ISECT_INTRO $$ #[z \\ D, E]
-                 | _ => raise Refine)
-        end
+    fun IsectIntro oz ok (H >> P) =
+      let
+        val #[P1, xP2] = P ^! ISECT
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xP2)
+               | SOME z => z)
+        val k = case ok of NONE => infer_level (H, P1) | SOME k => k
+        val H' = Context.insert H z Visibility.Hidden P1
+      in
+        [ H' >> xP2 // `` z
+        , H >> MEM $$ #[P1, UNIV k $$ #[]]
+        ] BY (fn [D,E] => ISECT_INTRO $$ #[z \\ D, E]
+               | _ => raise Refine)
+      end
 
-    fun IsectElim f s onames : tactic =
-      fn (H >> P) =>
-        let
-          val #[S, xT] = Context.lookup H f ^! ISECT
-          val Ts = xT // s
-          val (y, z) =
-            case onames of
-                 SOME names => names
-               | NONE =>
-                   (Context.fresh (H, Variable.named "y"),
-                    Context.fresh (H, Variable.named "z"))
+    fun IsectElim f s onames (H >> P) =
+      let
+        val #[S, xT] = Context.lookup H f ^! ISECT
+        val Ts = xT // s
+        val (y, z) =
+          case onames of
+               SOME names => names
+             | NONE =>
+                 (Context.fresh (H, Variable.named "y"),
+                  Context.fresh (H, Variable.named "z"))
 
-          val fsTs = EQ $$ #[``y, ``f, Ts]
-        in
-          [ H >> MEM $$ #[s, S]
-          , H @@ (y, Ts) @@ (z, fsTs) >> P
-          ] BY (fn [D, E] => FUN_ELIM $$ #[``f, s, D, y \\ (z \\ E)]
-                  | _ => raise Refine)
-        end
+        val fsTs = EQ $$ #[``y, ``f, Ts]
+      in
+        [ H >> MEM $$ #[s, S]
+        , H @@ (y, Ts) @@ (z, fsTs) >> P
+        ] BY (fn [D, E] => FUN_ELIM $$ #[``f, s, D, y \\ (z \\ E)]
+                | _ => raise Refine)
+      end
 
-    fun IsectMemberEq oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[M,N,A] = P ^! EQ
-          val #[P1, xP2] = A ^! ISECT
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xP2)
-                 | SOME z => z)
-          val k = case ok of NONE => infer_level (H, P1) | SOME k => k
-          val H' = Context.insert H z Visibility.Hidden P1
-        in
-          [ H' >> EQ $$ #[M,N, xP2 // ``z]
-          , H >> MEM $$ #[P1, UNIV k $$ #[]]
-          ] BY (fn [D, E] => ISECT_MEMBER_EQ $$ #[z \\ D, E]
-                 | _ => raise Refine)
-        end
+    fun IsectMemberEq oz ok (H >> P) =
+      let
+        val #[M,N,A] = P ^! EQ
+        val #[P1, xP2] = A ^! ISECT
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xP2)
+               | SOME z => z)
+        val k = case ok of NONE => infer_level (H, P1) | SOME k => k
+        val H' = Context.insert H z Visibility.Hidden P1
+      in
+        [ H' >> EQ $$ #[M,N, xP2 // ``z]
+        , H >> MEM $$ #[P1, UNIV k $$ #[]]
+        ] BY (fn [D, E] => ISECT_MEMBER_EQ $$ #[z \\ D, E]
+               | _ => raise Refine)
+      end
 
-    fun IsectMemberCaseEq oisect t : tactic =
-      fn (H >> P) =>
-        let
-          val #[F1,F2, Tt] = P ^! EQ
-          val isect =
-            case oisect of
-                 SOME isect => isect
-               | NONE => unify (infer_type (H, F1)) (infer_type (H, F2))
+    fun IsectMemberCaseEq oisect t (H >> P) =
+      let
+        val #[F1,F2, Tt] = P ^! EQ
+        val isect =
+          case oisect of
+               SOME isect => isect
+             | NONE => unify (infer_type (H, F1)) (infer_type (H, F2))
 
-          val #[S, xT] = isect ^! ISECT
-          val _ = unify Tt (xT // t)
-        in
-          [ H >> EQ $$ #[F1, F2, isect]
-          , H >> MEM $$ #[t, S]
-          ] BY mk_evidence ISECT_MEMBER_CASE_EQ
-        end
+        val #[S, xT] = isect ^! ISECT
+        val _ = unify Tt (xT // t)
+      in
+        [ H >> EQ $$ #[F1, F2, isect]
+        , H >> MEM $$ #[t, S]
+        ] BY mk_evidence ISECT_MEMBER_CASE_EQ
+      end
 
-    fun SubsetEq oz : tactic =
-      fn (H >> P) =>
-        let
-          val #[subset1, subset2, univ] = P ^! EQ
-          val (UNIV k, #[]) = as_app univ
-          val #[A,xB] = subset1 ^! SUBSET
-          val #[A',yB'] = subset2 ^! SUBSET
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xB)
-                 | SOME z => z)
-        in
-          [ H >> EQ $$ #[A,A',univ]
-          , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
-          ] BY (fn [D, E] => SUBSET_EQ $$ #[D, z \\ E]
-                 | _ => raise Refine)
-        end
+    fun SubsetEq oz (H >> P) =
+      let
+        val #[subset1, subset2, univ] = P ^! EQ
+        val (UNIV k, #[]) = as_app univ
+        val #[A,xB] = subset1 ^! SUBSET
+        val #[A',yB'] = subset2 ^! SUBSET
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xB)
+               | SOME z => z)
+      in
+        [ H >> EQ $$ #[A,A',univ]
+        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // `` z, univ]
+        ] BY (fn [D, E] => SUBSET_EQ $$ #[D, z \\ E]
+               | _ => raise Refine)
+      end
 
-    fun SubsetIntro w oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[P1, xP2] = P ^! SUBSET
-          val k = case ok of SOME k => k | NONE => infer_level (H, P)
-          val z =
-            Context.fresh (H,
-              case oz of
-                   SOME z => z
-                 | NONE => #1 (unbind xP2))
-        in
-          [ H >> MEM $$ #[ w, P1]
-          , H >> xP2 // w
-          , H @@ (z, P1) >> MEM $$ #[xP2 // ``z, UNIV k $$ #[]]
-          ] BY (fn [D, E, F] => SUBSET_INTRO $$ #[w, D, E, z \\ F]
-                 | _ => raise Refine)
-        end
+    fun SubsetIntro w oz ok (H >> P) =
+      let
+        val #[P1, xP2] = P ^! SUBSET
+        val k = case ok of SOME k => k | NONE => infer_level (H, P)
+        val z =
+          Context.fresh (H,
+            case oz of
+                 SOME z => z
+               | NONE => #1 (unbind xP2))
+      in
+        [ H >> MEM $$ #[ w, P1]
+        , H >> xP2 // w
+        , H @@ (z, P1) >> MEM $$ #[xP2 // ``z, UNIV k $$ #[]]
+        ] BY (fn [D, E, F] => SUBSET_INTRO $$ #[w, D, E, z \\ F]
+               | _ => raise Refine)
+      end
 
-    fun SubsetElim z onames : tactic =
-      fn (H >> P) =>
-        let
-          val #[S, xT] = Context.lookup H z ^! SUBSET
-          val (s, t) =
-            case onames of
-                 SOME names => names
-               | NONE =>
-                   (Context.fresh (H, #1 (unbind xT)),
-                    Context.fresh (H, Variable.named "t"))
+    fun SubsetElim z onames (H >> P) =
+      let
+        val #[S, xT] = Context.lookup H z ^! SUBSET
+        val (s, t) =
+          case onames of
+               SOME names => names
+             | NONE =>
+                 (Context.fresh (H, #1 (unbind xT)),
+                  Context.fresh (H, Variable.named "t"))
 
-          val G = Context.empty @@ (s, S)
-          val G' = Context.insert G t Visibility.Hidden (xT // ``s)
-          val H' = ctx_subst (Context.interpose_after H (z, G')) (``s) z
-          val P' = subst (``s) z P
-        in
-          [ H' >> P'
-          ] BY (fn [D] => SUBSET_ELIM $$ #[``z, s \\ (t \\ D)]
-                 | _ => raise Refine)
-        end
+        val G = Context.empty @@ (s, S)
+        val G' = Context.insert G t Visibility.Hidden (xT // ``s)
+        val H' = ctx_subst (Context.interpose_after H (z, G')) (``s) z
+        val P' = subst (``s) z P
+      in
+        [ H' >> P'
+        ] BY (fn [D] => SUBSET_ELIM $$ #[``z, s \\ (t \\ D)]
+               | _ => raise Refine)
+      end
 
-    fun SubsetMemberEq oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[s,t,subset] = P ^! EQ
-          val #[S,xT] = subset ^! SUBSET
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xT)
-                 | SOME z => z)
-          val k = case ok of SOME k => k | NONE => infer_level (H, subset)
-        in
-          [ H >> EQ $$ #[s,t,S]
-          , H >> xT // s
-          , H @@ (z,S) >> MEM $$ #[xT // ``z, UNIV k $$ #[]]
-          ] BY (fn [D, E, F] => SUBSET_MEMBER_EQ $$ #[D, E, z \\ F]
-                 | _ => raise Refine)
-        end
+    fun SubsetMemberEq oz ok (H >> P) =
+      let
+        val #[s,t,subset] = P ^! EQ
+        val #[S,xT] = subset ^! SUBSET
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xT)
+               | SOME z => z)
+        val k = case ok of SOME k => k | NONE => infer_level (H, subset)
+      in
+        [ H >> EQ $$ #[s,t,S]
+        , H >> xT // s
+        , H @@ (z,S) >> MEM $$ #[xT // ``z, UNIV k $$ #[]]
+        ] BY (fn [D, E, F] => SUBSET_MEMBER_EQ $$ #[D, E, z \\ F]
+               | _ => raise Refine)
+      end
 
 
-    val MemUnfold : tactic =
-      fn (H >> P) =>
-        let
-          val #[M, A] = P ^! MEM
-        in
-          [ H >> EQ $$ #[M, M, A]
-          ] BY (fn [D] => D
-                 | _ => raise Refine)
-        end
+    fun MemUnfold (H >> P) =
+      let
+        val #[M, A] = P ^! MEM
+      in
+        [ H >> EQ $$ #[M, M, A]
+        ] BY (fn [D] => D
+               | _ => raise Refine)
+      end
 
-    fun Witness M : tactic =
-      fn (H >> P) =>
-        let
-          val has_hidden_variables =
-            foldl
-              (fn (x, b) => b orelse #2 (Context.lookup_visibility H x) = Visibility.Hidden)
-              false
-              (free_variables M)
-          val _ =
-            if has_hidden_variables then
-              assert_irrelevant (H, P)
-            else
-              ()
-        in
-          [ H >> MEM $$ #[M, P]
-          ] BY (fn [D] => WITNESS $$ #[M, D]
-                 | _ => raise Refine)
-        end
+    fun Witness M (H >> P) =
+      let
+        val has_hidden_variables =
+          foldl
+            (fn (x, b) => b orelse #2 (Context.lookup_visibility H x) = Visibility.Hidden)
+            false
+            (free_variables M)
+        val _ =
+          if has_hidden_variables then
+            assert_irrelevant (H, P)
+          else
+            ()
+      in
+        [ H >> MEM $$ #[M, P]
+        ] BY (fn [D] => WITNESS $$ #[M, D]
+               | _ => raise Refine)
+      end
 
-    val HypEq : tactic =
-      fn (H >> P) =>
-        let
-          val #[M, M', A] = P ^! EQ
-          val x = as_variable (unify M M')
-          val _ = unify A (Context.lookup H x)
-        in
-          [] BY (fn _ => HYP_EQ $$ #[`` x])
-        end
+    fun HypEq (H >> P) =
+      let
+        val #[M, M', A] = P ^! EQ
+        val x = as_variable (unify M M')
+        val _ = unify A (Context.lookup H x)
+      in
+        [] BY (fn _ => HYP_EQ $$ #[`` x])
+      end
 
-    fun ProdEq oz : tactic =
-      fn (H >> P) =>
-        let
-          val #[prod1, prod2, univ] = P ^! EQ
-          val #[A, xB] = prod1 ^! PROD
-          val #[A', yB'] = prod2 ^! PROD
-          val (UNIV _, #[]) = as_app univ
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xB)
-                 | SOME z => z)
-        in
-          [ H >> EQ $$ #[A,A',univ]
-          , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // ``z, univ]
-          ] BY (fn [D, E] => PROD_EQ $$ #[D, z \\ E]
-                 | _ => raise Refine)
-        end
+    fun ProdEq oz (H >> P) =
+      let
+        val #[prod1, prod2, univ] = P ^! EQ
+        val #[A, xB] = prod1 ^! PROD
+        val #[A', yB'] = prod2 ^! PROD
+        val (UNIV _, #[]) = as_app univ
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xB)
+               | SOME z => z)
+      in
+        [ H >> EQ $$ #[A,A',univ]
+        , H @@ (z,A) >> EQ $$ #[xB // ``z, yB' // ``z, univ]
+        ] BY (fn [D, E] => PROD_EQ $$ #[D, z \\ E]
+               | _ => raise Refine)
+      end
 
     fun ProdIntro w oz ok : tactic =
       fn (H >> P) =>
@@ -589,97 +563,94 @@ struct
                  | _ => raise Refine)
         end
 
-    fun ProdElim z onames : tactic =
-      fn (H >> P) =>
-        let
-          val #[S, xT] = Context.lookup H z ^! PROD
-          val (s, t) =
-            case onames of
-                 SOME names => names
-               | NONE =>
-                   (Context.fresh (H, Variable.named "s"),
-                    Context.fresh (H, Variable.named "t"))
+    fun ProdElim z onames (H >> P) =
+      let
+        val #[S, xT] = Context.lookup H z ^! PROD
+        val (s, t) =
+          case onames of
+               SOME names => names
+             | NONE =>
+                 (Context.fresh (H, Variable.named "s"),
+                  Context.fresh (H, Variable.named "t"))
 
-          val st = PAIR $$ #[``s, ``t]
-          val J = Context.empty @@ (s, S) @@ (t, (xT // ``s))
-          val H' = ctx_subst (Context.interpose_after H (z, J)) st z
-        in
-          [ H' >> subst st z P
-          ] BY (fn [D] => PROD_ELIM $$ #[``z, s \\ (t \\ D)]
-                 | _ => raise Refine)
-        end
+        val st = PAIR $$ #[``s, ``t]
+        val J = Context.empty @@ (s, S) @@ (t, (xT // ``s))
+        val H' = ctx_subst (Context.interpose_after H (z, J)) st z
+      in
+        [ H' >> subst st z P
+        ] BY (fn [D] => PROD_ELIM $$ #[``z, s \\ (t \\ D)]
+               | _ => raise Refine)
+      end
 
-    fun PairEq oz ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[pair, pair', prod] = P ^! EQ
-          val #[M, N] = pair ^! PAIR
-          val #[M', N'] = pair' ^! PAIR
-          val #[A, xB] = prod ^! PROD
-          val z =
-            Context.fresh (H,
-              case oz of
-                   NONE => #1 (unbind xB)
-                 | SOME z => z)
-          val k = case ok of NONE => infer_level (H, A) | SOME k => k
-        in
-          [ H >> EQ $$ #[M, M', A]
-          , H >> EQ $$ #[N, N', xB // M]
-          , H @@ (z,A) >> MEM $$ #[xB // `` z, UNIV k $$ #[]]
-          ] BY (fn [D,E,F] => PAIR_EQ $$ #[D, E, z \\ F]
-                 | _ => raise Refine)
-        end
+    fun PairEq oz ok (H >> P) =
+      let
+        val #[pair, pair', prod] = P ^! EQ
+        val #[M, N] = pair ^! PAIR
+        val #[M', N'] = pair' ^! PAIR
+        val #[A, xB] = prod ^! PROD
+        val z =
+          Context.fresh (H,
+            case oz of
+                 NONE => #1 (unbind xB)
+               | SOME z => z)
+        val k = case ok of NONE => infer_level (H, A) | SOME k => k
+      in
+        [ H >> EQ $$ #[M, M', A]
+        , H >> EQ $$ #[N, N', xB // M]
+        , H @@ (z,A) >> MEM $$ #[xB // `` z, UNIV k $$ #[]]
+        ] BY (fn [D,E,F] => PAIR_EQ $$ #[D, E, z \\ F]
+               | _ => raise Refine)
+      end
 
-    fun SpreadEq ozC oprod onames : tactic =
-      fn (H >> P) =>
-        let
-          val #[spread, spread', CE1] = P ^! EQ
-          val #[E1, xyT1] = spread ^! SPREAD
-          val #[E2, uvT2] = spread' ^! SPREAD
+    fun SpreadEq ozC oprod onames (H >> P) =
+      let
+        val #[spread, spread', CE1] = P ^! EQ
+        val #[E1, xyT1] = spread ^! SPREAD
+        val #[E2, uvT2] = spread' ^! SPREAD
 
-          val prod =
-            case oprod of
-                 NONE => unify (infer_type (H, E1)) (infer_type (H, E2))
-               | SOME prod => prod
+        val prod =
+          case oprod of
+               NONE => unify (infer_type (H, E1)) (infer_type (H, E2))
+             | SOME prod => prod
 
-          val (s,t,y) =
-            case onames of
-                 NONE =>
-                  (Context.fresh (H, Variable.named "s"),
-                   Context.fresh (H, Variable.named "t"),
-                   Context.fresh (H, Variable.named "y"))
-               | SOME names => names
+        val (s,t,y) =
+          case onames of
+               NONE =>
+                (Context.fresh (H, Variable.named "s"),
+                 Context.fresh (H, Variable.named "t"),
+                 Context.fresh (H, Variable.named "y"))
+             | SOME names => names
 
-          val #[S, xT] = prod ^! PROD
+        val #[S, xT] = prod ^! PROD
 
-          val zC =
-            case ozC of
-                 NONE =>
-                 let
-                   val z = Context.fresh (H, Variable.named "z")
-                   val H' = H @@ (z, prod)
-                   val Cz =
-                     unify
-                       (infer_type (H', SPREAD $$ #[``z, xyT1]))
-                       (infer_type (H', SPREAD $$ #[``z, uvT2]))
-                 in
-                   z \\ Cz
-                 end
-               | SOME zC => zC
+        val zC =
+          case ozC of
+               NONE =>
+               let
+                 val z = Context.fresh (H, Variable.named "z")
+                 val H' = H @@ (z, prod)
+                 val Cz =
+                   unify
+                     (infer_type (H', SPREAD $$ #[``z, xyT1]))
+                     (infer_type (H', SPREAD $$ #[``z, uvT2]))
+               in
+                 z \\ Cz
+               end
+             | SOME zC => zC
 
-          val CE1' = unify CE1 (zC // E1)
-          val Ts = xT // ``s
-          val st = PAIR $$ #[``s, ``t]
-          val E1pair = EQ $$ #[E1, st, prod]
-          val Cst = zC // st
-          val T1st = (xyT1 // ``s) // ``t
-          val T2st = (uvT2 // ``s) // ``t
-        in
-          [ H >> EQ $$ #[E1, E2, prod]
-          , H @@ (s, S) @@ (t, Ts) @@ (y, E1pair) >> EQ $$ #[T1st, T2st, Cst]
-          ] BY (fn [D, E] => SPREAD_EQ $$ #[D, s \\ (t \\ (y \\ E))]
-                  | _ => raise Refine)
-        end
+        val CE1' = unify CE1 (zC // E1)
+        val Ts = xT // ``s
+        val st = PAIR $$ #[``s, ``t]
+        val E1pair = EQ $$ #[E1, st, prod]
+        val Cst = zC // st
+        val T1st = (xyT1 // ``s) // ``t
+        val T2st = (uvT2 // ``s) // ``t
+      in
+        [ H >> EQ $$ #[E1, E2, prod]
+        , H @@ (s, S) @@ (t, Ts) @@ (y, E1pair) >> EQ $$ #[T1st, T2st, Cst]
+        ] BY (fn [D, E] => SPREAD_EQ $$ #[D, s \\ (t \\ (y \\ E))]
+                | _ => raise Refine)
+      end
 
     fun Hypothesis x (H >> P) =
       let
@@ -692,27 +663,24 @@ struct
         [] BY (fn _ => ``x)
       end
 
-    val Assumption : tactic =
-      fn (H >> P) =>
-        case Context.search H (fn x => Syntax.eq (P, x)) of
-             SOME (x, _) => Hypothesis x (H >> P)
-           | NONE => raise Refine
+    fun Assumption (H >> P) =
+      case Context.search H (fn x => Syntax.eq (P, x)) of
+           SOME (x, _) => Hypothesis x (H >> P)
+         | NONE => raise Refine
 
-    fun Unfold (development, lem) : tactic =
-      fn (H >> P) =>
-        let
-          val definiens = Development.lookup_definition development lem
-          val rewrite = subst definiens lem
-        in
-          [ Context.map rewrite H >> rewrite P
-          ] BY (fn [D] => D
-                 | _ => raise Refine)
-        end
+    fun Unfold (development, lbl) (H >> P) =
+      let
+        val definiens = Development.lookup_definition development lbl
+        val rewrite = subst definiens lbl
+      in
+        [ Context.map rewrite H >> rewrite P
+        ] BY (fn [D] => D
+               | _ => raise Refine)
+      end
 
-    fun Lemma (development, lem) : tactic =
-      fn (H >> P) =>
+    fun Lemma (development, lbl) (H >> P) =
         let
-          val {statement, evidence} = Development.lookup_theorem development lem
+          val {statement, evidence} = Development.lookup_theorem development lbl
           val H' >> P' = statement
         in
           if Context.subcontext Syntax.eq (H', H) andalso Syntax.eq (P, P')
@@ -720,37 +688,34 @@ struct
           else raise Refine
         end
 
-    val Admit : tactic =
-      fn (H >> P) =>
-        [] BY (fn _ => ADMIT $$ #[])
+    fun Admit (H >> P) =
+      [] BY (fn _ => ADMIT $$ #[])
 
-    fun RewriteGoal (c : conv) : tactic =
-      fn (H >> P) =>
-        [ Context.map c H >> c P ] BY (fn [D] => D | _ => raise Refine)
+    fun RewriteGoal (c : conv) (H >> P) =
+      [ Context.map c H >> c P
+      ] BY (fn [D] => D | _ => raise Refine)
 
-    val EqSym : tactic =
-      fn (H >> P) =>
-        let
-          val #[M,N,A] = P ^! EQ
-        in
-          [ H >> EQ $$ #[N,M,A]
-          ] BY mk_evidence EQ_SYM
-        end
+    fun EqSym (H >> P) =
+      let
+        val #[M,N,A] = P ^! EQ
+      in
+        [ H >> EQ $$ #[N,M,A]
+        ] BY mk_evidence EQ_SYM
+      end
 
-    fun EqSubst eq xC ok : tactic =
-      fn (H >> P) =>
-        let
-          val #[M,N,A] = eq ^! EQ
-          val (H', z, C) = ctx_unbind (H, A, xC)
-          val P' = unify P (xC // M)
-          val k = case ok of SOME k => k | NONE => infer_level (H', C)
-        in
-          [ H >> eq
-          , H >> xC // N
-          , H' >> MEM $$ #[C, UNIV k $$ #[]]
-          ] BY (fn [D,E,F] => EQ_SUBST $$ #[D, E, z \\ F]
-                 | _ => raise Refine)
-        end
+    fun EqSubst eq xC ok (H >> P) =
+      let
+        val #[M,N,A] = eq ^! EQ
+        val (H', z, C) = ctx_unbind (H, A, xC)
+        val P' = unify P (xC // M)
+        val k = case ok of SOME k => k | NONE => infer_level (H', C)
+      in
+        [ H >> eq
+        , H >> xC // N
+        , H' >> MEM $$ #[C, UNIV k $$ #[]]
+        ] BY (fn [D,E,F] => EQ_SUBST $$ #[D, E, z \\ F]
+               | _ => raise Refine)
+      end
   end
 
   structure Conversions =

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -420,6 +420,17 @@ struct
                | _ => raise Refine)
       end
 
+    fun IndependentSubsetIntro (H >> P) =
+      let
+        val #[P1, xP2] = P ^! SUBSET
+        val (x, P2) = unbind xP2
+        val _ = if has_free (P2, x) then raise Refine else ()
+      in
+        [ H >> P1
+        , H >> P2
+        ] BY mk_evidence IND_SUBSET_INTRO
+      end
+
     fun SubsetElim (z, onames) (H >> P) =
       let
         val #[S, xT] = Context.lookup H z ^! SUBSET
@@ -496,23 +507,33 @@ struct
 
     val ProdEq = QuantifierEq (PROD, PROD_EQ)
 
-    fun ProdIntro (w, oz, ok) : tactic =
-      fn (H >> P) =>
-        let
-          val #[P1, xP2] = P ^! PROD
-          val k = case ok of SOME k => k | NONE => infer_level (H, P)
-          val z =
-            Context.fresh (H,
-              case oz of
-                   SOME z => z
-                 | NONE => #1 (unbind xP2))
-        in
-          [ H >> MEM $$ #[ w, P1]
-          , H >> xP2 // w
-          , H @@ (z, P1) >> MEM $$ #[xP2 // ``z, UNIV k $$ #[]]
-          ] BY (fn [D, E, F] => PROD_INTRO $$ #[w, D, E, z \\ F]
-                 | _ => raise Refine)
-        end
+    fun ProdIntro (w, oz, ok) (H >> P) =
+      let
+        val #[P1, xP2] = P ^! PROD
+        val k = case ok of SOME k => k | NONE => infer_level (H, P)
+        val z =
+          Context.fresh (H,
+            case oz of
+                 SOME z => z
+               | NONE => #1 (unbind xP2))
+      in
+        [ H >> MEM $$ #[w, P1]
+        , H >> xP2 // w
+        , H @@ (z, P1) >> MEM $$ #[xP2 // ``z, UNIV k $$ #[]]
+        ] BY (fn [D, E, F] => PROD_INTRO $$ #[w, D, E, z \\ F]
+               | _ => raise Refine)
+      end
+
+    fun IndependentProdIntro (H >> P) =
+      let
+        val #[P1, xP2] = P ^! PROD
+        val (x, P2) = unbind xP2
+        val _ = if has_free (P2, x) then raise Refine else ()
+      in
+        [ H >> P1
+        , H >> P2
+        ] BY mk_evidence IND_PROD_INTRO
+      end
 
     fun ProdElim (z, onames) (H >> P) =
       let

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -225,8 +225,8 @@ struct
       end
 
     fun VoidElim (H >> P) =
-        [ H >> VOID $$ #[]
-        ] BY mk_evidence VOID_ELIM
+      [ H >> VOID $$ #[]
+      ] BY mk_evidence VOID_ELIM
 
     fun AxEq (H >> P) =
       let
@@ -458,7 +458,7 @@ struct
                | _ => raise Refine)
       end
 
-    fun MemUnfold (H >> P) =
+    fun MemCD (H >> P) =
       let
         val #[M, A] = P ^! MEM
       in

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -685,6 +685,28 @@ struct
         ] BY (fn [D,E,F] => EQ_SUBST $$ #[D, E, z \\ F]
                | _ => raise Refine)
       end
+
+    datatype dir = LEFT | RIGHT
+    local
+      structure Tacticals = Tacticals (Lcf)
+      open Tacticals
+      infix THEN THENL
+    in
+      fun HypEqSubst (dir, z) xC ok (H >> P) =
+        let
+          val X = Context.lookup H z
+        in
+          case dir of
+               RIGHT => (EqSubst X xC ok THENL [Hypothesis z, ID, ID]) (H >> P)
+             | LEFT =>
+                 let
+                   val #[M,N,A] = X ^! EQ
+                 in
+                   (EqSubst (EQ $$ #[N,M,A]) xC ok
+                     THENL [EqSym THEN Hypothesis z, ID, ID]) (H >> P)
+                 end
+        end
+    end
   end
 
   structure Conversions =

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -630,14 +630,14 @@ struct
       end
 
     fun Lemma (development, lbl) (H >> P) =
-        let
-          val {statement, evidence} = Development.lookup_theorem development lbl
-          val H' >> P' = statement
-        in
-          if Context.subcontext Syntax.eq (H', H) andalso Syntax.eq (P, P')
-          then [] BY (fn _ => Susp.force evidence)
-          else raise Refine
-        end
+      let
+        val {statement, evidence} = Development.lookup_theorem development lbl
+        val H' >> P' = statement
+      in
+        if Context.subcontext Syntax.eq (H', H) andalso Syntax.eq (P, P')
+        then [] BY (fn _ => Susp.force evidence)
+        else raise Refine
+      end
 
     fun Admit (H >> P) =
       [] BY (fn _ => ADMIT $$ #[])

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -104,6 +104,9 @@ sig
 
     val EqSubst : term -> term -> Level.t option -> Lcf.tactic
     val EqSym : Lcf.tactic
+
+    datatype dir = LEFT | RIGHT
+    val HypEqSubst : dir * name -> term -> Level.t option -> Lcf.tactic
   end
 
   structure Conversions :

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -90,7 +90,7 @@ sig
     val SubsetElim : name * (name * name) option -> Lcf.tactic
     val SubsetMemberEq : name option * Level.t option -> Lcf.tactic
 
-    val MemUnfold : Lcf.tactic
+    val MemCD : Lcf.tactic
     val Witness : term -> Lcf.tactic
 
     val Assumption : Lcf.tactic

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -63,32 +63,32 @@ sig
      * 2. H >> B[M]
      * 3. H, x:A >> B[x] ∈ U{k}
      *)
-    val ProdIntro : term -> name option -> Level.t option -> Lcf.tactic
+    val ProdIntro : term * name option * Level.t option -> Lcf.tactic
 
     (* H, z : (Σx:A)B[x], H'[z] >> P[z] by ProdElim z (s, t)
      * H, z : (Σx:A)B[x], s : A, t : B[s], H'[<s,t>] >> P[<s,t>]
      *)
-    val ProdElim : name -> (name * name) option -> Lcf.tactic
+    val ProdElim : name * (name * name) option -> Lcf.tactic
 
-    val PairEq : name option -> Level.t option -> Lcf.tactic
-    val SpreadEq : term option -> term option -> (name * name * name) option  -> Lcf.tactic
+    val PairEq : name option * Level.t option -> Lcf.tactic
+    val SpreadEq : term option * term option * (name * name * name) option -> Lcf.tactic
 
     val FunEq : name option -> Lcf.tactic
-    val FunIntro : name option -> Level.t option -> Lcf.tactic
-    val FunElim : name -> term -> (name * name) option -> Lcf.tactic
-    val LamEq : name option -> Level.t option -> Lcf.tactic
+    val FunIntro : name option * Level.t option -> Lcf.tactic
+    val FunElim : name * term * (name * name) option -> Lcf.tactic
+    val LamEq : name option * Level.t option -> Lcf.tactic
     val ApEq : term option -> Lcf.tactic
 
     val IsectEq : name option -> Lcf.tactic
-    val IsectIntro : name option -> Level.t option -> Lcf.tactic
-    val IsectElim : name -> term -> (name * name) option -> Lcf.tactic
-    val IsectMemberEq : name option -> Level.t option -> Lcf.tactic
-    val IsectMemberCaseEq : term option -> term -> Lcf.tactic
+    val IsectIntro : name option * Level.t option -> Lcf.tactic
+    val IsectElim : name * term * (name * name) option -> Lcf.tactic
+    val IsectMemberEq : name option * Level.t option -> Lcf.tactic
+    val IsectMemberCaseEq : term option * term -> Lcf.tactic
 
     val SubsetEq : name option -> Lcf.tactic
-    val SubsetIntro : term -> name option -> Level.t option -> Lcf.tactic
-    val SubsetElim : name -> (name * name) option -> Lcf.tactic
-    val SubsetMemberEq : name option -> Level.t option -> Lcf.tactic
+    val SubsetIntro : term * name option * Level.t option -> Lcf.tactic
+    val SubsetElim : name * (name * name) option -> Lcf.tactic
+    val SubsetMemberEq : name option * Level.t option -> Lcf.tactic
 
     val MemUnfold : Lcf.tactic
     val Witness : term -> Lcf.tactic
@@ -102,11 +102,11 @@ sig
 
     val RewriteGoal : ConvTypes.conv -> Lcf.tactic
 
-    val EqSubst : term -> term -> Level.t option -> Lcf.tactic
+    val EqSubst : term * term * Level.t option -> Lcf.tactic
     val EqSym : Lcf.tactic
 
     datatype dir = LEFT | RIGHT
-    val HypEqSubst : dir * name -> term -> Level.t option -> Lcf.tactic
+    val HypEqSubst : dir * name * term * Level.t option -> Lcf.tactic
   end
 
   structure Conversions :

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -64,6 +64,7 @@ sig
      * 3. H, x:A >> B[x] ∈ U{k}
      *)
     val ProdIntro : term * name option * Level.t option -> Lcf.tactic
+    val IndependentProdIntro : Lcf.tactic
 
     (* H, z : (Σx:A)B[x], H'[z] >> P[z] by ProdElim z (s, t)
      * H, z : (Σx:A)B[x], s : A, t : B[s], H'[<s,t>] >> P[<s,t>]
@@ -87,6 +88,7 @@ sig
 
     val SubsetEq : name option -> Lcf.tactic
     val SubsetIntro : term * name option * Level.t option -> Lcf.tactic
+    val IndependentSubsetIntro : Lcf.tactic
     val SubsetElim : name * (name * name) option -> Lcf.tactic
     val SubsetMemberEq : name option * Level.t option -> Lcf.tactic
 

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -5,7 +5,7 @@ functor CttRuleParser
     where Lcf = Lcf
     where Syntax = Syntax):
 sig
-  structure Lcf : LCF
+  structure Lcf : ANNOTATED_LCF
   type state = Ctt.Development.t
   val parse_rule : (state -> Lcf.tactic) CharParser.charParser
 end =

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -235,8 +235,37 @@ struct
       && opt parse_level
       astac SubsetMemberEq
 
+  val parse_intro_args =
+    opt parse_tm
+      && opt (brackets parse_name)
+      && opt parse_level
+      wth (fn (tm, (z, k)) => {term = tm, fresh_variable = z, level = k})
+
+  val parse_intro =
+    symbol "intro"
+      && parse_intro_args
+      astac Intro
+
+  val parse_names =
+    opt (brackets (commaSep1 parse_name))
+    wth (fn SOME xs => xs
+          | NONE => [])
+
+  val parse_elim_args =
+    brackets parse_name
+      && opt parse_tm
+      && parse_names
+      wth (fn (z, (M, names)) => {target = z, term = M, names = names})
+
+  val parse_elim =
+    symbol "elim"
+      && parse_elim_args
+      astac Elim
+
   val extensional_parse =
     symbol "auto" astac_ Auto
+      || parse_intro
+      || parse_elim
       || parse_cum
       || symbol "eq-eq" astac_ EqEq
       || symbol "univ-eq" astac_ UnivEq
@@ -249,7 +278,7 @@ struct
       || parse_prod_eq || parse_prod_intro || parse_prod_elim || parse_pair_eq || parse_spread_eq
       || parse_fun_eq || parse_fun_intro || parse_fun_elim || parse_lam_eq || parse_ap_eq
       || parse_isect_eq || parse_isect_intro || parse_isect_elim || parse_isect_member_eq || parse_isect_member_case_eq
-      || symbol "mem-unfold" astac_ MemUnfold
+      || symbol "mem-cd" astac_ MemCD
       || symbol "assumption" astac_ Assumption
       || symbol "symmetry" astac_ EqSym
       || symbol "hyp-eq" astac_ HypEq

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -92,24 +92,24 @@ struct
       && parse_tm
       && opt (brackets parse_name)
       && opt parse_level
-      astac (fn (M, (k, z)) => ProdIntro M k z)
+      astac (ProdIntro o flat3)
 
   val parse_prod_elim =
     symbol "prod-elim"
       && brackets (parse_name && opt (comma >> parse_name << comma && parse_name))
-      astac (fn (x,st) => ProdElim x st)
+      astac ProdElim
 
   val parse_pair_eq =
     symbol "pair-eq"
       && opt (brackets parse_name) && opt parse_level
-      astac (fn (z, k) => PairEq z k)
+      astac PairEq
 
   val parse_spread_eq =
     symbol "spread-eq"
       && opt parse_tm
          && opt parse_tm
          && opt (brackets (parse_name && parse_name && parse_name))
-      astac (fn (M, (N, names)) => SpreadEq M N (Option.map flat3 names))
+      astac (fn (M, (N, names)) => SpreadEq (M, N, Option.map flat3 names))
 
   val parse_fun_eq =
     symbol "fun-eq"
@@ -119,20 +119,20 @@ struct
   val parse_fun_intro =
     symbol "fun-intro"
       && opt (brackets parse_name) && opt parse_level
-      astac (fn (z,k) => FunIntro z k)
+      astac FunIntro
 
   val parse_fun_elim =
     symbol "fun-elim"
       && brackets parse_name
          && parse_tm
          && opt (brackets (comma >> parse_name << comma && parse_name))
-      astac (fn (z, (M, st)) => FunElim z M st)
+      astac (FunElim o flat3)
 
   val parse_lam_eq =
     symbol "lam-eq"
       && opt (brackets parse_name)
          && opt parse_level
-      astac (fn (z,k) => LamEq z k)
+      astac LamEq
 
   val parse_ap_eq =
     symbol "ap-eq"
@@ -147,25 +147,25 @@ struct
   val parse_isect_intro =
     symbol "isect-intro"
       && opt (brackets parse_name) && opt parse_level
-      astac (fn (z,k) => IsectIntro z k)
+      astac IsectIntro
 
   val parse_isect_elim =
     symbol "isect-elim"
       && brackets parse_name
          && parse_tm
          && opt (brackets (parse_name && parse_name))
-      astac (fn (z,(M,st)) => IsectElim z M st)
+      astac (IsectElim o flat3)
 
   val parse_isect_member_eq =
     symbol "isect-member-eq"
       && opt (brackets parse_name) && opt parse_level
-      astac (fn (z,k) => IsectMemberEq z k)
+      astac IsectMemberEq
 
   val parse_isect_member_case_eq =
     symbol "isect-member-case-eq"
       && ((parse_tm && parse_tm wth Sum.INL) || parse_tm wth Sum.INR)
-      astac (fn Sum.INL (M,N) => IsectMemberCaseEq (SOME M) N
-              | Sum.INR M => IsectMemberCaseEq NONE M)
+      astac (fn Sum.INL (M,N) => IsectMemberCaseEq (SOME M, N)
+              | Sum.INR M => IsectMemberCaseEq (NONE, M))
 
   val parse_witness =
     symbol "witness"
@@ -180,7 +180,7 @@ struct
   val parse_eq_subst =
     symbol "subst"
       && parse_tm && parse_tm && opt parse_level
-      astac (fn (M, (N, k)) => EqSubst M N k)
+      astac (EqSubst o flat3)
 
   val parse_dir =
     (symbol "→" || symbol "->") return RIGHT
@@ -191,7 +191,7 @@ struct
       && parse_dir
       && brackets parse_name
       && parse_tm && opt parse_level
-      astac (fn (z, (dir, (xC, k))) => HypEqSubst (z,dir) xC k)
+      astac (HypEqSubst o flat4)
 
   val parse_lemma =
     symbol "lemma"
@@ -221,19 +221,19 @@ struct
       && parse_tm
       && opt (brackets parse_name)
       && opt parse_level
-      astac (fn (M, (z, k)) => SubsetIntro M z k)
+      astac (SubsetIntro o flat3)
 
   val parse_subset_elim =
     symbol "subset-elim"
       && brackets parse_name
       && opt (brackets (parse_name << comma && parse_name))
-      astac (fn (z, st) => SubsetElim z st)
+      astac SubsetElim
 
   val parse_subset_member_eq =
     symbol "subset-member-eq"
       && opt (brackets parse_name)
       && opt parse_level
-      astac (fn (z, k) => SubsetMemberEq z k)
+      astac SubsetMemberEq
 
   val extensional_parse =
     symbol "auto" astac_ Auto

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -73,12 +73,16 @@ struct
       && opt parse_level
       astac Cum
 
-  fun quote_brackets p =
+  fun angles p =
+    brackets p
+      || middle (symbol "〈") p  (symbol "〉")
+
+  fun quote_squares p =
     middle (symbol "[") p (symbol "]")
       || middle (symbol "⌊") p (symbol "⌋")
 
   val parse_tm =
-    quote_brackets ParseSyntax.parse_abt
+    quote_squares ParseSyntax.parse_abt
 
   val parse_witness =
     symbol "witness"
@@ -87,7 +91,7 @@ struct
 
   val parse_hypothesis =
     symbol "hypothesis"
-      && brackets parse_name
+      && angles parse_name
       astac Hypothesis
 
   val parse_eq_subst =
@@ -102,31 +106,31 @@ struct
   val parse_hyp_subst =
     symbol "hyp-subst"
       && parse_dir
-      && brackets parse_name
+      && angles parse_name
       && parse_tm && opt parse_level
       astac (HypEqSubst o flat4)
 
   val parse_lemma =
     symbol "lemma"
-      && brackets parse_name
+      && angles parse_name
       wth (fn (name, lbl) => fn st => fn pos =>
              Lcf.annotate ({name = name, pos = pos}, Lemma (st, lbl)))
 
   val parse_unfold =
     symbol "unfold"
-      && brackets parse_name
+      && angles parse_name
       wth (fn (name, lbl) => fn st => fn pos =>
              Lcf.annotate ({name = name, pos = pos}, Unfold (st, lbl)))
 
   val parse_custom_tactic =
     symbol "refine"
-      >> brackets parse_name
+      >> angles parse_name
       wth (fn lbl => fn st => fn (pos : Pos.t) =>
             Lcf.annotate ({name = Syntax.Variable.to_string lbl, pos = pos}, Development.lookup_tactic st lbl))
 
   val parse_intro_args =
     opt parse_tm
-      && opt (brackets parse_name)
+      && opt (angles parse_name)
       && opt parse_level
       wth (fn (tm, (z, k)) => {term = tm, fresh_variable = z, level = k})
 
@@ -136,12 +140,12 @@ struct
       astac Intro
 
   val parse_names =
-    opt (brackets (commaSep1 parse_name))
+    opt (angles (commaSep1 parse_name))
     wth (fn SOME xs => xs
           | NONE => [])
 
   val parse_elim_args =
-    brackets parse_name
+    angles parse_name
       && opt parse_tm
       && parse_names
       wth (fn (z, (M, names)) => {target = z, term = M, names = names})
@@ -152,7 +156,7 @@ struct
       astac Elim
 
   val parse_terms =
-    opt (quote_brackets (commaSep1 ParseSyntax.parse_abt))
+    opt (quote_squares (commaSep1 ParseSyntax.parse_abt))
     wth (fn SOME xs => xs
           | NONE => [])
 

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -182,6 +182,17 @@ struct
       && parse_tm && parse_tm && opt parse_level
       astac (fn (M, (N, k)) => EqSubst M N k)
 
+  val parse_dir =
+    (symbol "→" || symbol "->") return RIGHT
+      || (symbol "←" || symbol "<-") return LEFT
+
+  val parse_hyp_subst =
+    symbol "hyp-subst"
+      && parse_dir
+      && brackets parse_name
+      && parse_tm && opt parse_level
+      astac (fn (z, (dir, (xC, k))) => HypEqSubst (z,dir) xC k)
+
   val parse_lemma =
     symbol "lemma"
       && brackets parse_name
@@ -243,6 +254,7 @@ struct
       || symbol "symmetry" astac_ EqSym
       || symbol "hyp-eq" astac_ HypEq
       || parse_witness
+      || parse_hyp_subst
       || parse_eq_subst
       || parse_subset_eq
       || parse_subset_intro

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -1,5 +1,5 @@
 functor CttRuleParser
-  (structure Lcf : LCF
+  (structure Lcf : ANNOTATED_LCF where type metadata = TacticMetadata.metadata
    structure Syntax : PARSE_ABT
    structure Ctt : CTT_UTIL
     where Lcf = Lcf
@@ -10,11 +10,12 @@ sig
   val parse_rule : (state -> Lcf.tactic) CharParser.charParser
 end =
 struct
-  structure Lcf = Lcf
+  structure AnnLcf = Lcf
   structure ParseSyntax = Syntax
-
   structure Tacticals = Tacticals (Lcf)
   open Ctt Lcf Tacticals ParserCombinators CharParser
+  structure Lcf = AnnLcf
+
   infix 2 return wth suchthat return guard when
   infixr 1 || <|>
   infixr 3 &&
@@ -40,7 +41,7 @@ struct
   structure TP = TokenParser (LangDef)
   open TP Rules
 
-  exception XXX
+  type state = Development.t
 
   val parse_level =
     symbol "@"
@@ -55,10 +56,22 @@ struct
     identifier
       wth Syntax.Variable.named
 
+  fun decorate_tac tac =
+    fn (name, args) => fn (pos : Pos.t) =>
+      Lcf.annotate ({name = name, pos = pos}, tac args)
+
+  fun astac (p, tac) = p wth (decorate_tac tac)
+  infix 2 astac
+
+  fun astac_ (p : string charParser, tac : tactic) : (Pos.t -> tactic) charParser =
+    p wth (fn name => fn (pos : Pos.t) =>
+      Lcf.annotate ({name = name, pos = pos}, tac))
+  infix 2 astac_
+
   val parse_cum =
     symbol "cum"
-      >> opt parse_level
-      wth Cum
+      && opt parse_level
+      astac Cum
 
   val parse_tm =
     middle (symbol "[") ParseSyntax.parse_abt (symbol "]")
@@ -66,168 +79,169 @@ struct
 
   val parse_unit_elim =
     symbol "unit-elim"
-      >> brackets parse_name
-      wth UnitElim
+      && brackets parse_name
+      astac UnitElim
 
   val parse_prod_eq =
     symbol "prod-eq"
-      >> opt (brackets parse_name)
-      wth ProdEq
+      && opt (brackets parse_name)
+      astac ProdEq
 
   val parse_prod_intro =
     symbol "prod-intro"
-      >> parse_tm
+      && parse_tm
       && opt (brackets parse_name)
       && opt parse_level
-      wth (fn (M, (k, z)) => ProdIntro M k z)
+      astac (fn (M, (k, z)) => ProdIntro M k z)
 
   val parse_prod_elim =
     symbol "prod-elim"
-      >> brackets (parse_name && opt (comma >> parse_name << comma && parse_name))
-      wth (fn (x,st) => ProdElim x st)
+      && brackets (parse_name && opt (comma >> parse_name << comma && parse_name))
+      astac (fn (x,st) => ProdElim x st)
 
   val parse_pair_eq =
     symbol "pair-eq"
-      >> opt (brackets parse_name) && opt parse_level
-      wth (fn (z, k) => PairEq z k)
+      && opt (brackets parse_name) && opt parse_level
+      astac (fn (z, k) => PairEq z k)
 
   val parse_spread_eq =
     symbol "spread-eq"
-      >> opt parse_tm
+      && opt parse_tm
          && opt parse_tm
          && opt (brackets (parse_name && parse_name && parse_name))
-      wth (fn (M, (N, names)) => SpreadEq M N (Option.map flat3 names))
+      astac (fn (M, (N, names)) => SpreadEq M N (Option.map flat3 names))
 
   val parse_fun_eq =
     symbol "fun-eq"
-      >> opt (brackets parse_name)
-      wth FunEq
+      && opt (brackets parse_name)
+      astac FunEq
 
   val parse_fun_intro =
     symbol "fun-intro"
-      >> opt (brackets parse_name) && opt parse_level
-      wth (fn (z,k) => FunIntro z k)
+      && opt (brackets parse_name) && opt parse_level
+      astac (fn (z,k) => FunIntro z k)
 
   val parse_fun_elim =
     symbol "fun-elim"
-      >> brackets parse_name
+      && brackets parse_name
          && parse_tm
          && opt (brackets (comma >> parse_name << comma && parse_name))
-      wth (fn (z, (M, st)) => FunElim z M st)
+      astac (fn (z, (M, st)) => FunElim z M st)
 
   val parse_lam_eq =
     symbol "lam-eq"
-      >> opt (brackets parse_name)
+      && opt (brackets parse_name)
          && opt parse_level
-      wth (fn (z,k) => LamEq z k)
+      astac (fn (z,k) => LamEq z k)
 
   val parse_ap_eq =
     symbol "ap-eq"
-      >> opt parse_tm
-      wth ApEq
+      && opt parse_tm
+      astac ApEq
 
   val parse_isect_eq =
     symbol "isect-eq"
-      >> opt (brackets parse_name)
-      wth IsectEq
+      && opt (brackets parse_name)
+      astac IsectEq
 
   val parse_isect_intro =
     symbol "isect-intro"
-      >> opt (brackets parse_name) && opt parse_level
-      wth (fn (z,k) => IsectIntro z k)
+      && opt (brackets parse_name) && opt parse_level
+      astac (fn (z,k) => IsectIntro z k)
 
   val parse_isect_elim =
     symbol "isect-elim"
-      >> brackets parse_name
+      && brackets parse_name
          && parse_tm
          && opt (brackets (parse_name && parse_name))
-      wth (fn (z,(M,st)) => IsectElim z M st)
+      astac (fn (z,(M,st)) => IsectElim z M st)
 
   val parse_isect_member_eq =
     symbol "isect-member-eq"
-      >> opt (brackets parse_name) && opt parse_level
-      wth (fn (z,k) => IsectMemberEq z k)
+      && opt (brackets parse_name) && opt parse_level
+      astac (fn (z,k) => IsectMemberEq z k)
 
   val parse_isect_member_case_eq =
     symbol "isect-member-case-eq"
-      >> ((parse_tm && parse_tm wth Sum.INL) || parse_tm wth Sum.INR)
-      wth (fn Sum.INL (M,N) => IsectMemberCaseEq (SOME M) N
-            | Sum.INR M => IsectMemberCaseEq NONE M)
+      && ((parse_tm && parse_tm wth Sum.INL) || parse_tm wth Sum.INR)
+      astac (fn Sum.INL (M,N) => IsectMemberCaseEq (SOME M) N
+              | Sum.INR M => IsectMemberCaseEq NONE M)
 
   val parse_witness =
     symbol "witness"
-      >> parse_tm
-      wth Witness
+      && parse_tm
+      astac Witness
 
   val parse_hypothesis =
     symbol "hypothesis"
-      >> brackets parse_name
-      wth Hypothesis
+      && brackets parse_name
+      astac Hypothesis
 
   val parse_eq_subst =
     symbol "subst"
-      >> parse_tm && parse_tm && opt parse_level
-      wth (fn (M, (N, k)) => EqSubst M N k)
-
-  type state = Development.t
+      && parse_tm && parse_tm && opt parse_level
+      astac (fn (M, (N, k)) => EqSubst M N k)
 
   val parse_lemma =
     symbol "lemma"
-      >> brackets parse_name
-      wth (fn lbl => fn st => Lemma (st, lbl))
+      && brackets parse_name
+      wth (fn (name, lbl) => fn st => fn pos =>
+             Lcf.annotate ({name = name, pos = pos}, Lemma (st, lbl)))
 
   val parse_unfold =
     symbol "unfold"
-      >> brackets parse_name
-      wth (fn lbl => fn st => Unfold (st, lbl))
+      && brackets parse_name
+      wth (fn (name, lbl) => fn st => fn pos =>
+             Lcf.annotate ({name = name, pos = pos}, Unfold (st, lbl)))
 
   val parse_custom_tactic =
     symbol "refine"
       >> brackets parse_name
-      wth (fn lbl => fn st => Development.lookup_tactic st lbl)
+      wth (fn lbl => fn st => fn (pos : Pos.t) =>
+            Lcf.annotate ({name = Syntax.Variable.to_string lbl, pos = pos}, Development.lookup_tactic st lbl))
 
   val parse_subset_eq =
     symbol "subset-eq"
-      >> opt (brackets parse_name)
-      wth SubsetEq
+      && opt (brackets parse_name)
+      astac SubsetEq
 
   val parse_subset_intro =
     symbol "subset-intro"
-      >> parse_tm
+      && parse_tm
       && opt (brackets parse_name)
       && opt parse_level
-      wth (fn (M, (z, k)) => SubsetIntro M z k)
+      astac (fn (M, (z, k)) => SubsetIntro M z k)
 
   val parse_subset_elim =
     symbol "subset-elim"
-      >> brackets parse_name
+      && brackets parse_name
       && opt (brackets (parse_name << comma && parse_name))
-      wth (fn (z, st) => SubsetElim z st)
+      astac (fn (z, st) => SubsetElim z st)
 
   val parse_subset_member_eq =
     symbol "subset-member-eq"
-      >> opt (brackets parse_name)
+      && opt (brackets parse_name)
       && opt parse_level
-      wth (fn (z, k) => SubsetMemberEq z k)
+      astac (fn (z, k) => SubsetMemberEq z k)
 
   val extensional_parse =
-    symbol "auto" return Auto
+    symbol "auto" astac_ Auto
       || parse_cum
-      || symbol "eq-eq" return EqEq
-      || symbol "univ-eq" return UnivEq
-      || symbol "void-eq" return VoidEq
-      || symbol "void-elim" return VoidElim
-      || symbol "unit-eq" return UnitEq
-      || symbol "unit-intro" return UnitIntro
+      || symbol "eq-eq" astac_ EqEq
+      || symbol "univ-eq" astac_ UnivEq
+      || symbol "void-eq" astac_ VoidEq
+      || symbol "void-elim" astac_ VoidElim
+      || symbol "unit-eq" astac_ UnitEq
+      || symbol "unit-intro" astac_ UnitIntro
       || parse_unit_elim
-      || symbol "ax-eq" return AxEq
+      || symbol "ax-eq" astac_ AxEq
       || parse_prod_eq || parse_prod_intro || parse_prod_elim || parse_pair_eq || parse_spread_eq
       || parse_fun_eq || parse_fun_intro || parse_fun_elim || parse_lam_eq || parse_ap_eq
       || parse_isect_eq || parse_isect_intro || parse_isect_elim || parse_isect_member_eq || parse_isect_member_case_eq
-      || symbol "mem-unfold" return MemUnfold
-      || symbol "assumption" return Assumption
-      || symbol "symmetry" return EqSym
-      || symbol "hyp-eq" return HypEq
+      || symbol "mem-unfold" astac_ MemUnfold
+      || symbol "assumption" astac_ Assumption
+      || symbol "symmetry" astac_ EqSym
+      || symbol "hyp-eq" astac_ HypEq
       || parse_witness
       || parse_eq_subst
       || parse_subset_eq
@@ -240,13 +254,15 @@ struct
       || parse_unfold
       || parse_custom_tactic
 
-  val parse_rule = intensional_parse || extensional_parse wth (fn t => fn _ => t)
+  val parse_rule : (state -> tactic) charParser =
+    !! (intensional_parse || extensional_parse wth (fn t => fn _ => t))
+    wth (fn (t, pos) => fn st => t st pos)
 
 end
 
 structure CttRuleParser = CttRuleParser
   (structure Ctt = CttUtil
-   structure Lcf = Lcf
+   structure Lcf = AnnotatedLcf
    structure Development = Development
    structure Syntax = Syntax)
 

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -35,7 +35,9 @@ struct
        ORELSE FunIntro (fresh_variable, level)
        ORELSE IsectIntro (fresh_variable, level)
        ORELSE_LAZY (fn _ => ProdIntro (valOf term, fresh_variable, level))
+       ORELSE IndependentProdIntro
        ORELSE_LAZY (fn _ => SubsetIntro (valOf term, fresh_variable, level))
+       ORELSE IndependentSubsetIntro
 
   fun take2 (x::y::_) = SOME (x,y)
     | take2 _ = NONE

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -23,6 +23,11 @@ struct
      names : name list,
      term : term option}
 
+  type eq_cd_args =
+    {names : name list,
+     level : Level.t option,
+     terms : term list}
+
   fun Intro {term,fresh_variable,level} =
      MemCD
        ORELSE UnitIntro
@@ -35,6 +40,11 @@ struct
   fun take2 (x::y::_) = SOME (x,y)
     | take2 _ = NONE
 
+  fun take3 (x::y::z::_) = SOME (x,y,z)
+    | take3 _ = NONE
+
+  fun list_at (xs, n) = SOME (List.nth (xs, n)) handle _ => NONE
+
   fun Elim {target, names, term} =
     (VoidElim THEN Hypothesis target)
       ORELSE UnitElim target
@@ -43,25 +53,37 @@ struct
       ORELSE_LAZY (fn _ => IsectElim (target, valOf term, take2 names))
       ORELSE SubsetElim (target, take2 names)
 
-  local
-    val EqRules =
+  fun EqCD {names, level, terms} =
+    let
+      val fresh_variable = list_at (names, 0)
+    in
       AxEq
-      ORELSE EqEq
-      ORELSE FunEq NONE
-      ORELSE IsectEq NONE
-      ORELSE PairEq (NONE, NONE)
-      ORELSE LamEq (NONE, NONE)
-      ORELSE UnitEq
-      ORELSE ProdEq NONE
-      ORELSE VoidEq
-      ORELSE UnivEq
-      ORELSE HypEq
-      ORELSE ApEq NONE
-      ORELSE SpreadEq (NONE, NONE, NONE)
-      ORELSE Cum NONE
-      ORELSE SubsetEq NONE
-      ORELSE SubsetMemberEq (NONE, NONE)
-      ORELSE IsectMemberEq (NONE, NONE)
+        ORELSE EqEq
+        ORELSE UnitEq
+        ORELSE VoidEq
+        ORELSE UnivEq
+        ORELSE HypEq
+        ORELSE FunEq fresh_variable
+        ORELSE IsectEq fresh_variable
+        ORELSE ProdEq fresh_variable
+        ORELSE SubsetEq fresh_variable
+        ORELSE PairEq (fresh_variable, level)
+        ORELSE LamEq (fresh_variable, level)
+        ORELSE ApEq (list_at (terms, 0))
+        ORELSE SpreadEq (list_at (terms, 0), list_at (terms, 1), take3 names)
+        ORELSE Cum level
+        ORELSE SubsetMemberEq (fresh_variable, level)
+        ORELSE IsectMemberEq (fresh_variable, level)
+        ORELSE_LAZY (fn _ =>
+          case terms of
+               [M, N] => IsectMemberCaseEq (SOME M, N)
+             | [N] => IsectMemberCaseEq (NONE, N)
+             | _ => FAIL)
+    end
+
+  local
+    val AutoEqCD =
+      EqCD {names = [], level = NONE, terms = []}
 
     val AutoVoidElim = VoidElim THEN Assumption
     val AutoIntro = Intro {term = NONE, fresh_variable = NONE, level = NONE}
@@ -73,7 +95,7 @@ struct
     val DeepReduce = RewriteGoal (CDEEP Reduce)
   in
     val Auto =
-      LIMIT (AutoIntro ORELSE AutoVoidElim ORELSE EqRules ORELSE PROGRESS DeepReduce)
+      LIMIT (AutoIntro ORELSE AutoVoidElim ORELSE AutoEqCD ORELSE PROGRESS DeepReduce)
   end
 end
 

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -19,24 +19,25 @@ struct
       ORELSE EqEq
       ORELSE FunEq NONE
       ORELSE IsectEq NONE
-      ORELSE PairEq NONE NONE
-      ORELSE LamEq NONE NONE
+      ORELSE PairEq (NONE, NONE)
+      ORELSE LamEq (NONE, NONE)
       ORELSE UnitEq
       ORELSE ProdEq NONE
       ORELSE VoidEq
       ORELSE UnivEq
       ORELSE HypEq
       ORELSE ApEq NONE
-      ORELSE SpreadEq NONE NONE NONE
+      ORELSE SpreadEq (NONE, NONE, NONE)
       ORELSE Cum NONE
       ORELSE SubsetEq NONE
-      ORELSE SubsetMemberEq NONE NONE
+      ORELSE SubsetMemberEq (NONE, NONE)
+      ORELSE IsectMemberEq (NONE, NONE)
 
     val IntroRules =
       MemUnfold
       ORELSE Assumption
-      ORELSE FunIntro NONE NONE
-      ORELSE IsectIntro NONE NONE
+      ORELSE FunIntro (NONE, NONE)
+      ORELSE IsectIntro (NONE, NONE)
       ORELSE UnitIntro
 
     open Conversions Conversionals

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -11,7 +11,7 @@ struct
      structure ConvTypes = ConvTypes)
 
   open Tacticals Rules
-  infix ORELSE ORELSE_LAZY THEN
+  infix ORELSE THEN
 
   local
     val EqRules =

--- a/src/ctt_util.sig
+++ b/src/ctt_util.sig
@@ -13,7 +13,13 @@ sig
      names : name list,
      term : term option}
 
+  type eq_cd_args =
+    {names : name list,
+     level : Level.t option,
+     terms : term list}
+
   val Intro : intro_args -> Lcf.tactic
   val Elim : elim_args -> Lcf.tactic
+  val EqCD : eq_cd_args -> Lcf.tactic
 
 end

--- a/src/ctt_util.sig
+++ b/src/ctt_util.sig
@@ -2,4 +2,18 @@ signature CTT_UTIL =
 sig
   include CTT
   val Auto : Lcf.tactic
+
+  type intro_args =
+    {term : Syntax.t option,
+     fresh_variable : name option,
+     level : Level.t option}
+
+  type elim_args =
+    {target : name,
+     names : name list,
+     term : term option}
+
+  val Intro : intro_args -> Lcf.tactic
+  val Elim : elim_args -> Lcf.tactic
+
 end

--- a/src/extract.fun
+++ b/src/extract.fun
@@ -25,6 +25,7 @@ struct
 
        | PROD_EQ $ _ => ax
        | PROD_INTRO $ #[M, D, E, xF] => PAIR $$ #[M, extract E]
+       | IND_PROD_INTRO $ #[D,E] => PAIR $$ #[extract D, extract E]
        | PROD_ELIM $ #[R, xyD] => SPREAD $$ #[R, extract xyD]
        | PAIR_EQ $ _ => ax
        | SPREAD_EQ $ _ => ax
@@ -48,6 +49,7 @@ struct
 
        | SUBSET_EQ $ _ => ax
        | SUBSET_INTRO $ #[w,_,_,_] => w
+       | IND_SUBSET_INTRO $ #[D, _] => extract D
        | SUBSET_ELIM $ #[R, stD] => extract (stD // R) // ax
        | SUBSET_MEMBER_EQ $ _ => ax
 

--- a/src/lcf.fun
+++ b/src/lcf.fun
@@ -13,3 +13,7 @@ end
 structure Lcf = Lcf
   (structure Sequent = Sequent
    type evidence = Syntax.t)
+
+structure AnnotatedLcf = AnnotatedLcf
+  (structure Lcf = Lcf
+   type metadata = {name : string, pos : Pos.t})

--- a/src/operator.sml
+++ b/src/operator.sml
@@ -6,11 +6,11 @@ struct
     | EQ_EQ
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
-    | PROD_EQ | PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
+    | PROD_EQ | PROD_INTRO | IND_PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
     | FUN_EQ | FUN_INTRO | FUN_ELIM | LAM_EQ | AP_EQ
     | ISECT_EQ | ISECT_INTRO | ISECT_ELIM | ISECT_MEMBER_EQ | ISECT_MEMBER_CASE_EQ
     | WITNESS | HYP_EQ | EQ_SUBST | EQ_SYM
-    | SUBSET_EQ | SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
+    | SUBSET_EQ | SUBSET_INTRO | IND_SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
 
     | ADMIT
 
@@ -41,6 +41,7 @@ struct
 
        | PROD_EQ => #[0,1]
        | PROD_INTRO => #[0,0,0,1]
+       | IND_PROD_INTRO => #[0,0]
        | PROD_ELIM => #[0,2]
        | PAIR_EQ => #[0,0,1]
        | SPREAD_EQ => #[0,3]
@@ -64,6 +65,7 @@ struct
 
        | SUBSET_EQ => #[0,1]
        | SUBSET_INTRO => #[0,0,0,1]
+       | IND_SUBSET_INTRO => #[0,0]
        | SUBSET_ELIM => #[0,2]
        | SUBSET_MEMBER_EQ => #[0,0,1]
 
@@ -103,6 +105,7 @@ struct
 
        | PROD_EQ => "prod⁼"
        | PROD_INTRO => "prod-intro"
+       | IND_PROD_INTRO => "independent-prod-intro"
        | PROD_ELIM => "prod-elim"
        | PAIR_EQ => "pair⁼"
        | SPREAD_EQ => "spread⁼"
@@ -127,6 +130,7 @@ struct
 
        | SUBSET_EQ => "subset⁼"
        | SUBSET_INTRO => "subset-intro"
+       | IND_SUBSET_INTRO => "independent-subset-intro"
        | SUBSET_ELIM => "subset-elim"
        | SUBSET_MEMBER_EQ => "subset-member-eq"
 

--- a/src/operator.sml
+++ b/src/operator.sml
@@ -159,8 +159,12 @@ struct
     val parse_int =
       repeat1 digit wth valOf o Int.fromString o String.implode
 
+  fun angles p =
+    middle (string "<") p (string ">")
+      || middle (string "〈") p  (string "〉")
+
     val parse_univ =
-      string "U<" >> parse_int << string ">" wth UNIV
+      string "U" >> angles parse_int wth UNIV
 
     val parse_operator =
       parse_univ

--- a/src/sequent.fun
+++ b/src/sequent.fun
@@ -14,7 +14,10 @@ struct
       val ctx = Context.to_string Syntax.to_string H
       val prop = Syntax.to_string P
     in
-      ctx ^ "\n⊢ " ^ prop
+      if Context.is_empty H then
+        "⊢ " ^ prop
+      else
+        Context.to_string Syntax.to_string H ^ "\n⊢ " ^ prop
     end
 
   fun eq (H >> P, H' >> P') =

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -6,18 +6,17 @@ group is
   ../lib/cmlib/cmlib.cm
   ../lib/parcom.cm
 
+  visibility.sml
   operator.sml
   syntax.sml
 
-  extract.sig
-  extract.fun
+  level.sig
+  level.sml
 
   conv_types.sig
   conv_types.fun
   conversionals.sig
   conversionals.fun
-
-  visibility.sml
 
   context.sig
   context.fun
@@ -26,21 +25,21 @@ group is
   sequent.fun
 
   lcf.fun
+  extract.sig
+  extract.fun
 
-  level.sig
-  level.sml
+  development.sig
+  development.fun
+
   ctt.sig
   ctt.fun
   ctt_util.sig
   ctt_util.fun
 
+  tactic_metadata.sml
   tactic_script.sig
   tactic_script.fun
-
   ctt_rule_parser.fun
-
-  development.sig
-  development.fun
 
   development_parser.sig
   development_parser.fun

--- a/src/tactic_metadata.sml
+++ b/src/tactic_metadata.sml
@@ -1,0 +1,4 @@
+structure TacticMetadata =
+struct
+  type metadata = {name : string, pos : Pos.t}
+end

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -33,7 +33,11 @@ struct
   structure TP = TokenParser (LangDef)
   open TP
 
+  val pipe = symbol "|"
+
   val parse_id : (state -> tactic) charParser = symbol "id" return (fn _ => ID)
+  val parse_fail : (state -> tactic) charParser = symbol "fail" return (fn _ => FAIL)
+
   fun parse_script () : (state -> tactic) charParser =
     separate1 ((squares (commaSep ($ parse_script)) wth Sum.INL) <|> ($ plain wth Sum.INR)) semi
     wth (foldl (fn (t1, t2) => fn s =>
@@ -41,7 +45,7 @@ struct
                         Sum.INR t => THEN (t2 s, t s)
                       | Sum.INL x => THENL (t2 s, map (fn t' => t' s) x)) (fn _ => ID))
 
-  and plain () = parse_rule || $ parse_try || $ parse_repeat || parse_id
+  and plain () = parse_rule || $ parse_try || $ parse_repeat || parse_id || parse_fail || $ parse_orelse
 
   and parse_try () =
         middle (symbol "?{") ($ parse_script) (symbol "}")
@@ -50,6 +54,10 @@ struct
   and parse_repeat () =
         middle (symbol "*{") ($ parse_script) (symbol "}")
           wth (fn t => REPEAT o t)
+
+  and parse_orelse () =
+        parens (separate1 ($ parse_script) pipe)
+        wth foldl (fn (t1, t2) => fn s => ORELSE (t1 s, t2 s)) (fn _ => FAIL)
 
   val parse = $ parse_script << opt (dot || semi)
 end


### PR DESCRIPTION
- close #45 : report source locations in refinement errors (also name of tactic)
- close #48 : add concrete syntax for `ORELSE` tactical `(t1 | t2)`
- partially implement #41 : add independent versions of product & subset intro rules
- harmonize all the intro, elim and eq rules under a few "megatactics" in the manner of Nuprl: `intro`, `elim`, `eq-cd`. Now, the actual rules which these tactics call are no longer available in the concrete syntax.
- improve `auto` tactic to automatically discharge goals that hypothesize `Void`
- add a `hyp-subst` tactic that simplifies common uses of `eq-subst`
