### PR TITLE
Custom Operator Declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ sudo make install
 Optionally, you may install the [JonPRL Mode for
 Emacs](https://github.com/david-christiansen/jonprl-mode).
 
+If you use `pretty-mode`, then you may install the following patterns:
+
+```elisp
+(pretty-add-keywords
+  'jonprl-mode
+  '(("\\\[" . "⸤")
+    ("\\\]" . "⸥")
+    ("<" . "⟨")
+    (">" . "⟩")
+    ("<>" . "⬧")
+    ("\\<\\(=def=\\)\\>" . "≝")
+    ))
+```
+
 ### Running JonPRL
 
 To run JonPRL, simply direct it at your development:
@@ -44,13 +58,12 @@ in order, in case of any dependencies.
 
 ### Basic Syntax
 
-JonPRL has a two-level syntax. There is the syntax of terms in the
-underlying lambda calculus (the object language) and the syntax of
-tactics and definitions in the metalanguage. Terms from the underlying
-lambda calculus are embedded into the metalanguage using either square
-brackets ('[' and ']') or floor brackets ('⌊' and '⌋'). When referring
-to names from the object language in the metalanguage, they are quoted
-in angle brackets ('<' and '>').
+JonPRL has a two-level syntax. There is the syntax of terms in the underlying
+lambda calculus (the object language) and the syntax of tactics and definitions
+in the metalanguage. Terms from the underlying lambda calculus are embedded
+into the metalanguage using brackets (`[` and `]`). When referring to names
+from the object language in the metalanguage, they are quoted in angle brackets
+(`<` and `>`).
 
 The syntax of the object language represents all binders in a
 consistent manner. The variables to be bound in a subterm are written

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -1,21 +1,25 @@
-RawCat =def= [
+Operator RawCat : ().
+Operator obj : (0).
+Operator hom : (0;0;0).
+Operator idn : (0;0).
+Operator cmp : (0;0;0;0).
+
+[RawCat] =def= [
   Σ(U<0>; Obj.
   Σ(Π(Obj; A. Π(Obj; B. U<0>)); Hom.
   Σ(Π(Obj; A.
-    ap(ap(Hom; A); A)); idn.
+    ap(ap(Hom; A); A)); Idn.
   Σ(Π(Obj; A. Π(Obj; B. Π(Obj; C.
     Π(ap(ap(Hom; B); C); g.
     Π(ap(ap(Hom; A); B); f.
-      ap(ap(Hom; A); C)))))); cmp.
+      ap(ap(Hom; A); C)))))); Cmp.
   unit))))
 ].
 
-obj =def= [λ(C. spread(C; x.y.x))].
-hom =def= [λ(C. spread(spread(C; x.y.y); x.y.x))].
-idn =def= [λ(C. spread(spread(spread(C; x.y.y); x.y.y); x.y.x))].
-cmp =def= [λ(C. spread(spread(spread(spread(C; x.y.y); x.y.y); x.y.y); x.y.x))].
-
-Operator welp : (1;0;0).
+[obj(C)] =def= [spread(C; x.y.x)].
+[hom(C;A;B)] =def= [ap(ap(spread(spread(C; x.y.y); x.y.x); A); B)].
+[idn(C;A)] =def= [ap(spread(spread(spread(C; x.y.y); x.y.y); x.y.x); A)].
+[cmp(C;A;B;C)] =def= [ap(ap(ap(spread(spread(spread(spread(C; x.y.y); x.y.y); x.y.y); x.y.x); A); B); C)].
 
 Tactic rawcat_unfold {
   unfold <RawCat>;
@@ -25,89 +29,94 @@ Tactic rawcat_unfold {
   unfold <cmp>.
 }.
 
+
 Theorem RawCat_wf : [∈(RawCat; U<1>)] {
   refine <rawcat_unfold>; auto.
 }.
 
-Theorem obj_wf : [∀(RawCat; RC. ∈(ap(obj; RC); U<0>))] {
+
+Theorem obj_wf : [∀(RawCat; RC. ∈(obj(RC); U<0>))] {
   refine <rawcat_unfold>; auto.
 }.
 
 Theorem hom_wf : [
   ∀(RawCat; RC.
-  ∀(ap(obj; RC); A.
-  ∀(ap(obj; RC); B.
-    ∈(ap(ap(ap(hom; RC); A); B); U<0>))))
+  ∀(obj(RC); A.
+  ∀(obj(RC); B.
+    ∈(hom(RC;A;B); U<0>))))
 ] {
   refine <rawcat_unfold>; auto.
 }.
 
-LawCat =def= [
-  λ(RC.
-  Σ(Π(ap(obj; RC); A.
-    Π(ap(ap(ap(hom; RC); A); A); f.
-      =(ap(ap(ap(cmp; RC); ap(idn; RC)); f);
-        f;
-        ap(ap(ap(hom; RC); A); A)))); law_idn_lhs.
-  Σ(Π(ap(obj; RC); A.
-    Π(ap(ap(ap(hom; RC); A); A); f.
-      =(ap(ap(ap(cmp; RC); f); ap(idn; RC));
-        f;
-        ap(ap(ap(hom; RC); A); A)))); law_idn_rhs.
-  Σ(Π(ap(obj; RC); A. Π(ap(obj; RC); B. Π(ap(obj; RC); C. Π(ap(obj; RC); D.
-    Π(ap(ap(ap(hom; RC); A); B); f.
-    Π(ap(ap(ap(hom; RC); B); C); g.
-    Π(ap(ap(ap(hom; RC); C); D); h.
-      =(ap(ap(ap(cmp; RC); ap(ap(ap(cmp; RC); h); g)); f);
-        ap(ap(ap(cmp; RC); h); ap(ap(ap(cmp; RC); g); f));
-        ap(ap(ap(hom; RC); A); D))))))))); law_cmp_ass.
-   unit))))
-].
 
-(*
-Theorem LawCat_wf : [∀(RawCat; RC. ∈(ap(LawCat; RC); U<1>))] {
-  intro @1;
-  [ unfold <LawCat>; auto; refine <rawcat_unfold>; auto;
-    elim <RC>; auto; elim <t>; auto; elim <t'>; auto; elim <t''>; auto;
-    [ id
-    , id
-    , id
-    , id
-    ]
-  , lemma <RawCat_wf>
-  ].
-}.
-*)
-
-Cat =def= [subset(RawCat; RC. ap(LawCat; RC))].
-
-law_idn_lhs =def= [λ(RC. spread(ap(LawCat; RC); x.y.x))].
-law_idn_rhs =def= [λ(RC. spread(spread(ap(LawCat; RC); x.y.y); x.y.x))].
-law_cmp_ass =def= [λ(RC. spread(spread(spread(ap(LawCat; RC); x.y.y); x.y.y); x.y.x))].
-
-Theorem InitialRawCat : [RawCat] {
-  unfold <RawCat>;
-  intro [void]; auto;
-  intro [λ(A. λ(B. void))]; auto;
-  witness [pair(λ(A. <>); pair(λ(A. <>); <>))]; auto.
-}.
-
-Theorem TerminalRawCat : [RawCat] {
-  unfold <RawCat>;
-  intro [unit]; auto;
-  intro [λ(A. λ(B. unit))]; auto;
-  intro [λ(A. <>)]; auto;
-  intro [λ(A. λ(B. λ(C. λ(g. λ(f. <>)))))];
-  auto.
-}.
-
-RawFun =def= [
-  λ(RC.
-  λ(RD.
-  Σ(Π(ap(obj; RC); _. ap(obj; RD)); fun_obj.
-  Σ(Π(ap(obj; RC); A.
-    Π(ap(obj; RC); B.
-    Π(ap(ap(ap(hom; RC); A); B); _.
-    Π(ap(ap(ap(hom; RD); ap(fun_obj; A)); ap(fun_obj; B)); _. _)))); fun_hom.
-  unit))))
-].
+|||
+||| LawCat =def= [
+|||   λ(RC.
+|||   Σ(Π(ap(obj; RC); A.
+|||     Π(ap(ap(ap(hom; RC); A); A); f.
+|||       =(ap(ap(ap(cmp; RC); ap(idn; RC)); f);
+|||         f;
+|||         ap(ap(ap(hom; RC); A); A)))); law_idn_lhs.
+|||   Σ(Π(ap(obj; RC); A.
+|||     Π(ap(ap(ap(hom; RC); A); A); f.
+|||       =(ap(ap(ap(cmp; RC); f); ap(idn; RC));
+|||         f;
+|||         ap(ap(ap(hom; RC); A); A)))); law_idn_rhs.
+|||   Σ(Π(ap(obj; RC); A. Π(ap(obj; RC); B. Π(ap(obj; RC); C. Π(ap(obj; RC); D.
+|||     Π(ap(ap(ap(hom; RC); A); B); f.
+|||     Π(ap(ap(ap(hom; RC); B); C); g.
+|||     Π(ap(ap(ap(hom; RC); C); D); h.
+|||       =(ap(ap(ap(cmp; RC); ap(ap(ap(cmp; RC); h); g)); f);
+|||         ap(ap(ap(cmp; RC); h); ap(ap(ap(cmp; RC); g); f));
+|||         ap(ap(ap(hom; RC); A); D))))))))); law_cmp_ass.
+|||    unit))))
+||| ].
+|||
+||| (*
+||| Theorem LawCat_wf : [∀(RawCat; RC. ∈(ap(LawCat; RC); U<1>))] {
+|||   intro @1;
+|||   [ unfold <LawCat>; auto; refine <rawcat_unfold>; auto;
+|||     elim <RC>; auto; elim <t>; auto; elim <t'>; auto; elim <t''>; auto;
+|||     [ id
+|||     , id
+|||     , id
+|||     , id
+|||     ]
+|||   , lemma <RawCat_wf>
+|||   ].
+||| }.
+||| *)
+||| 
+||| Cat =def= [subset(RawCat; RC. ap(LawCat; RC))].
+||| 
+||| law_idn_lhs =def= [λ(RC. spread(ap(LawCat; RC); x.y.x))].
+||| law_idn_rhs =def= [λ(RC. spread(spread(ap(LawCat; RC); x.y.y); x.y.x))].
+||| law_cmp_ass =def= [λ(RC. spread(spread(spread(ap(LawCat; RC); x.y.y); x.y.y); x.y.x))].
+||| 
+||| Theorem InitialRawCat : [RawCat] {
+|||   unfold <RawCat>;
+|||   intro [void]; auto;
+|||   intro [λ(A. λ(B. void))]; auto;
+|||   witness [pair(λ(A. <>); pair(λ(A. <>); <>))]; auto.
+||| }.
+||| 
+||| Theorem TerminalRawCat : [RawCat] {
+|||   unfold <RawCat>;
+|||   intro [unit]; auto;
+|||   intro [λ(A. λ(B. unit))]; auto;
+|||   intro [λ(A. <>)]; auto;
+|||   intro [λ(A. λ(B. λ(C. λ(g. λ(f. <>)))))];
+|||   auto.
+||| }.
+||| 
+||| RawFun =def= [
+|||   λ(RC.
+|||   λ(RD.
+|||   Σ(Π(ap(obj; RC); _. ap(obj; RD)); fun_obj.
+|||   Σ(Π(ap(obj; RC); A.
+|||     Π(ap(obj; RC); B.
+|||     Π(ap(ap(ap(hom; RC); A); B); _.
+|||     Π(ap(ap(ap(hom; RD); ap(fun_obj; A)); ap(fun_obj; B)); _. _)))); fun_hom.
+|||   unit))))
+||| ].
+||| *)

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -29,7 +29,6 @@ Tactic rawcat_unfold {
   unfold <cmp>.
 }.
 
-
 Theorem RawCat_wf : [∈(RawCat; U<1>)] {
   refine <rawcat_unfold>; auto.
 }.
@@ -86,20 +85,20 @@ Theorem hom_wf : [
 |||   ].
 ||| }.
 ||| *)
-||| 
+|||
 ||| Cat =def= [subset(RawCat; RC. ap(LawCat; RC))].
-||| 
+|||
 ||| law_idn_lhs =def= [λ(RC. spread(ap(LawCat; RC); x.y.x))].
 ||| law_idn_rhs =def= [λ(RC. spread(spread(ap(LawCat; RC); x.y.y); x.y.x))].
 ||| law_cmp_ass =def= [λ(RC. spread(spread(spread(ap(LawCat; RC); x.y.y); x.y.y); x.y.x))].
-||| 
+|||
 ||| Theorem InitialRawCat : [RawCat] {
 |||   unfold <RawCat>;
 |||   intro [void]; auto;
 |||   intro [λ(A. λ(B. void))]; auto;
 |||   witness [pair(λ(A. <>); pair(λ(A. <>); <>))]; auto.
 ||| }.
-||| 
+|||
 ||| Theorem TerminalRawCat : [RawCat] {
 |||   unfold <RawCat>;
 |||   intro [unit]; auto;
@@ -108,7 +107,7 @@ Theorem hom_wf : [
 |||   intro [λ(A. λ(B. λ(C. λ(g. λ(f. <>)))))];
 |||   auto.
 ||| }.
-||| 
+|||
 ||| RawFun =def= [
 |||   λ(RC.
 |||   λ(RD.

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -15,6 +15,8 @@ hom =def= [λ(C. spread(spread(C; x.y.y); x.y.x))].
 idn =def= [λ(C. spread(spread(spread(C; x.y.y); x.y.y); x.y.x))].
 cmp =def= [λ(C. spread(spread(spread(spread(C; x.y.y); x.y.y); x.y.y); x.y.x))].
 
+Operator welp : (1;0;0).
+
 Tactic rawcat_unfold {
   unfold <RawCat>;
   unfold <obj>;

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -2,36 +2,68 @@ Operator MonoidSig : ().
 Operator car : (0).
 Operator ze : (0).
 Operator op : (0;0;0).
+
+Operator MonoidLaws : (0).
 Operator LeftUnit : (0).
 Operator RightUnit : (0).
+Operator Assoc : (0).
 
-[MonoidSig] =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
-[car(M)] =def= [spread(M; x.y.x)].
-[ze(M)] =def= [spread(spread(M; x.y.y); x.y.x)].
-[op(M;X;Y)] =def= ⌊ap(ap(spread(spread(M; x.y.y); x.y.y);X);Y)⌋.
-[LeftUnit(M)] =def= [∀(car(M); m. =(m; op(M; ze(M); m); car(M)))].
-[RightUnit(M)] =def= [∀(car(M); m. =(op(M; ze(M); m); m; car(M)))].
+Operator Monoid : ().
 
-Tactic monoid-unfold {
+⌊MonoidSig⌋ =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
+⌊car(M)⌋ =def= ⌊spread(M; x.y.x)⌋.
+⌊ze(M)⌋ =def= ⌊spread(spread(M; x.y.y); x.y.x)⌋.
+⌊op(M;X;Y)⌋ =def= ⌊ap(ap(spread(spread(M; x.y.y); x.y.y);X);Y)⌋.
+⌊LeftUnit(M)⌋ =def= ⌊∀(car(M); m. =(m; op(M; ze(M); m); car(M)))⌋.
+⌊RightUnit(M)⌋ =def= ⌊∀(car(M); m. =(op(M; ze(M); m); m; car(M)))⌋.
+⌊Assoc(M)⌋ =def= ⌊∀(car(M); x. ∀(car(M); y. ∀(car(M); z. =(op(M;op(M;x;y);z); op(M;x;op(M;y;z));car(M)))))⌋.
+
+⌊MonoidLaws(M)⌋ =def= ⌊Σ(LeftUnit(M); _. Σ(RightUnit(M); _. Assoc(M)))⌋.
+⌊Monoid⌋ =def= ⌊subset(MonoidSig; M. MonoidLaws(M))⌋.
+
+Tactic monoid-sig-unfold {
   unfold 〈MonoidSig〉; unfold 〈car〉; unfold 〈op〉; unfold 〈ze〉.
 }.
 
 Theorem MonoidSig-wf : ⌊∈(MonoidSig; U〈1〉)⌋ {
-  refine <monoid-unfold>; auto.
+  refine 〈monoid-sig-unfold〉; auto.
 }.
 
-
 Theorem car-wf : ⌊∀(MonoidSig; M. ∈(car(M); U〈0〉))⌋ {
-  refine 〈monoid-unfold〉; auto;
+  refine 〈monoid-sig-unfold〉; auto;
   elim 〈M〉; auto.
 }.
 
+Tactic monoid-laws-unfold {
+  unfold 〈MonoidLaws〉; unfold 〈LeftUnit〉; unfold 〈RightUnit〉; unfold 〈Assoc〉.
+}.
+
+Tactic monoid-unfold {
+  unfold 〈Monoid〉; refine 〈monoid-sig-unfold〉; refine 〈monoid-laws-unfold〉.
+}.
+
+Tactic monoid-simplify {
+  *{ refine 〈monoid-unfold〉; auto }.
+}.
+
 Theorem LeftUnit-wf : ⌊∀(MonoidSig; M. ∈(LeftUnit(M); U〈0〉))⌋ {
-  unfold 〈LeftUnit〉; refine <monoid-unfold>; auto.
+  refine 〈monoid-simplify〉.
 }.
 
 Theorem RightUnit-wf : ⌊∀(MonoidSig; M. ∈(RightUnit(M);U〈0〉))⌋ {
-  unfold 〈RightUnit〉; refine 〈monoid-unfold〉; auto.
+  refine 〈monoid-simplify〉.
+}.
+
+Theorem Assoc-wf : ⌊∀(MonoidSig; M. ∈(Assoc(M); U〈0〉))⌋ {
+  refine 〈monoid-simplify〉.
+}.
+
+Theorem MonoidLaws-wf : ⌊∀(MonoidSig; M. ∈(MonoidLaws(M); U〈0〉))⌋ {
+  refine 〈monoid-simplify〉.
+}.
+
+Theorem Monoid-wf : ⌊∈(Monoid; U〈1〉)⌋ {
+  refine 〈monoid-simplify〉.
 }.
 
 Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
@@ -40,13 +72,19 @@ Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
   intro ⌊<>⌋ ; auto.
 }.
 
-Theorem UnitMonoid-LeftUnit : ⌊LeftUnit(UnitMonoidStruct)⌋ {
-  unfold 〈UnitMonoidStruct〉; unfold 〈LeftUnit〉; refine 〈monoid-unfold〉; auto;
+Theorem UnitMonoid : ⌊Monoid⌋ {
+  unfold 〈Monoid〉;
+  intro ⌊UnitMonoidStruct⌋; unfold 〈UnitMonoidStruct〉;
+  refine 〈monoid-simplify〉;
   elim 〈m〉; auto.
+}.
+
+Theorem UnitMonoid-LeftUnit : ⌊LeftUnit(UnitMonoidStruct)⌋ {
+  unfold 〈UnitMonoidStruct〉;
+  refine 〈monoid-simplify〉; elim 〈m〉; auto.
 }.
 
 Theorem UnitMonoid-RightUnit : ⌊RightUnit(UnitMonoidStruct)⌋ {
-  unfold 〈UnitMonoidStruct〉; unfold 〈RightUnit〉; refine 〈monoid-unfold〉; auto;
-  elim 〈m〉; auto.
+  unfold 〈UnitMonoidStruct〉;
+  refine 〈monoid-simplify〉; elim 〈m〉; auto.
 }.
-

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -1,32 +1,37 @@
-MonoidSig =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
-car =def= ⌊λ(M. spread(M; x.y.x))⌋.
-ze =def= ⌊λ(M. spread(spread(M; x.y.y); x.y.x))⌋.
-op =def= ⌊λ(M. spread(spread(M; x.y.y); x.y.y))⌋.
+Operator MonoidSig : ().
+Operator car : (0).
+Operator ze : (0).
+Operator op : (0;0;0).
+Operator LeftUnit : (0).
+Operator RightUnit : (0).
 
-LeftUnit =def= ⌊λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); ap(ze;M)); m) ;ap(car;M))))⌋.
-RightUnit =def= ⌊λ(M. ∀(ap(car;M); m. =(m; ap(ap(ap(op;M); m); ap(ze;M));ap(car;M))))⌋.
+[MonoidSig] =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
+[car(M)] =def= [spread(M; x.y.x)].
+[ze(M)] =def= [spread(spread(M; x.y.y); x.y.x)].
+[op(M;X;Y)] =def= ⌊ap(ap(spread(spread(M; x.y.y); x.y.y);X);Y)⌋.
+[LeftUnit(M)] =def= [∀(car(M); m. =(m; op(M; ze(M); m); car(M)))].
+[RightUnit(M)] =def= [∀(car(M); m. =(op(M; ze(M); m); m; car(M)))].
 
 Tactic monoid-unfold {
   unfold 〈MonoidSig〉; unfold 〈car〉; unfold 〈op〉; unfold 〈ze〉.
 }.
 
 Theorem MonoidSig-wf : ⌊∈(MonoidSig; U〈1〉)⌋ {
-  refine 〈monoid-unfold〉; auto.
+  refine <monoid-unfold>; auto.
 }.
 
-Theorem car-wf : ⌊∀(MonoidSig; M. ∈(ap(car;M); U〈0〉))⌋ {
+
+Theorem car-wf : ⌊∀(MonoidSig; M. ∈(car(M); U〈0〉))⌋ {
   refine 〈monoid-unfold〉; auto;
   elim 〈M〉; auto.
 }.
 
-Theorem LeftUnit-wf : ⌊∀(MonoidSig; M. ∈(ap(LeftUnit;M);U〈0〉))⌋ {
-  unfold 〈LeftUnit〉; auto; refine 〈monoid-unfold〉;
-  auto; elim 〈M〉; auto .
+Theorem LeftUnit-wf : ⌊∀(MonoidSig; M. ∈(LeftUnit(M); U〈0〉))⌋ {
+  unfold 〈LeftUnit〉; refine <monoid-unfold>; auto.
 }.
 
-Theorem RightUnit-wf : ⌊∀(MonoidSig; M. ∈(ap(RightUnit;M);U〈0〉))⌋ {
-  unfold 〈RightUnit〉; auto; refine 〈monoid-unfold〉;
-  auto; elim 〈M〉; auto .
+Theorem RightUnit-wf : ⌊∀(MonoidSig; M. ∈(RightUnit(M);U〈0〉))⌋ {
+  unfold 〈RightUnit〉; refine 〈monoid-unfold〉; auto.
 }.
 
 Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
@@ -35,12 +40,13 @@ Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
   intro ⌊<>⌋ ; auto.
 }.
 
-Theorem UnitMonoid-LeftUnit : ⌊ap(LeftUnit;UnitMonoidStruct)⌋ {
+Theorem UnitMonoid-LeftUnit : ⌊LeftUnit(UnitMonoidStruct)⌋ {
   unfold 〈UnitMonoidStruct〉; unfold 〈LeftUnit〉; refine 〈monoid-unfold〉; auto;
   elim 〈m〉; auto.
 }.
 
-Theorem UnitMonoid-RightUnit : ⌊ap(RightUnit;UnitMonoidStruct)⌋ {
+Theorem UnitMonoid-RightUnit : ⌊RightUnit(UnitMonoidStruct)⌋ {
   unfold 〈UnitMonoidStruct〉; unfold 〈RightUnit〉; refine 〈monoid-unfold〉; auto;
   elim 〈m〉; auto.
 }.
+

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -10,81 +10,81 @@ Operator Assoc : (0).
 
 Operator Monoid : ().
 
-⌊MonoidSig⌋ =def= ⌊Σ(U〈0〉; A. Σ(A; zero. Π(A; m. Π(A; n. A))))⌋.
-⌊car(M)⌋ =def= ⌊spread(M; x.y.x)⌋.
-⌊ze(M)⌋ =def= ⌊spread(spread(M; x.y.y); x.y.x)⌋.
-⌊op(M;X;Y)⌋ =def= ⌊ap(ap(spread(spread(M; x.y.y); x.y.y);X);Y)⌋.
-⌊LeftUnit(M)⌋ =def= ⌊∀(car(M); m. =(m; op(M; ze(M); m); car(M)))⌋.
-⌊RightUnit(M)⌋ =def= ⌊∀(car(M); m. =(op(M; ze(M); m); m; car(M)))⌋.
-⌊Assoc(M)⌋ =def= ⌊∀(car(M); x. ∀(car(M); y. ∀(car(M); z. =(op(M;op(M;x;y);z); op(M;x;op(M;y;z));car(M)))))⌋.
+[MonoidSig] =def= [Σ(U<0>; A. Σ(A; zero. Π(A; m. Π(A; n. A))))].
+[car(M)] =def= [spread(M; x.y.x)].
+[ze(M)] =def= [spread(spread(M; x.y.y); x.y.x)].
+[op(M;X;Y)] =def= [ap(ap(spread(spread(M; x.y.y); x.y.y);X);Y)].
+[LeftUnit(M)] =def= [∀(car(M); m. =(m; op(M; ze(M); m); car(M)))].
+[RightUnit(M)] =def= [∀(car(M); m. =(op(M; ze(M); m); m; car(M)))].
+[Assoc(M)] =def= [∀(car(M); x. ∀(car(M); y. ∀(car(M); z. =(op(M;op(M;x;y);z); op(M;x;op(M;y;z));car(M)))))].
 
-⌊MonoidLaws(M)⌋ =def= ⌊Σ(LeftUnit(M); _. Σ(RightUnit(M); _. Assoc(M)))⌋.
-⌊Monoid⌋ =def= ⌊subset(MonoidSig; M. MonoidLaws(M))⌋.
+[MonoidLaws(M)] =def= [Σ(LeftUnit(M); _. Σ(RightUnit(M); _. Assoc(M)))].
+[Monoid] =def= [subset(MonoidSig; M. MonoidLaws(M))].
 
 Tactic monoid-sig-unfold {
-  unfold 〈MonoidSig〉; unfold 〈car〉; unfold 〈op〉; unfold 〈ze〉.
+  unfold <MonoidSig>; unfold <car>; unfold <op>; unfold <ze>.
 }.
 
-Theorem MonoidSig-wf : ⌊∈(MonoidSig; U〈1〉)⌋ {
-  refine 〈monoid-sig-unfold〉; auto.
+Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
+  refine <monoid-sig-unfold>; auto.
 }.
 
-Theorem car-wf : ⌊∀(MonoidSig; M. ∈(car(M); U〈0〉))⌋ {
-  refine 〈monoid-sig-unfold〉; auto;
-  elim 〈M〉; auto.
+Theorem car-wf : [∀(MonoidSig; M. ∈(car(M); U<0>))] {
+  refine <monoid-sig-unfold>; auto;
+  elim <M>; auto.
 }.
 
 Tactic monoid-laws-unfold {
-  unfold 〈MonoidLaws〉; unfold 〈LeftUnit〉; unfold 〈RightUnit〉; unfold 〈Assoc〉.
+  unfold <MonoidLaws>; unfold <LeftUnit>; unfold <RightUnit>; unfold <Assoc>.
 }.
 
 Tactic monoid-unfold {
-  unfold 〈Monoid〉; refine 〈monoid-sig-unfold〉; refine 〈monoid-laws-unfold〉.
+  unfold <Monoid>; refine <monoid-sig-unfold>; refine <monoid-laws-unfold>.
 }.
 
 Tactic monoid-simplify {
-  *{ refine 〈monoid-unfold〉; auto }.
+  *{ refine <monoid-unfold>; auto }.
 }.
 
-Theorem LeftUnit-wf : ⌊∀(MonoidSig; M. ∈(LeftUnit(M); U〈0〉))⌋ {
-  refine 〈monoid-simplify〉.
+Theorem LeftUnit-wf : [∀(MonoidSig; M. ∈(LeftUnit(M); U<0>))] {
+  refine <monoid-simplify>.
 }.
 
-Theorem RightUnit-wf : ⌊∀(MonoidSig; M. ∈(RightUnit(M);U〈0〉))⌋ {
-  refine 〈monoid-simplify〉.
+Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(RightUnit(M);U<0>))] {
+  refine <monoid-simplify>.
 }.
 
-Theorem Assoc-wf : ⌊∀(MonoidSig; M. ∈(Assoc(M); U〈0〉))⌋ {
-  refine 〈monoid-simplify〉.
+Theorem Assoc-wf : [∀(MonoidSig; M. ∈(Assoc(M); U<0>))] {
+  refine <monoid-simplify>.
 }.
 
-Theorem MonoidLaws-wf : ⌊∀(MonoidSig; M. ∈(MonoidLaws(M); U〈0〉))⌋ {
-  refine 〈monoid-simplify〉.
+Theorem MonoidLaws-wf : [∀(MonoidSig; M. ∈(MonoidLaws(M); U<0>))] {
+  refine <monoid-simplify>.
 }.
 
-Theorem Monoid-wf : ⌊∈(Monoid; U〈1〉)⌋ {
-  refine 〈monoid-simplify〉.
+Theorem Monoid-wf : [∈(Monoid; U<1>)] {
+  refine <monoid-simplify>.
 }.
 
-Theorem UnitMonoidStruct : ⌊MonoidSig⌋ {
-  unfold 〈MonoidSig〉;
-  intro ⌊unit⌋; auto;
-  intro ⌊<>⌋ ; auto.
+Theorem UnitMonoidStruct : [MonoidSig] {
+  unfold <MonoidSig>;
+  intro [unit]; auto;
+  intro [<>] ; auto.
 }.
 
-Theorem UnitMonoid : ⌊Monoid⌋ {
-  unfold 〈Monoid〉;
-  intro ⌊UnitMonoidStruct⌋; unfold 〈UnitMonoidStruct〉;
-  refine 〈monoid-simplify〉;
-  elim 〈m〉; auto.
+Theorem UnitMonoid : [Monoid] {
+  unfold <Monoid>;
+  intro [UnitMonoidStruct]; unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>;
+  elim <m>; auto.
 }.
 
-Theorem UnitMonoid-LeftUnit : ⌊LeftUnit(UnitMonoidStruct)⌋ {
-  unfold 〈UnitMonoidStruct〉;
-  refine 〈monoid-simplify〉; elim 〈m〉; auto.
+Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {
+  unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>; elim <m>; auto.
 }.
 
-Theorem UnitMonoid-RightUnit : ⌊RightUnit(UnitMonoidStruct)⌋ {
-  unfold 〈UnitMonoidStruct〉;
-  refine 〈monoid-simplify〉; elim 〈m〉; auto.
+Theorem UnitMonoid-RightUnit : [RightUnit(UnitMonoidStruct)] {
+  unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>; elim <m>; auto.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -6,6 +6,5 @@ Theorem squash-wf : [∀(U<0>; A. ∈(squash(A); U<0>))] {
 }.
 
 Theorem squash-intro : [∀(U<0>; A. Π(A; M. squash(A)))] {
-  auto; unfold <squash>; auto;
-  intro; auto.
+  unfold <squash>; auto.
 }.

--- a/example/squash.jonprl
+++ b/example/squash.jonprl
@@ -1,10 +1,11 @@
-squash =def= [λ(A. subset(unit; _. A))].
+Operator squash : (0).
+[squash(A)] =def= [subset(unit; _. A)].
 
-Theorem squash-wf : [∀(U<0>; A. ∈(ap(squash;A); U<0>))] {
+Theorem squash-wf : [∀(U<0>; A. ∈(squash(A); U<0>))] {
   unfold <squash>; auto.
 }.
 
-Theorem squash-intro : [∀(U<0>; A. Π(A; M. ap(squash; A)))] {
+Theorem squash-intro : [∀(U<0>; A. Π(A; M. squash(A)))] {
   auto; unfold <squash>; auto;
   intro; auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -1,6 +1,9 @@
 welp =def= ⌊unit⌋.
 welp2 =def= ⌊unit⌋.
 
+Operator mine : (1).
+hmmm =def= ⌊mine(x.x)⌋.
+
 Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
   *{ intro ; auto }.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -1,8 +1,5 @@
-welp =def= ⌊unit⌋.
-welp2 =def= ⌊unit⌋.
-
-Operator mine : (1).
-hmmm =def= ⌊mine(x.x)⌋.
+Operator welp : ().
+[welp] =def= [unit].
 
 Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
   *{ intro ; auto }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -1,45 +1,45 @@
 Operator welp : ().
 [welp] =def= [unit].
 
-Theorem test1 : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
+Theorem test1 : [Σ(unit; _. Σ(unit; _. unit))] {
   *{ intro ; auto }.
 }.
 
 ||| Lemmas defined earlier in the development may be used later on using the 'lemma' tactic.
-Theorem test1' : ⌊Σ(unit; _. Σ(unit; _. unit))⌋ {
-  lemma 〈test1〉.
+Theorem test1' : [Σ(unit; _. Σ(unit; _. unit))] {
+  lemma <test1>.
 }.
 
 ||| Abstractions may be unfolded using the 'unfold' tactic.
-Theorem test2 : ⌊Π(unit; _. Σ(unit; _. welp))⌋ {
-  unfold 〈welp〉; auto
+Theorem test2 : [Π(unit; _. Σ(unit; _. welp))] {
+  unfold <welp>; auto
 }.
 
-Theorem test3 : ⌊∈(λ(x. x); Π(unit; _. unit))⌋ {
+Theorem test3 : [∈(λ(x. x); Π(unit; _. unit))] {
   auto.
 }.
 
-Theorem test4 : ⌊∈(λ(x.pair(x;x)); Π(void;_.void))⌋ {
+Theorem test4 : [∈(λ(x.pair(x;x)); Π(void;_.void))] {
   auto.
 }.
 
-Theorem test5 : ⌊Π(void; _. Σ(unit; _.unit))⌋ {
+Theorem test5 : [Π(void; _. Σ(unit; _.unit))] {
   auto.
 }.
 
-Theorem test6 : ⌊Π(unit; _. Σ(unit; _.unit))⌋ {
-  witness ⌊λ(x. pair(x;x))⌋; auto.
+Theorem test6 : [Π(unit; _. Σ(unit; _.unit))] {
+  witness [λ(x. pair(x;x))]; auto.
 }.
 
-Theorem test7 : ⌊Π(Σ(void;_.unit); z. void)⌋ {
+Theorem test7 : [Π(Σ(void;_.unit); z. void)] {
   auto;
-  elim 〈z〉;
+  elim <z>;
   auto.
 }.
 
-Theorem axiom-of-choice : ⌊∀(U〈0〉; A. ∀(U〈0〉; B. ∀(Π(A; _. Π(B; _. U〈0〉)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))⌋ {
-  auto; intro ⌊λ(w. spread(ap(φ;w); x.y.x))⌋; auto;
-  elim 〈φ〉 ⌊a⌋; auto;
-  hyp-subst ← 〈z〉 ⌊z. ap(ap(Q;a); spread(z; x.y.x))⌋; auto;
-  elim 〈y〉; auto.
+Theorem axiom-of-choice : [∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
+  auto; intro [λ(w. spread(ap(φ;w); x.y.x))]; auto;
+  elim <φ> [a]; auto;
+  hyp-subst ← <z> [z. ap(ap(Q;a); spread(z; x.y.x))]; auto;
+  elim <y>; auto.
 }.

--- a/lib/abt-parsing-lib/parse_abt.sig
+++ b/lib/abt-parsing-lib/parse_abt.sig
@@ -2,6 +2,7 @@ signature PARSE_ABT =
 sig
   include ABT_UTIL
 
-  val parse_abt : t CharParser.charParser
+  type state
+  val parse_abt : (state -> t) CharParser.charParser
 end
 

--- a/lib/abt-parsing-lib/parse_abt.sig
+++ b/lib/abt-parsing-lib/parse_abt.sig
@@ -2,7 +2,10 @@ signature PARSE_ABT =
 sig
   include ABT_UTIL
 
-  type state
-  val parse_abt : (state -> t) CharParser.charParser
+  structure ParseOperator : PARSE_OPERATOR
+  sharing Operator = ParseOperator
+
+  type env
+  val parse_abt : env -> t CharParser.charParser
 end
 

--- a/lib/abt-parsing-lib/parse_abt_test.fun
+++ b/lib/abt-parsing-lib/parse_abt_test.fun
@@ -4,7 +4,7 @@ struct
 
   structure O : PARSE_OPERATOR =
   struct
-    type state = unit
+    type env = unit
     type t = oper
     val eq = op=
     fun arity LAM = #[1]
@@ -18,17 +18,17 @@ struct
     infix 2 return
     infixr 1 ||
 
-    val parse_operator =
-      string "λ" return (fn () => LAM)
-        || string "<>" return (fn () => AX)
-        || string "ap" return (fn () => AP)
+    fun parse_operator () =
+      string "λ" return LAM
+        || string "<>" return AX
+        || string "ap" return AP
   end
 
   structure Syn = AbtUtil(Abt(structure Operator = O and Variable = Variable()))
   structure ParseSyn = ParseAbt(structure Syntax = Syn and Operator = O)
 
-  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string (b ()) ^ "\n") pr)
-  fun doit s = print_res (CharParser.parseString ParseSyn.parse_abt s)
+  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string b ^ "\n") pr)
+  fun doit s = print_res (CharParser.parseString (ParseSyn.parse_abt ()) s)
 
   val _ =
     (doit "λ(x.λ(x.ap(x;<>)))";

--- a/lib/abt-parsing-lib/parse_abt_test.fun
+++ b/lib/abt-parsing-lib/parse_abt_test.fun
@@ -4,6 +4,7 @@ struct
 
   structure O : PARSE_OPERATOR =
   struct
+    type state = unit
     type t = oper
     val eq = op=
     fun arity LAM = #[1]
@@ -18,15 +19,15 @@ struct
     infixr 1 ||
 
     val parse_operator =
-      string "λ" return LAM
-        || string "<>" return AX
-        || string "ap" return AP
+      string "λ" return (fn () => LAM)
+        || string "<>" return (fn () => AX)
+        || string "ap" return (fn () => AP)
   end
 
   structure Syn = AbtUtil(Abt(structure Operator = O and Variable = Variable()))
   structure ParseSyn = ParseAbt(structure Syntax = Syn and Operator = O)
 
-  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string b ^ "\n") pr)
+  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string (b ()) ^ "\n") pr)
   fun doit s = print_res (CharParser.parseString ParseSyn.parse_abt s)
 
   val _ =

--- a/lib/abt-parsing-lib/parse_operator.sig
+++ b/lib/abt-parsing-lib/parse_operator.sig
@@ -2,5 +2,6 @@ signature PARSE_OPERATOR =
 sig
   include OPERATOR
 
-  val parse_operator : t CharParser.charParser
+  type state
+  val parse_operator : (state -> t) CharParser.charParser
 end

--- a/lib/abt-parsing-lib/parse_operator.sig
+++ b/lib/abt-parsing-lib/parse_operator.sig
@@ -2,6 +2,6 @@ signature PARSE_OPERATOR =
 sig
   include OPERATOR
 
-  type state
-  val parse_operator : (state -> t) CharParser.charParser
+  type env
+  val parse_operator : env -> t CharParser.charParser
 end

--- a/lib/telescopes/telescope.fun
+++ b/lib/telescopes/telescope.fun
@@ -168,7 +168,6 @@ struct
 
   local
     open SnocView
-    exception Hole
   in
     fun search (tele : 'a telescope) phi =
       let

--- a/lib/telescopes/telescopes.cm
+++ b/lib/telescopes/telescopes.cm
@@ -1,5 +1,6 @@
 Library
   signature TELESCOPE
+  signature LABEL
   functor Telescope
   functor TelescopeNotation
 is

--- a/src/conv_types.fun
+++ b/src/conv_types.fun
@@ -19,8 +19,6 @@ struct
   open Conv.Syntax
   infix $ \ $$ \\
 
-  exception Hole
-
   structure Set = SplaySet(structure Elem = Variable)
   structure Dict = SplayDict(structure Key = Variable)
 

--- a/src/conv_types.fun
+++ b/src/conv_types.fun
@@ -14,7 +14,7 @@ functor ConvCompiler (Conv : CONV_TYPES) : CONV_COMPILER =
 struct
   open Conv
 
-  type rule = {input : Syntax.t, output : Syntax.t}
+  type rule = {definiendum : Syntax.t, definiens : Syntax.t}
 
   open Conv.Syntax
   infix $ \ $$ \\
@@ -49,13 +49,13 @@ struct
       go Set.empty (out template) (out term) Dict.empty
     end
 
-  fun compile {input, output} = fn (M : Syntax.t) =>
+  fun compile {definiendum, definiens} = fn (M : Syntax.t) =>
     let
-      val inop $ inargs = out input handle _ => raise Conv
-      val outop $ outargs = out output handle _ => raise Conv
+      val inop $ inargs = out definiendum handle _ => raise Conv
+      val outop $ outargs = out definiens handle _ => raise Conv
       val Mop $ M_args = out M handle _ => raise Conv
       val _ = if Operator.eq (Mop, inop) then () else raise Conv
-      val chart = compute_chart (input, M)
+      val chart = compute_chart (definiendum, M)
 
       fun go H (p $ es) = p $$ Vector.map (go H o out) es
         | go H (x \ E) = x \\ go (Set.insert H x) (out E)
@@ -65,7 +65,7 @@ struct
             else
               Dict.lookup chart x handle _ => `` x
     in
-      go Set.empty (out output)
+      go Set.empty (out definiens)
     end
 end
 

--- a/src/conv_types.fun
+++ b/src/conv_types.fun
@@ -10,4 +10,64 @@ struct
   exception Conv
 end
 
+functor ConvCompiler (Conv : CONV_TYPES) : CONV_COMPILER =
+struct
+  open Conv
+
+  type rule = {input : Syntax.t, output : Syntax.t}
+
+  open Conv.Syntax
+  infix $ \ $$ \\
+
+  exception Hole
+
+  structure Set = SplaySet(structure Elem = Variable)
+  structure Dict = SplayDict(structure Key = Variable)
+
+  exception InvalidTemplate
+  fun compute_chart (template, term) =
+    let
+      fun go H (p $ es) (p' $ es') R =
+          if Operator.eq (p, p') then
+            let
+              open Vector
+              val zipped = tabulate (length es, fn n => (sub (es, n), sub (es', n)))
+            in
+              foldl (fn ((e,e'), R') => go H (out e) (out e') R') R zipped
+            end
+          else
+            raise InvalidTemplate
+        | go H (x \ E) (y \ E') R =
+          go (Set.insert H x) (out E) (out (subst (``x) y E')) R
+        | go H (`x) E R =
+          if Set.member H x then
+            R
+          else
+            Dict.insert R x (into E)
+        | go _ _ _ _ = raise InvalidTemplate
+    in
+      go Set.empty (out template) (out term) Dict.empty
+    end
+
+  fun compile {input, output} = fn (M : Syntax.t) =>
+    let
+      val inop $ inargs = out input handle _ => raise Conv
+      val outop $ outargs = out output handle _ => raise Conv
+      val Mop $ M_args = out M handle _ => raise Conv
+      val _ = if Operator.eq (Mop, inop) then () else raise Conv
+      val chart = compute_chart (input, M)
+
+      fun go H (p $ es) = p $$ Vector.map (go H o out) es
+        | go H (x \ E) = x \\ go (Set.insert H x) (out E)
+        | go H (` x) =
+            if Set.member H x then
+              go H (` x)
+            else
+              Dict.lookup chart x handle _ => `` x
+    in
+      go Set.empty (out output)
+    end
+end
+
 structure ConvTypes = ConvTypes (Syntax)
+structure ConvCompiler = ConvCompiler (ConvTypes)

--- a/src/conv_types.fun
+++ b/src/conv_types.fun
@@ -61,7 +61,7 @@ struct
         | go H (x \ E) = x \\ go (Set.insert H x) (out E)
         | go H (` x) =
             if Set.member H x then
-              go H (` x)
+              `` x
             else
               Dict.lookup chart x handle _ => `` x
     in

--- a/src/conv_types.sig
+++ b/src/conv_types.sig
@@ -9,3 +9,11 @@ sig
 
   exception Conv
 end
+
+signature CONV_COMPILER =
+sig
+  include CONV_TYPES
+
+  type rule = {input : Syntax.t, output : Syntax.t}
+  val compile : rule -> conv
+end

--- a/src/conv_types.sig
+++ b/src/conv_types.sig
@@ -14,6 +14,6 @@ signature CONV_COMPILER =
 sig
   include CONV_TYPES
 
-  type rule = {input : Syntax.t, output : Syntax.t}
+  type rule = {definiendum : Syntax.t, definiens : Syntax.t}
   val compile : rule -> conv
 end

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -644,10 +644,10 @@ struct
 
     fun Unfold (development, lbl) (H >> P) =
       let
-        val definiens = Development.lookup_definition development lbl
-        val rewrite = subst definiens lbl
+        open Conversionals
+        val conv = CDEEP (Development.lookup_definition development lbl)
       in
-        [ Context.map rewrite H >> rewrite P
+        [ Context.map conv H >> conv P
         ] BY (fn [D] => D
                | _ => raise Refine)
       end

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -1,20 +1,20 @@
 functor Ctt
-  (structure Syntax : ABT_UTIL
-     where Operator = Operator
+  (structure Development : DEVELOPMENT
+   structure Syntax : ABT_UTIL
+    where type Operator.t = Development.label OperatorType.operator
+
    structure Sequent : SEQUENT
      where type term = Syntax.t
      where type Context.name = Syntax.Variable.t
-   structure Lcf : LCF
-     where type goal = Sequent.sequent
-     where type evidence = Syntax.t
-   structure ConvTypes : CONV_TYPES
-     where Syntax = Syntax
-   structure Development : DEVELOPMENT
-     where Lcf = Lcf
-     where Telescope.Label = Syntax.Variable
-     where type term = Syntax.t) : CTT =
+
+   structure ConvTypes : CONV_TYPES where Syntax = Syntax
+
+   sharing type Development.Lcf.goal = Sequent.sequent
+   sharing type Development.Lcf.evidence = Syntax.t
+   sharing Development.Telescope.Label = Syntax.Variable
+   sharing type Development.term = Syntax.t) : CTT =
 struct
-  structure Lcf = Lcf
+  structure Lcf = Development.Lcf
   structure ConvTypes = ConvTypes
   structure Syntax = Syntax
 
@@ -24,12 +24,14 @@ struct
   type term = Syntax.t
   type goal = Sequent.sequent
 
+  structure Operator = Syntax.Operator
   structure Development = Development
   structure Conversionals = Conversionals
     (structure Syntax = Syntax
      structure ConvTypes = ConvTypes)
 
-  open Operator Syntax
+  open Syntax
+  open Operator OperatorType
   infix $ \
   infix 8 $$ // \\
 
@@ -728,7 +730,6 @@ end
 
 structure Ctt = Ctt
   (structure Syntax = Syntax
-   structure Lcf = Lcf
    structure ConvTypes = ConvTypes
    structure Sequent = Sequent
    structure Development = Development)

--- a/src/ctt_frontend.sml
+++ b/src/ctt_frontend.sml
@@ -5,20 +5,10 @@ struct
   fun print_development development =
     let
       open Development.Telescope
-      fun obj_to_string lbl (Development.Definition {definiens}) =
-            lbl ^ " =def= ⌊" ^ Syntax.to_string definiens ^ "⌋."
-        | obj_to_string lbl (Development.Theorem {statement, evidence,...}) =
-            let
-              val evidence' = Susp.force evidence
-            in
-              "Theorem " ^ lbl ^ " : ⌊" ^ Lcf.goal_to_string statement ^ "⌋ {\n  "
-                ^ Syntax.to_string evidence' ^ "\n} ext {\n  "
-                ^ Syntax.to_string (Extract.extract evidence') ^ "\n}."
-            end
-        | obj_to_string lbl (Development.Tactic _) =
-            "Tactic " ^ lbl ^ "."
       fun go ConsView.Empty = ()
-        | go (ConsView.Cons (lbl, obj, tele)) = (print (obj_to_string lbl obj ^ "\n\n"); go (ConsView.out tele))
+        | go (ConsView.Cons (lbl, obj, tele)) =
+            (print (Development.Object.to_string (lbl, obj) ^ "\n\n");
+             go (ConsView.out tele))
     in
       go (ConsView.out (Development.out development))
     end

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -1,17 +1,21 @@
 functor CttRuleParser
   (structure Lcf : ANNOTATED_LCF where type metadata = TacticMetadata.metadata
-   structure Syntax : PARSE_ABT
    structure Ctt : CTT_UTIL
-    where Lcf = Lcf
-    where Syntax = Syntax):
+   structure Operator : PARSE_OPERATOR
+    where type env = Ctt.Development.label -> int vector
+   sharing type Ctt.Lcf.goal = Lcf.goal
+   sharing type Ctt.Lcf.evidence = Lcf.evidence
+   sharing Ctt.Syntax.Operator = Operator):
 sig
   structure Lcf : ANNOTATED_LCF
-  type state = Ctt.Development.t
-  val parse_rule : (state -> Lcf.tactic) CharParser.charParser
+  type env = Ctt.Development.t
+  val parse_rule : env -> Lcf.tactic CharParser.charParser
 end =
 struct
   structure AnnLcf = Lcf
-  structure ParseSyntax = Syntax
+  structure ParseSyntax = ParseAbt
+    (structure Syntax = AbtUtil(Ctt.Syntax)
+     structure Operator = Operator)
   structure Tacticals = Tacticals (Lcf)
   open Ctt Lcf Tacticals ParserCombinators CharParser
   structure Lcf = AnnLcf
@@ -41,7 +45,7 @@ struct
   structure TP = TokenParser (LangDef)
   open TP Rules
 
-  type state = Development.t
+  type env = Development.t
 
   val parse_level =
     symbol "@"
@@ -60,18 +64,9 @@ struct
     fn (name, args) => fn (pos : Pos.t) =>
       Lcf.annotate ({name = name, pos = pos}, tac args)
 
-  fun astac (p, tac) = p wth (decorate_tac tac)
-  infix 2 astac
-
-  fun astac_ (p : string charParser, tac : tactic) : (Pos.t -> tactic) charParser =
-    p wth (fn name => fn (pos : Pos.t) =>
-      Lcf.annotate ({name = name, pos = pos}, tac))
-  infix 2 astac_
-
-  val parse_cum =
-    symbol "cum"
-      && opt parse_level
-      astac Cum
+  fun name_tac name tac =
+    fn (pos : Pos.t) =>
+      Lcf.annotate ({name = name, pos = pos}, tac)
 
   fun angles p =
     brackets p
@@ -81,123 +76,159 @@ struct
     middle (symbol "[") p (symbol "]")
       || middle (symbol "⌊") p (symbol "⌋")
 
-  val parse_tm =
-    quote_squares ParseSyntax.parse_abt
+  exception Hole
 
-  val parse_witness =
-    symbol "witness"
-      && parse_tm
-      astac Witness
+  type 'a intensional_parser = Development.t -> 'a charParser
+  type tactic_parser = (Pos.t -> tactic) intensional_parser
 
-  val parse_hypothesis =
-    symbol "hypothesis"
+  val parse_tm : term intensional_parser =
+    fn D => quote_squares (ParseSyntax.parse_abt (Development.lookup_operator D))
+
+  val parse_cum : tactic_parser =
+    fn D => symbol "cum"
+      && opt parse_level
+      wth (fn (name, k) => name_tac name (Cum k))
+
+  val parse_witness : tactic_parser =
+    fn D => symbol "witness"
+      && parse_tm D
+      wth (fn (name, tm) =>
+        name_tac name (Witness tm))
+
+  val parse_hypothesis : tactic_parser =
+    fn D => symbol "hypothesis"
       && angles parse_name
-      astac Hypothesis
+      wth (fn (name, z) =>
+        name_tac name (Hypothesis z))
 
-  val parse_eq_subst =
-    symbol "subst"
-      && parse_tm && parse_tm && opt parse_level
-      astac (EqSubst o flat3)
+  val parse_eq_subst : tactic_parser =
+    fn D => symbol "subst"
+      && parse_tm D && parse_tm D && opt parse_level
+      wth (fn (name, (M, (N, k))) =>
+        name_tac name (EqSubst (M, N, k)))
 
   val parse_dir =
     (symbol "→" || symbol "->") return RIGHT
       || (symbol "←" || symbol "<-") return LEFT
 
-  val parse_hyp_subst =
-    symbol "hyp-subst"
+  val parse_hyp_subst : tactic_parser =
+    fn D => symbol "hyp-subst"
       && parse_dir
       && angles parse_name
-      && parse_tm && opt parse_level
-      astac (HypEqSubst o flat4)
+      && parse_tm D && opt parse_level
+      wth (fn (name, (dir, (z, (M, k)))) =>
+        name_tac name (HypEqSubst (dir, z, M, k)))
 
-  val parse_lemma =
-    symbol "lemma"
-      && angles parse_name
-      wth (fn (name, lbl) => fn st => fn pos =>
-             Lcf.annotate ({name = name, pos = pos}, Lemma (st, lbl)))
-
-  val parse_unfold =
-    symbol "unfold"
-      && angles parse_name
-      wth (fn (name, lbl) => fn st => fn pos =>
-             Lcf.annotate ({name = name, pos = pos}, Unfold (st, lbl)))
-
-  val parse_custom_tactic =
-    symbol "refine"
-      >> angles parse_name
-      wth (fn lbl => fn st => fn (pos : Pos.t) =>
-            Lcf.annotate ({name = Syntax.Variable.to_string lbl, pos = pos}, fn goal =>
-              Development.lookup_tactic st lbl goal))
-
-  val parse_intro_args =
-    opt parse_tm
+  val parse_intro_args : intro_args intensional_parser =
+    fn D => opt (parse_tm D)
       && opt (angles parse_name)
       && opt parse_level
-      wth (fn (tm, (z, k)) => {term = tm, fresh_variable = z, level = k})
-
-  val parse_intro =
-    symbol "intro"
-      && parse_intro_args
-      astac Intro
+      wth (fn (tm, (z, k)) =>
+            {term = tm,
+             fresh_variable = z,
+             level = k})
 
   val parse_names =
     opt (angles (commaSep1 parse_name))
     wth (fn SOME xs => xs
           | NONE => [])
 
-  val parse_elim_args =
-    angles parse_name
-      && opt parse_tm
+  val parse_elim_args : elim_args intensional_parser=
+    fn D => angles parse_name
+      && opt (parse_tm D)
       && parse_names
-      wth (fn (z, (M, names)) => {target = z, term = M, names = names})
+      wth (fn (z, (M, names)) =>
+            {target = z,
+             term = M,
+             names = names})
 
-  val parse_elim =
-    symbol "elim"
-      && parse_elim_args
-      astac Elim
+  val parse_terms : term list intensional_parser =
+    fn D => opt (quote_squares (commaSep1 (ParseSyntax.parse_abt (Development.lookup_operator D))))
+    wth (fn oxs => getOpt (oxs, []))
 
-  val parse_terms =
-    opt (quote_squares (commaSep1 ParseSyntax.parse_abt))
-    wth (fn SOME xs => xs
-          | NONE => [])
-
-  val parse_eq_cd_args =
-    parse_terms
+  val parse_eq_cd_args : eq_cd_args intensional_parser =
+    fn D => (parse_terms D)
       && parse_names
       && opt parse_level
       wth (fn (Ms, (xs, k)) => {names = xs, terms = Ms, level = k})
 
+  val parse_intro =
+    fn D => symbol "intro"
+      && parse_intro_args D
+      wth (fn (name, args) => name_tac name (Intro args))
+
+  val parse_elim =
+    fn D => symbol "elim"
+      && parse_elim_args D
+      wth (fn (name, args) => name_tac name (Elim args))
+
+
   val parse_eq_cd =
-    symbol "eq-cd"
-      && parse_eq_cd_args
-      astac EqCD
+    fn D => symbol "eq-cd"
+      && (parse_eq_cd_args D)
+      wth (fn (name, args) => name_tac name (EqCD args))
 
-  val extensional_parse =
-    symbol "auto" astac_ Auto
-      || parse_intro
-      || parse_elim
-      || parse_eq_cd
-      || parse_cum
-      || symbol "mem-cd" astac_ MemCD
-      || symbol "assumption" astac_ Assumption
-      || symbol "symmetry" astac_ EqSym
-      || parse_witness
-      || parse_hyp_subst
-      || parse_eq_subst
+  val parse_symmetry : tactic_parser =
+    fn D => symbol "symmetry"
+      wth (fn name => name_tac name EqSym)
 
-  val intensional_parse =
-    parse_lemma
-      || parse_unfold
-      || parse_custom_tactic
+  val parse_assumption : tactic_parser =
+    fn D => symbol "assumption"
+      wth (fn name => name_tac name Assumption)
 
-  val parse_rule : (state -> tactic) charParser =
-    !! (intensional_parse || extensional_parse wth (fn t => fn _ => t))
-    wth (fn (t, pos) => fn st => t st pos)
+  val parse_mem_cd : tactic_parser =
+    fn D => symbol "mem-cd"
+      wth (fn name => name_tac name MemCD)
+
+  val parse_auto : tactic_parser =
+    fn D => symbol "auto"
+      wth (fn name => name_tac name Auto)
+
+  val parse_lemma : tactic_parser =
+    fn D => symbol "lemma"
+      && angles parse_name
+      wth (fn (name, lbl) => fn pos =>
+             Lcf.annotate ({name = name, pos = pos}, Lemma (D, lbl)))
+
+  val parse_unfold : tactic_parser =
+    fn D => symbol "unfold"
+      && angles parse_name
+      wth (fn (name, lbl) => fn pos =>
+             Lcf.annotate ({name = name, pos = pos}, Unfold (D, lbl)))
+
+  val parse_custom_tactic : tactic_parser =
+    fn D => symbol "refine"
+      >> angles parse_name
+      wth (fn lbl => fn (pos : Pos.t) =>
+            Lcf.annotate ({name = Syntax.Variable.to_string lbl, pos = pos}, fn goal =>
+              Development.lookup_tactic D lbl goal))
+
+  fun tactic_parsers D =
+    parse_lemma D
+      || parse_unfold D
+      || parse_custom_tactic D
+      || parse_witness D
+      || parse_hypothesis D
+      || parse_eq_subst D
+      || parse_hyp_subst D
+      || parse_intro D
+      || parse_elim D
+      || parse_eq_cd D
+      || parse_cum D
+      || parse_auto D
+      || parse_mem_cd D
+      || parse_assumption D
+      || parse_symmetry D
+
+  val parse_rule : Development.t -> tactic charParser =
+    fn D => !! (tactic_parsers D)
+    wth (fn (t, pos) => t pos)
 
 end
 
 structure CttRuleParser = CttRuleParser
-  (structure Ctt = CttUtil
+  (structure Operator = Syntax.ParseOperator
+   structure Ctt = CttUtil
    structure Lcf = AnnotatedLcf
    structure Development = Development
    structure Syntax = Syntax)

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -231,5 +231,9 @@ structure CttRuleParser = CttRuleParser
    structure Development = Development
    structure Syntax = Syntax)
 
-structure CttScript = TacticScript (CttRuleParser)
+structure CttScript = TacticScript
+  (struct
+    structure LcfApart = Lcf
+    open CttRuleParser
+   end)
 

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -76,8 +76,6 @@ struct
     middle (symbol "[") p (symbol "]")
       || middle (symbol "⌊") p (symbol "⌋")
 
-  exception Hole
-
   type 'a intensional_parser = Development.t -> 'a charParser
   type tactic_parser = (Pos.t -> tactic) intensional_parser
 

--- a/src/development.fun
+++ b/src/development.fun
@@ -96,6 +96,11 @@ struct
     case Telescope.lookup T lbl of
          Object.Tactic tac => tac
        | _ => raise Subscript
+
+  fun lookup_operator T lbl =
+    case Telescope.lookup T lbl of
+         Object.Operator {arity} => arity
+       | _ => raise Subscript
 end
 
 structure Development : DEVELOPMENT = Development

--- a/src/development.fun
+++ b/src/development.fun
@@ -1,6 +1,7 @@
 functor Development
   (structure Syntax : ABT_UTIL
    structure Lcf : LCF
+    where type evidence = Syntax.t
    structure Extract : EXTRACT
     where type evidence = Lcf.evidence
     where type term = Syntax.t
@@ -12,17 +13,35 @@ struct
   type label = Telescope.label
   type term = Syntax.t
 
-  type definition = {definiens : term}
-  type theorem =
-    {statement : Lcf.goal,
-     script : Lcf.tactic,
-     evidence : Lcf.evidence Susp.susp}
+  structure Object =
+  struct
+    type definition = {definiens : term}
+    type theorem =
+      {statement : Lcf.goal,
+       script : Lcf.tactic,
+       evidence : Lcf.evidence Susp.susp}
 
-  datatype object =
-      Definition of definition
-    | Theorem of theorem
-    | Tactic of Lcf.tactic
+    datatype t =
+        Definition of definition
+      | Theorem of theorem
+      | Tactic of Lcf.tactic
 
+    fun to_string (lbl, Definition {definiens}) =
+              Telescope.Label.to_string lbl ^ " =def= ⌊" ^ Syntax.to_string definiens ^ "⌋."
+      | to_string (lbl, Theorem {statement, evidence,...}) =
+          let
+            val evidence' = Susp.force evidence
+          in
+            "Theorem " ^ Telescope.Label.to_string lbl
+              ^ " : ⌊" ^ Lcf.goal_to_string statement ^ "⌋ {\n  "
+              ^ Syntax.to_string evidence' ^ "\n} ext {\n  "
+              ^ Syntax.to_string (Extract.extract evidence') ^ "\n}."
+          end
+      | to_string (lbl, Tactic _) =
+          "Tactic " ^ Telescope.Label.to_string lbl ^ "."
+  end
+
+  type object = Object.t
   type t = object Telescope.telescope
   fun out t = t
 
@@ -31,14 +50,14 @@ struct
   exception RemainingSubgoals of Lcf.goal list
 
   fun define T (lbl, tm) =
-    Telescope.snoc T (lbl, Definition {definiens = tm})
+    Telescope.snoc T (lbl, Object.Definition {definiens = tm})
 
   fun prove T (lbl, goal, tac) =
     let
       val (subgoals, validation) = tac goal
     in
       case subgoals of
-           [] => Telescope.snoc T (lbl, Theorem
+           [] => Telescope.snoc T (lbl, Object.Theorem
                   {statement = goal,
                    script = tac,
                    evidence = Susp.delay (fn _ => validation [])})
@@ -46,22 +65,22 @@ struct
     end
 
   fun define_tactic T (lbl, tac) =
-    Telescope.snoc T (lbl, Tactic tac)
+    Telescope.snoc T (lbl, Object.Tactic tac)
 
   fun lookup_definition T lbl =
     case Telescope.lookup T lbl of
-         Definition {definiens} => definiens
-       | Theorem {evidence,...} => Extract.extract (Susp.force evidence)
+         Object.Definition {definiens} => definiens
+       | Object.Theorem {evidence,...} => Extract.extract (Susp.force evidence)
        | _ => raise Subscript
 
   fun lookup_theorem T lbl =
     case Telescope.lookup T lbl of
-         Theorem {statement,evidence,...} => {statement = statement, evidence = evidence}
+         Object.Theorem {statement,evidence,...} => {statement = statement, evidence = evidence}
        | _ => raise Subscript
 
   fun lookup_tactic T lbl =
     case Telescope.lookup T lbl of
-         Tactic tac => tac
+         Object.Tactic tac => tac
        | _ => raise Subscript
 end
 

--- a/src/development.fun
+++ b/src/development.fun
@@ -41,7 +41,7 @@ struct
             val evidence' = Susp.force evidence
           in
             "Theorem " ^ Telescope.Label.to_string lbl
-              ^ " : ⌊" ^ Lcf.goal_to_string statement ^ "⌋ {\n  "
+              ^ " : ⸤" ^ Lcf.goal_to_string statement ^ "⸥ {\n  "
               ^ Syntax.to_string evidence' ^ "\n} ext {\n  "
               ^ Syntax.to_string (Extract.extract evidence') ^ "\n}."
           end
@@ -54,8 +54,8 @@ struct
             ^ (case conversion of
                    NONE => ""
                   | SOME ({definiendum, definiens}, _) =>
-                       "\n⌊" ^ Syntax.to_string definiendum ^ "⌋ =def= "
-                       ^ "⌊" ^ Syntax.to_string definiens ^ "⌋.")
+                       "\n⸤" ^ Syntax.to_string definiendum ^ "⸥ ≝ "
+                       ^ "⸤" ^ Syntax.to_string definiens ^ "⸥.")
   end
 
   type object = Object.t

--- a/src/development.fun
+++ b/src/development.fun
@@ -84,7 +84,6 @@ struct
   fun declare_operator T (lbl, arity) =
     Telescope.snoc T (lbl, Object.Operator {arity = arity, conversion = NONE})
 
-  exception Hole
   local
     open Syntax
     infix $

--- a/src/development.sig
+++ b/src/development.sig
@@ -6,18 +6,14 @@ sig
   structure Telescope : TELESCOPE
   type label = Telescope.label
 
-  type definition = {definiens : term}
-  type theorem =
-    {statement : Lcf.goal,
-     script : Lcf.tactic,
-     evidence : Lcf.evidence Susp.susp}
+  structure Object :
+  sig
+    type t
+    val to_string : label * t -> string
+  end
 
   type t
-
-  datatype object =
-      Definition of definition
-    | Theorem of theorem
-    | Tactic of Lcf.tactic
+  type object = Object.t
 
   val out : t -> object Telescope.telescope
 

--- a/src/development.sig
+++ b/src/development.sig
@@ -41,4 +41,7 @@ sig
 
   (* lookup a custom tactic *)
   val lookup_tactic : t -> label -> Lcf.tactic
+
+  (* lookup a custom operator *)
+  val lookup_operator : t -> label -> int vector
 end

--- a/src/development.sig
+++ b/src/development.sig
@@ -30,6 +30,9 @@ sig
   (* extend a development with a custom tactic *)
   val define_tactic : t -> label * Lcf.tactic -> t
 
+  (* extend a development with a new operator *)
+  val declare_operator : t -> label * int vector -> t
+
   (* lookup the definiens *)
   val lookup_definition : t -> label -> term
 

--- a/src/development.sig
+++ b/src/development.sig
@@ -3,8 +3,11 @@ sig
   type term
 
   structure Lcf : LCF
+  structure ConvCompiler : CONV_COMPILER
   structure Telescope : TELESCOPE
   type label = Telescope.label
+
+  sharing type ConvCompiler.Syntax.t = term
 
   structure Object :
   sig
@@ -20,9 +23,6 @@ sig
   (* the empty development *)
   val empty : t
 
-  (* extend a development with a definition *)
-  val define : t -> label * term -> t
-
   (* extend a development with a theorem *)
   val prove : t -> label * Lcf.goal * Lcf.tactic -> t
   exception RemainingSubgoals of Lcf.goal list
@@ -32,9 +32,10 @@ sig
 
   (* extend a development with a new operator *)
   val declare_operator : t -> label * int vector -> t
+  val define_operator : t -> ConvCompiler.rule -> t
 
   (* lookup the definiens *)
-  val lookup_definition : t -> label -> term
+  val lookup_definition : t -> label -> ConvCompiler.conv
 
   (* lookup the statement & evidence of a theorem *)
   val lookup_theorem : t -> label -> {statement : Lcf.goal, evidence : Lcf.evidence Susp.susp}

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -44,9 +44,7 @@ struct
 
   val lookup_operator = Development.lookup_operator
 
-  fun parse_tm D  =
-    middle (symbol "[") (Syntax.parse_abt (lookup_operator D)) (symbol "]")
-      || middle (symbol "⌊") (Syntax.parse_abt (lookup_operator D)) (symbol "⌋")
+  val parse_tm  = squares o Syntax.parse_abt o lookup_operator
 
   val parse_name =
     identifier

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -1,6 +1,8 @@
 functor DevelopmentParser
-  (structure Syntax : PARSE_ABT
-   structure Development : DEVELOPMENT
+  (structure Development : DEVELOPMENT
+   structure Syntax : PARSE_ABT
+    where type Operator.t = Development.Telescope.Label.t OperatorType.operator
+    where type env = Development.Telescope.Label.t -> int vector
    structure Sequent : SEQUENT
    structure TacticScript : TACTIC_SCRIPT
 
@@ -8,7 +10,7 @@ functor DevelopmentParser
    sharing TacticScript.Lcf = Development.Lcf
    sharing type Development.term = Syntax.t
    sharing type Sequent.term = Development.term
-   sharing type TacticScript.state = Development.t
+   sharing type TacticScript.env = Development.t
    sharing type TacticScript.Lcf.goal = Sequent.sequent
   ) : DEVELOPMENT_PARSER =
 struct
@@ -18,7 +20,7 @@ struct
   infix 2 return wth suchthat return guard when
   infixr 1 || <|>
   infixr 3 &&
-  infixr 4 << >>
+  infixr 4 << >> --
 
   structure LangDef :> LANGUAGE_DEF =
   struct
@@ -40,26 +42,29 @@ struct
   structure TP = TokenParser (LangDef)
   open TP
 
-  val parse_tm =
-    middle (symbol "[") Syntax.parse_abt (symbol "]")
-      || middle (symbol "⌊") Syntax.parse_abt (symbol "⌋")
+  val lookup_operator = Development.lookup_operator
+
+  fun parse_tm D  =
+    middle (symbol "[") (Syntax.parse_abt (lookup_operator D)) (symbol "]")
+      || middle (symbol "⌊") (Syntax.parse_abt (lookup_operator D)) (symbol "⌋")
 
   val parse_name =
     identifier
       wth Syntax.Variable.named
 
-  val parse_definition =
+  fun parse_definition D =
     parse_name << symbol "=def="
-      && parse_tm
-      wth (fn (definiendum, definiens) => fn D =>
+      && parse_tm D
+      wth (fn (definiendum, definiens) =>
              Development.define D (definiendum, definiens))
 
-  val parse_theorem =
+  fun parse_theorem D =
     reserved "Theorem" >> parse_name << colon
-      && parse_tm
-      && braces TacticScript.parse
-      wth (fn (thm, (M, tac)) => fn D =>
-             Development.prove D (thm, Sequent.>> (Sequent.Context.empty, M), tac D))
+      && parse_tm D
+      && braces (TacticScript.parse D)
+      wth (fn (thm, (M, tac)) =>
+             Development.prove D
+              (thm, Sequent.>> (Sequent.Context.empty, M), tac))
 
   val parse_int =
     repeat1 digit wth valOf o Int.fromString o String.implode
@@ -68,20 +73,28 @@ struct
     parens (semiSep parse_int)
     wth Vector.fromList
 
-  val parse_tactic =
+  fun parse_tactic D =
     reserved "Tactic" >> parse_name
-      && braces TacticScript.parse
-      wth (fn (lbl, tac) => fn D => Development.define_tactic D (lbl, tac D))
+      && braces (TacticScript.parse D)
+      wth (fn (lbl, tac) => Development.define_tactic D (lbl, tac))
 
-  val parse_operator_decl =
+  fun parse_operator_decl D =
     reserved "Operator" >> parse_name << colon
       && parse_arity
-      wth (fn (lbl, arity) => fn D => Development.declare_operator D (lbl, arity))
+      wth (fn (lbl, arity) => Development.declare_operator D (lbl, arity))
 
-  fun parse dev =
-    sepEnd (parse_definition || parse_theorem || parse_tactic || parse_operator_decl) dot << not any
-      wth (foldl (fn (K, D) => K D) dev)
+  fun parse_decl D =
+    parse_definition D
+      || parse_theorem D
+      || parse_tactic D
+      || parse_operator_decl D
 
+  fun parse' D () =
+    (parse_decl D << dot) -- (fn D' =>
+      $ (parse' D') <|>
+      (whiteSpace >> not any) return D')
+
+  fun parse D = ($ (parse' D))
 end
 
 structure CttDevelopmentParser = DevelopmentParser

--- a/src/extract.fun
+++ b/src/extract.fun
@@ -1,11 +1,13 @@
-functor Extract (Syn : ABT_UTIL where Operator = Operator) : EXTRACT =
+functor Extract (Syn : ABT_UTIL where type Operator.t = StringVariable.t OperatorType.operator) : EXTRACT =
 struct
   type evidence = Syn.t
   type term = Syn.t
 
   exception MalformedEvidence of Syn.t
 
-  open Syn Operator
+  open Syn
+  open Operator
+  open OperatorType
   infix $ \ $$ \\ //
 
   val ax = AX $$ #[]

--- a/src/operator.sml
+++ b/src/operator.sml
@@ -92,6 +92,7 @@ struct
     | eq (EQ, EQ) = true
     | eq (MEM, MEM) = true
     | eq (SUBSET, SUBSET) = true
+    | eq (CUSTOM o1, CUSTOM o2) = Label.eq (#label o1, #label o2)
     | eq _ = false
 
   fun arity O =

--- a/src/syntax.sml
+++ b/src/syntax.sml
@@ -1,15 +1,50 @@
 structure Syntax : PARSE_ABT =
 struct
-  structure V = StringVariable
+  structure V =
+  struct
+    structure Label = StringVariable
+
+    local
+      open ParserCombinators CharParser
+      infix 2 return wth suchthat return guard when
+      infixr 1 ||
+      infixr 4 << >>
+
+      structure LangDef :> LANGUAGE_DEF =
+      struct
+        type scanner = char CharParser.charParser
+        val commentStart = SOME "(*"
+        val commentEnd = SOME "*)"
+        val commentLine = SOME "|||"
+        val nestedComments = false
+
+        val identLetter = CharParser.letter || CharParser.oneOf (String.explode "-'_ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσΤτΥυΦφΧχΨψΩω") || CharParser.digit
+        val identStart = identLetter
+        val opStart = fail "Operators not supported" : scanner
+        val opLetter = opStart
+        val reservedNames = []
+        val reservedOpNames = []
+        val caseSensitive = true
+      end
+
+      structure TP = TokenParser (LangDef)
+      open TP
+    in
+      val parse_label : Label.t CharParser.charParser = identifier
+    end
+
+  end
+
+  structure Operator = Operator (V)
   structure Abt = Abt
     (structure Operator = Operator
-     structure Variable = V)
+     structure Variable = V.Label)
 
   structure MyOp = Operator
   structure ParseAbt = ParseAbt
     (structure Syntax = AbtUtil(Abt)
      structure Operator = Operator)
-  open ParseAbt
+  open ParseAbt OperatorType
 
   local
     infix $ \

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -1,10 +1,10 @@
 functor TacticScript
   (structure Lcf : ANNOTATED_LCF where type metadata = TacticMetadata.metadata
-   type state
-   val parse_rule : (state -> Lcf.tactic) CharParser.charParser) : TACTIC_SCRIPT =
+   type env
+   val parse_rule : env -> Lcf.tactic CharParser.charParser) : TACTIC_SCRIPT =
 struct
   structure Lcf = Lcf
-  type state = state
+  type env = env
 
   structure Tacticals = Tacticals (Lcf)
   open Lcf Tacticals ParserCombinators CharParser
@@ -43,33 +43,33 @@ struct
     !! (symbol "fail") wth (fn (name, pos) =>
       Lcf.annotate ({name = name, pos = pos}, FAIL))
 
-  fun parse_script () : (state -> tactic) charParser =
-    separate1 ((squares (commaSep ($ parse_script)) wth Sum.INL) <|> ($ plain wth Sum.INR)) semi
-    wth (foldl (fn (t1, t2) => fn s =>
+  fun parse_script D () : tactic charParser =
+    separate1 ((squares (commaSep ($ (parse_script D))) wth Sum.INL) <|> ($ (plain D) wth Sum.INR)) semi
+    wth (foldl (fn (t1, t2) =>
                    case t1 of
-                        Sum.INR t => THEN (t2 s, t s)
-                      | Sum.INL x => THENL (t2 s, map (fn t' => t' s) x)) (fn _ => ID))
+                        Sum.INR t => THEN (t2, t)
+                      | Sum.INL ts => THENL (t2, ts)) ID)
 
-  and plain () =
-    parse_rule
-      || $ parse_try
-      || $ parse_repeat
-      || $ parse_orelse
-      || parse_id wth (fn tac => fn _ => tac)
-      || parse_fail wth (fn tac => fn _ => tac)
+  and plain D () =
+    parse_rule D
+      || $ (parse_try D)
+      || $ (parse_repeat D)
+      || $ (parse_orelse D)
+      || parse_id
+      || parse_fail
 
-  and parse_try () =
-        middle (symbol "?{") ($ parse_script) (symbol "}")
-          wth (fn t => TRY o t)
+  and parse_try D () =
+        middle (symbol "?{") ($ (parse_script D)) (symbol "}")
+          wth TRY
 
-  and parse_repeat () =
-        middle (symbol "*{") ($ parse_script) (symbol "}")
-          wth (fn t => REPEAT o t)
+  and parse_repeat D () =
+        middle (symbol "*{") ($ (parse_script D)) (symbol "}")
+          wth REPEAT
 
-  and parse_orelse () =
-        parens (separate1 ($ parse_script) pipe)
-        wth foldl (fn (t1, t2) => fn s => ORELSE (t1 s, t2 s)) (fn _ => FAIL)
+  and parse_orelse D () =
+        parens (separate1 ($ (parse_script D)) pipe)
+        wth foldl ORELSE FAIL
 
-  val parse = $ parse_script << opt (dot || semi)
+  fun parse D = $ (parse_script D) << opt (dot || semi)
 end
 

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -1,12 +1,16 @@
 functor TacticScript
   (structure Lcf : ANNOTATED_LCF where type metadata = TacticMetadata.metadata
+   structure LcfApart : LCF_APART
+     where type goal = Lcf.goal
+     where type evidence = Lcf.evidence
+
    type env
    val parse_rule : env -> Lcf.tactic CharParser.charParser) : TACTIC_SCRIPT =
 struct
   structure Lcf = Lcf
   type env = env
 
-  structure Tacticals = Tacticals (Lcf)
+  structure Tacticals = ProgressTacticals (LcfApart)
   open Lcf Tacticals ParserCombinators CharParser
   infix 2 return wth suchthat return guard when
   infixr 1 || <|>
@@ -64,7 +68,7 @@ struct
 
   and parse_repeat D () =
         middle (symbol "*{") ($ (parse_script D)) (symbol "}")
-          wth REPEAT
+          wth LIMIT
 
   and parse_orelse D () =
         parens (separate1 ($ (parse_script D)) pipe)

--- a/src/tactic_script.sig
+++ b/src/tactic_script.sig
@@ -2,6 +2,6 @@ signature TACTIC_SCRIPT =
 sig
   structure Lcf : LCF
 
-  type state
-  val parse : (state -> Lcf.tactic) CharParser.charParser
+  type env
+  val parse : env -> Lcf.tactic CharParser.charParser
 end


### PR DESCRIPTION
This is to resolve #51.
- [x] support declaring and parsing new operators of arbitrary arity
- [x] change rewrites/definitions to support rewriting operators of arbitrary arity
- [x] remove hard-to-type characters from source language; add example `pretty-mode` pattern declaration to `README`

Currently, this does nothing to enforce well-scopedness of definitions.
