### PR TITLE
Revisiting names

### DIFF
--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -117,7 +117,7 @@ Tactic cat_unfold {
 
 Theorem Cat-wf : [∈(Cat; U<1>)] {
   *{refine <cat_unfold>; auto};
-  elim #0; auto.
+  elim #1; auto.
 }.
 
 Theorem InitialRawCat : [RawCat] {
@@ -131,7 +131,7 @@ Theorem InitialCat : [Cat] {
   unfold <Cat>;
   intro [InitialRawCat] @0; unfold <InitialRawCat>;
   *{refine <lawcat_unfold>; auto};
-  elim #0; auto.
+  elim #1; auto.
 }.
 
 Theorem TerminalRawCat : [RawCat] {
@@ -147,6 +147,5 @@ Theorem TerminalCat : [Cat] {
   unfold <Cat>;
   intro [TerminalRawCat] <C> @0; unfold <TerminalRawCat>;
   *{refine <lawcat_unfold>; auto};
-  ?{elim #2; auto};
-  elim #0; auto.
+  elim #3; auto
 }.

--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -117,7 +117,7 @@ Tactic cat_unfold {
 
 Theorem Cat-wf : [∈(Cat; U<1>)] {
   *{refine <cat_unfold>; auto};
-  elim <C>; auto.
+  elim #0; auto.
 }.
 
 Theorem InitialRawCat : [RawCat] {
@@ -131,7 +131,7 @@ Theorem InitialCat : [Cat] {
   unfold <Cat>;
   intro [InitialRawCat] @0; unfold <InitialRawCat>;
   *{refine <lawcat_unfold>; auto};
-  elim <C>; auto.
+  elim #0; auto.
 }.
 
 Theorem TerminalRawCat : [RawCat] {
@@ -147,6 +147,6 @@ Theorem TerminalCat : [Cat] {
   unfold <Cat>;
   intro [TerminalRawCat] <C> @0; unfold <TerminalRawCat>;
   *{refine <lawcat_unfold>; auto};
-  ?{elim <f>; auto};
-  elim <C>; auto.
+  ?{elim #2; auto};
+  elim #0; auto.
 }.

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -22,7 +22,7 @@ Operator Monoid : ().
 [Monoid] =def= [subset(MonoidSig; M. MonoidLaws(M))].
 
 Tactic monoid-sig-unfold {
-  unfold <MonoidSig>; unfold <car>; unfold <op>; unfold <ze>.
+  unfold <MonoidSig car op ze>
 }.
 
 Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
@@ -30,12 +30,11 @@ Theorem MonoidSig-wf : [∈(MonoidSig; U<1>)] {
 }.
 
 Theorem car-wf : [∀(MonoidSig; M. ∈(car(M); U<0>))] {
-  refine <monoid-sig-unfold>; auto;
-  elim <M>; auto.
+  refine <monoid-sig-unfold>; auto.
 }.
 
 Tactic monoid-laws-unfold {
-  unfold <MonoidLaws>; unfold <LeftUnit>; unfold <RightUnit>; unfold <Assoc>.
+  unfold <MonoidLaws LeftUnit RightUnit Assoc>
 }.
 
 Tactic monoid-unfold {
@@ -76,15 +75,15 @@ Theorem UnitMonoid : [Monoid] {
   unfold <Monoid>;
   intro [UnitMonoidStruct] @0; unfold <UnitMonoidStruct>;
   refine <monoid-simplify>;
-  elim <m>; auto.
+  elim #0; auto.
 }.
 
 Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim <m>; auto.
+  refine <monoid-simplify>; elim #0; auto.
 }.
 
 Theorem UnitMonoid-RightUnit : [RightUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim <m>; auto.
+  refine <monoid-simplify>; elim #0; auto.
 }.

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -54,15 +54,15 @@ Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(RightUnit(M);U<0>))] {
 }.
 
 Theorem Assoc-wf : [∀(MonoidSig; M. ∈(Assoc(M); U<0>))] {
-  refine <monoid-simplify>.
+  refine <monoid-simplify>; elim #1; auto; elim #3; auto
 }.
 
 Theorem MonoidLaws-wf : [∀(MonoidSig; M. ∈(MonoidLaws(M); U<0>))] {
-  refine <monoid-simplify>.
+  refine <monoid-simplify>; elim #1; auto; elim #3; auto
 }.
 
 Theorem Monoid-wf : [∈(Monoid; U<1>)] {
-  refine <monoid-simplify>.
+  refine <monoid-simplify>; elim #1; auto; elim #3; auto
 }.
 
 Theorem UnitMonoidStruct : [MonoidSig] {
@@ -75,15 +75,16 @@ Theorem UnitMonoid : [Monoid] {
   unfold <Monoid>;
   intro [UnitMonoidStruct] @0; unfold <UnitMonoidStruct>;
   refine <monoid-simplify>;
-  elim #0; auto.
+  elim #1; auto;
+  elim #3; auto
 }.
 
 Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim #0; auto.
+  refine <monoid-simplify>; elim #1; auto.
 }.
 
 Theorem UnitMonoid-RightUnit : [RightUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim #0; auto.
+  refine <monoid-simplify>; elim #1; auto.
 }.

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -54,15 +54,15 @@ Theorem RightUnit-wf : [∀(MonoidSig; M. ∈(RightUnit(M);U<0>))] {
 }.
 
 Theorem Assoc-wf : [∀(MonoidSig; M. ∈(Assoc(M); U<0>))] {
-  refine <monoid-simplify>; elim #1; auto; elim #3; auto
+  refine <monoid-simplify>.
 }.
 
 Theorem MonoidLaws-wf : [∀(MonoidSig; M. ∈(MonoidLaws(M); U<0>))] {
-  refine <monoid-simplify>; elim #1; auto; elim #3; auto
+  refine <monoid-simplify>.
 }.
 
 Theorem Monoid-wf : [∈(Monoid; U<1>)] {
-  refine <monoid-simplify>; elim #1; auto; elim #3; auto
+  refine <monoid-simplify>.
 }.
 
 Theorem UnitMonoidStruct : [MonoidSig] {
@@ -75,8 +75,7 @@ Theorem UnitMonoid : [Monoid] {
   unfold <Monoid>;
   intro [UnitMonoidStruct] @0; unfold <UnitMonoidStruct>;
   refine <monoid-simplify>;
-  elim #1; auto;
-  elim #3; auto
+  elim #1; auto.
 }.
 
 Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {

--- a/example/polynomials.jonprl
+++ b/example/polynomials.jonprl
@@ -64,3 +64,41 @@ Theorem Pullback_wf : [
 ] {
   unfold <Pullback Bundle Fiber map dom fst snd>; auto
 }.
+
+Operator Polynomial : ().
+[Polynomial] =def= [Σ(U<0>; Base. Bundle(Base))].
+
+Theorem Polynomail_wf : [
+  ∈(Polynomial; U<1>)
+] {
+  unfold <Polynomial Bundle>; auto
+}.
+
+Operator base : (0).
+[base(E)] =def= [fst(E)].
+
+Operator bundle : (0).
+[bundle(E)] =def= [snd(E)].
+
+Operator Yoneda : (0;0).
+[Yoneda(B;X)] =def= [Π(B; _. X)].
+
+Theorem Yoneda_wf : [
+  ∀(U<0>; B.
+  ∀(U<0>; X.
+    ∈(Yoneda(B;X); U<0>)))
+] {
+  unfold <Yoneda>; auto.
+}.
+
+Operator Ext : (0;0).
+[Ext(E;X)] =def= [Σ(base(E); b. Yoneda(X; Fiber(base(E); bundle(E); b)))].
+
+Theorem Ext_wf : [
+  ∀(Polynomial; E.
+  ∀(U<0>; X.
+    ∈(Ext(E;X); U<1>)))
+] {
+  unfold <Polynomial Ext Bundle base Yoneda Fiber bundle dom map fst snd>; auto;
+  unfold <snd>; auto
+}.

--- a/example/polynomials.jonprl
+++ b/example/polynomials.jonprl
@@ -56,7 +56,6 @@ Operator Pullback : (0;0;0).
   Σ(dom(f); x. Fiber(B; g; map(f; x)))
 ].
 
-||| FIXME
 Theorem Pullback_wf : [
   ∀(U<0>; B.
   ∀(Bundle(B); f.

--- a/example/polynomials.jonprl
+++ b/example/polynomials.jonprl
@@ -6,37 +6,38 @@ Operator Bundle : (0).
   unit))
 ].
 
+Operator fst : (0).
+[fst(p)] =def= [spread(p; x.y.x)].
+
+Operator snd : (0).
+[snd(p)] =def= [spread(p; x.y.y)].
+
 Operator dom : (0).
-[dom(f)] =def= [spread(f; x.y.x)].
+[dom(f)] =def= [fst(f)].
 
 Operator map : (0;0).
-[map(f;b)] =def= [ap(spread(spread(f; x.y.y); x.y.x); b)].
+[map(f;b)] =def= [ap(fst(snd(f)); b)].
 
 Theorem Bundle_wf : [
   ∀(U<0>; B. ∈(Bundle(B); U<1>))
 ] {
-  unfold <Bundle>; auto.
+  unfold <Bundle>; auto
 }.
 
 Theorem dom_wf : [
   ∀(U<0>; B. ∀(Bundle(B); f. ∈(dom(f); U<0>)))
 ] {
-  unfold <Bundle>;
-  unfold <dom>;
-  auto.
+  unfold <Bundle map dom fst>; auto
 }.
 
 Theorem map_wf : [
   ∀(U<0>; B. ∀(Bundle(B); f. ∀(dom(f); x. ∈(map(f; x); B))))
 ] {
-  unfold <Bundle>;
-  unfold <dom>;
-  unfold <map>;
-  auto.
+  unfold <Bundle dom map fst snd>; auto.
 }.
 
-Operator Fiber : (0;0).
-[Fiber(f; b)] =def= [
+Operator Fiber : (0;0;0).
+[Fiber(B; f; b)] =def= [
   Σ(dom(f); x. =(b; map(f; x); B))
 ].
 
@@ -44,17 +45,15 @@ Theorem Fiber_wf : [
   ∀(U<0>; B.
   ∀(Bundle(B); f.
   ∀(B; b.
-    ∈(Fiber(f; b); U<0>))))
+    ∈(Fiber(B; f; b); U<0>))))
 ] {
-  unfold <Bundle>; auto;
-  unfold <Fiber>; auto;
-  unfold <dom>; auto;
-  unfold <map>; auto.
+  unfold <Bundle Fiber dom map fst snd>; auto
+
 }.
 
-Operator Pullback : (0;0).
-[Pullback(f; g)] =def= [
-  Σ(dom(f); x. Fiber(g; map(f; x)))
+Operator Pullback : (0;0;0).
+[Pullback(B; f; g)] =def= [
+  Σ(dom(f); x. Fiber(B; g; map(f; x)))
 ].
 
 ||| FIXME
@@ -62,7 +61,7 @@ Theorem Pullback_wf : [
   ∀(U<0>; B.
   ∀(Bundle(B); f.
   ∀(Bundle(B); g.
-    ∈(Pullback(f; g); U<0>))))
+    ∈(Pullback(B; f; g); U<0>))))
 ] {
-  auto.
+  unfold <Pullback Bundle Fiber map dom fst snd>; auto
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -33,13 +33,13 @@ Theorem test6 : [Π(unit; _. Σ(unit; _.unit))] {
 
 Theorem test7 : [Π(Σ(void;_.unit); z. void)] {
   auto;
-  elim <z>;
+  elim #0;
   auto.
 }.
 
 Theorem axiom-of-choice : [∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
   auto; intro [λ(w. spread(ap(φ;w); x.y.x))]; auto;
-  elim <φ> [a]; auto;
-  hyp-subst ← <z> [z. ap(ap(Q;a); spread(z; x.y.x))]; auto;
-  elim <y>; auto.
+  elim #3 [a]; auto;
+  hyp-subst ← #6 [z. ap(ap(Q;a); spread(z; x.y.x))]; auto;
+  elim #5; auto.
 }.

--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -33,13 +33,13 @@ Theorem test6 : [Π(unit; _. Σ(unit; _.unit))] {
 
 Theorem test7 : [Π(Σ(void;_.unit); z. void)] {
   auto;
-  elim #0;
+  elim #1;
   auto.
 }.
 
 Theorem axiom-of-choice : [∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
   auto; intro [λ(w. spread(ap(φ;w); x.y.x))]; auto;
-  elim #3 [a]; auto;
-  hyp-subst ← #6 [z. ap(ap(Q;a); spread(z; x.y.x))]; auto;
-  elim #5; auto.
+  elim #4 [a]; auto;
+  hyp-subst ← #7 [h. ap(ap(Q;a); spread(h; x.y.x))]; auto;
+  elim #6; auto.
 }.

--- a/lib/abt-parsing-lib/parse_abt.fun
+++ b/lib/abt-parsing-lib/parse_abt.fun
@@ -58,7 +58,7 @@ struct
           v
         end
 
-    val empty : t =
+    fun empty () : t =
       {bound = StringListDict.empty,
        free = ref StringListDict.empty}
   end
@@ -89,6 +89,6 @@ struct
     and args sigma env () = separate (force (abt sigma env)) (symbol ";") wth Vector.fromList ?? "args"
 
   in
-    val parse_abt = force o abt SymbolTable.empty
+    fun parse_abt x = force (abt (SymbolTable.empty ()) x)
   end
 end

--- a/lib/abt-parsing-lib/parse_abt.fun
+++ b/lib/abt-parsing-lib/parse_abt.fun
@@ -58,9 +58,17 @@ struct
           v
         end
 
-    fun empty () : t =
+    fun dict_from_fvs fvs =
+      let
+        fun go [] R = R
+          | go (x::xs) R = go xs (StringListDict.insert R (Variable.to_string x) x)
+      in
+        go fvs StringListDict.empty
+      end
+
+    fun empty fvs : t =
       {bound = StringListDict.empty,
-       free = ref StringListDict.empty}
+       free = ref (dict_from_fvs fvs)}
   end
 
   fun parens p = (symbol "(" >> spaces) >> p << (spaces >> symbol ")")
@@ -89,6 +97,8 @@ struct
     and args sigma env () = separate (force (abt sigma env)) (symbol ";") wth Vector.fromList ?? "args"
 
   in
-    fun parse_abt x = force (abt (SymbolTable.empty ()) x)
+    fun parse_abt fvs env =
+      force (abt (SymbolTable.empty fvs) env)
+
   end
 end

--- a/lib/abt-parsing-lib/parse_abt.sig
+++ b/lib/abt-parsing-lib/parse_abt.sig
@@ -5,7 +5,6 @@ sig
   structure ParseOperator : PARSE_OPERATOR
   sharing Operator = ParseOperator
 
-  type env
-  val parse_abt : env -> t CharParser.charParser
+  val parse_abt : Variable.t list -> ParseOperator.env -> t CharParser.charParser
 end
 

--- a/src/abt_free_variables.fun
+++ b/src/abt_free_variables.fun
@@ -1,0 +1,19 @@
+functor AbtFreeVariables (Abt : ABT) : ABT_FREE_VARIABLES =
+struct
+  structure Abt = Abt
+
+  open Abt
+  infix $ \
+
+  structure Set = SplaySet (structure Elem = Abt.Variable)
+
+  local
+    fun go B (p $ es) R =
+        Vector.foldl (fn (x,y) => Set.union x y) R (Vector.map (fn E => go B (out E) R) es)
+      | go B (`x) R = if Set.member B x then R else Set.insert R x
+      | go B (x \ E) R = go (Set.insert B x) (out E) R
+  in
+    fun free_variables M =
+      go Set.empty (out M) Set.empty
+  end
+end

--- a/src/abt_free_variables.sig
+++ b/src/abt_free_variables.sig
@@ -1,0 +1,8 @@
+signature ABT_FREE_VARIABLES =
+sig
+  structure Abt : ABT
+  structure Set : SET
+  sharing type Set.elem = Abt.Variable.t
+
+  val free_variables : Abt.t -> Set.set
+end

--- a/src/context.fun
+++ b/src/context.fun
@@ -1,10 +1,12 @@
-functor Context (V : VARIABLE) :> CONTEXT where type name = V.t =
+functor Context (Syntax : ABT_UTIL) : CONTEXT =
 struct
-
+  structure V = Syntax.Variable
+  structure Syntax = Syntax
   structure Tel = Telescope (V)
   type name = V.t
+  type term = Syntax.t
 
-  type 'a context = ('a * Visibility.t) Tel.telescope
+  type context = (term * Visibility.t) Tel.telescope
 
   val empty = Tel.empty
   fun insert H k vis v =
@@ -13,7 +15,7 @@ struct
   val interpose_after = Tel.interpose_after
   val fresh = Tel.fresh
 
-  fun is_empty (ctx : 'a context) =
+  fun is_empty (ctx : context) =
     let
       open Tel.SnocView
     in
@@ -24,10 +26,10 @@ struct
 
   exception NotFound of name
 
-  fun modify (ctx : 'a context) (k : V.t) f =
+  fun modify (ctx : context) (k : V.t) f =
     Tel.modify ctx (k, fn (a, vis) => (f a, vis))
 
-  fun lookup_visibility (ctx : 'a context) k =
+  fun lookup_visibility (ctx : context) k =
     (Tel.lookup ctx k)
 
   fun lookup ctx k = #1 (lookup_visibility ctx k)
@@ -62,7 +64,7 @@ struct
   fun map_after k f ctx =
     Tel.map_after ctx (k, fn (a, vis) => (f a, vis))
 
-  fun to_string f tele =
+  fun to_string tele =
     let
       open Tel.ConsView
       fun go i Empty r = r
@@ -73,16 +75,47 @@ struct
                      Visibility.Visible => V.to_string lbl
                    | Visibility.Hidden => "[" ^ V.to_string lbl ^ "]"
             in
-              go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ pretty_lbl ^ " : " ^ f a)
+              go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ pretty_lbl ^ " : " ^ Syntax.to_string a)
             end
     in
       go 0 (out tele) ""
     end
 
-  fun eq test =
-    Tel.eq (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
-  fun subcontext test =
-    Tel.subtelescope (fn ((a, vis), (b, vis')) => vis = vis' andalso test (a, b))
+  val eq : context * context -> bool =
+    Tel.eq (fn ((a, vis), (b, vis')) => vis = vis' andalso Syntax.eq (a, b))
+  val subcontext : context * context -> bool =
+    Tel.subtelescope (fn ((a, vis), (b, vis')) => vis = vis' andalso Syntax.eq (a, b))
+
+  fun rebind ctx tm =
+    let
+      open Tel.SnocView
+
+      fun make_var_table vs =
+        let
+          fun go [] R = R
+            | go (x::xs) R = go xs (StringListDict.insert R (V.to_string x) x)
+        in
+          go vs StringListDict.empty
+        end
+
+      fun go Empty tbl tm = tm
+        | go (Snoc (ctx', v, (a,vis))) tbl tm =
+           if StringListDict.isEmpty tbl then
+             tm
+           else
+             let
+               val vstr = V.to_string v
+             in
+               case StringListDict.find tbl vstr of
+                    NONE =>
+                      go (out ctx') tbl tm
+                  | SOME v' =>
+                      go (out ctx') (StringListDict.remove tbl vstr)
+                      (Syntax.subst (Syntax.``v) v' tm)
+             end
+    in
+      go (out ctx) (make_var_table (Syntax.free_variables tm)) tm
+    end
 end
 
-structure Context = Context(Syntax.Variable)
+structure Context = Context(Syntax)

--- a/src/context.fun
+++ b/src/context.fun
@@ -32,6 +32,16 @@ struct
 
   fun lookup ctx k = #1 (lookup_visibility ctx k)
 
+  fun nth ctx i =
+    let
+      open Tel.ConsView
+      fun go n Empty = raise Subscript
+        | go n (Cons (lbl, _, tele')) =
+          if n = i then lbl else go (n + 1) (out tele')
+    in
+      go 0 (out ctx)
+    end
+
   fun search ctx phi =
     case Tel.search ctx (phi o #1) of
          SOME (lbl, (a, vis)) => SOME (lbl, a)
@@ -55,18 +65,18 @@ struct
   fun to_string f tele =
     let
       open Tel.ConsView
-      fun go Empty r = r
-        | go (Cons (lbl, (a, vis), tele')) r =
+      fun go i Empty r = r
+        | go i (Cons (lbl, (a, vis), tele')) r =
             let
               val pretty_lbl =
                 case vis of
                      Visibility.Visible => V.to_string lbl
                    | Visibility.Hidden => "[" ^ V.to_string lbl ^ "]"
             in
-              go (out tele') (r ^ "\n" ^ pretty_lbl ^ " : " ^ f a)
+              go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ pretty_lbl ^ " : " ^ f a)
             end
     in
-      go (out tele) ""
+      go 0 (out tele) ""
     end
 
   fun eq test =

--- a/src/context.fun
+++ b/src/context.fun
@@ -78,7 +78,7 @@ struct
               go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ pretty_lbl ^ " : " ^ Syntax.to_string a)
             end
     in
-      go 0 (out tele) ""
+      go 1 (out tele) ""
     end
 
   val eq : context * context -> bool =

--- a/src/context.sig
+++ b/src/context.sig
@@ -16,6 +16,9 @@ sig
   exception NotFound of name
   val lookup : 'a context -> name -> 'a
   val lookup_visibility : 'a context -> name -> 'a * Visibility.t
+
+  val nth : 'a context -> int -> name
+
   val search : 'a context -> ('a -> bool) -> (name * 'a) option
 
   val map : ('a -> 'b) -> 'a context -> 'b context

--- a/src/context.sig
+++ b/src/context.sig
@@ -1,32 +1,36 @@
 signature CONTEXT =
 sig
-  type name
-  type 'a context
+  structure Syntax : ABT_UTIL
+  type name = Syntax.Variable.t
+  type term = Syntax.t
+  type context
 
-  val fresh : 'a context * name -> name
+  val fresh : context * name -> name
 
-  val empty : 'a context
-  val is_empty : 'a context -> bool
+  val empty : context
+  val is_empty : context -> bool
 
-  val insert : 'a context -> name -> Visibility.t -> 'a -> 'a context
-  val interpose_after : 'a context -> name * 'a context -> 'a context
+  val insert : context -> name -> Visibility.t -> term -> context
+  val interpose_after : context -> name * context -> context
 
-  val modify : 'a context -> name -> ('a -> 'a) -> 'a context
+  val modify : context -> name -> (term -> term) -> context
 
   exception NotFound of name
-  val lookup : 'a context -> name -> 'a
-  val lookup_visibility : 'a context -> name -> 'a * Visibility.t
+  val lookup : context -> name -> term
+  val lookup_visibility : context -> name -> term * Visibility.t
 
-  val nth : 'a context -> int -> name
+  val nth : context -> int -> name
 
-  val search : 'a context -> ('a -> bool) -> (name * 'a) option
+  val search : context -> (term -> bool) -> (name * term) option
 
-  val map : ('a -> 'b) -> 'a context -> 'b context
-  val map_after : name -> ('a -> 'a) -> 'a context -> 'a context
-  val list_items : 'a context -> (name * Visibility.t * 'a) list
+  val map : (term -> term) -> context -> context
+  val map_after : name -> (term -> term) -> context -> context
+  val list_items : context -> (name * Visibility.t * term) list
 
-  val to_string : ('a -> string) -> 'a context -> string
+  val to_string : context -> string
 
-  val eq : ('a * 'a -> bool) -> 'a context * 'a context -> bool
-  val subcontext : ('a * 'a -> bool) -> 'a context * 'a context -> bool
+  val eq : context * context -> bool
+  val subcontext : context * context -> bool
+
+  val rebind : context -> term -> term
 end

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -198,7 +198,7 @@ struct
 
     fun UnitElim i (H >> P) =
       let
-        val x = Context.nth H i
+        val x = Context.nth H (i - 1)
         val #[] = Context.lookup H x ^! UNIT
         val ax = AX $$ #[]
         val H' = ctx_subst H ax x
@@ -283,7 +283,7 @@ struct
     fun FunElim (i, s, onames) (H >> P) =
       let
         val s = Context.rebind H s
-        val f = Context.nth H i
+        val f = Context.nth H (i - 1)
         val #[S, xT] = Context.lookup H f ^! FUN
         val Ts = xT // s
         val (y, z) =
@@ -359,7 +359,7 @@ struct
     fun IsectElim (i, s, onames) (H >> P) =
       let
         val s = Context.rebind H s
-        val f = Context.nth H i
+        val f = Context.nth H (i - 1)
         val #[S, xT] = Context.lookup H f ^! ISECT
         val Ts = xT // s
         val (y, z) =
@@ -444,7 +444,7 @@ struct
 
     fun SubsetElim (i, onames) (H >> P) =
       let
-        val z = Context.nth H i
+        val z = Context.nth H (i - 1)
         val #[S, xT] = Context.lookup H z ^! SUBSET
         val (s, t) =
           case onames of
@@ -552,7 +552,7 @@ struct
 
     fun ProdElim (i, onames) (H >> P) =
       let
-        val z = Context.nth H i
+        val z = Context.nth H (i - 1)
         val #[S, xT] = Context.lookup H z ^! PROD
         val (s, t) =
           case onames of
@@ -651,7 +651,7 @@ struct
         [] BY (fn _ => ``x)
       end
 
-    fun Hypothesis i (H >> P) = Hypothesis_ (Context.nth H i) (H >> P)
+    fun Hypothesis i (H >> P) = Hypothesis_ (Context.nth H (i - 1)) (H >> P)
 
     fun Assumption (H >> P) =
       case Context.search H (fn x => Syntax.eq (P, x)) of
@@ -710,14 +710,14 @@ struct
     fun EqSubst (eq, xC, ok) (H >> P) =
       let
         val #[M,N,A] = Context.rebind H eq ^! EQ
-        val (H', z, C) = ctx_unbind (H, A, xC)
+        val (H', x, C) = ctx_unbind (H, A, xC)
         val P' = unify P (xC // M)
         val k = case ok of SOME k => k | NONE => infer_level (H', C)
       in
         [ H >> eq
         , H >> xC // N
         , H' >> MEM $$ #[C, UNIV k $$ #[]]
-        ] BY (fn [D,E,F] => EQ_SUBST $$ #[D, E, z \\ F]
+        ] BY (fn [D,E,F] => EQ_SUBST $$ #[D, E, x \\ F]
                | _ => raise Refine)
       end
 
@@ -730,7 +730,7 @@ struct
       fun HypEqSubst (dir, i, xC, ok) (H >> P) =
         let
           val xC = Context.rebind H xC
-          val z = Context.nth H i
+          val z = Context.nth H (i - 1)
           val X = Context.lookup H z
         in
           case dir of

--- a/src/ctt.fun
+++ b/src/ctt.fun
@@ -197,8 +197,9 @@ struct
         [] BY mk_evidence UNIT_INTRO
       end
 
-    fun UnitElim x (H >> P) =
+    fun UnitElim i (H >> P) =
       let
+        val x = Context.nth H i
         val #[] = Context.lookup H x ^! UNIT
         val ax = AX $$ #[]
         val H' = ctx_subst H ax x
@@ -280,8 +281,9 @@ struct
                | _ => raise Refine)
       end
 
-    fun FunElim (f, s, onames) (H >> P) =
+    fun FunElim (i, s, onames) (H >> P) =
       let
+        val f = Context.nth H i
         val #[S, xT] = Context.lookup H f ^! FUN
         val Ts = xT // s
         val (y, z) =
@@ -354,8 +356,9 @@ struct
                | _ => raise Refine)
       end
 
-    fun IsectElim (f, s, onames) (H >> P) =
+    fun IsectElim (i, s, onames) (H >> P) =
       let
+        val f = Context.nth H i
         val #[S, xT] = Context.lookup H f ^! ISECT
         val Ts = xT // s
         val (y, z) =
@@ -436,8 +439,9 @@ struct
         ] BY mk_evidence IND_SUBSET_INTRO
       end
 
-    fun SubsetElim (z, onames) (H >> P) =
+    fun SubsetElim (i, onames) (H >> P) =
       let
+        val z = Context.nth H i
         val #[S, xT] = Context.lookup H z ^! SUBSET
         val (s, t) =
           case onames of
@@ -540,8 +544,9 @@ struct
         ] BY mk_evidence IND_PROD_INTRO
       end
 
-    fun ProdElim (z, onames) (H >> P) =
+    fun ProdElim (i, onames) (H >> P) =
       let
+        val z = Context.nth H i
         val #[S, xT] = Context.lookup H z ^! PROD
         val (s, t) =
           case onames of
@@ -629,7 +634,7 @@ struct
                 | _ => raise Refine)
       end
 
-    fun Hypothesis x (H >> P) =
+    fun Hypothesis_ x (H >> P) =
       let
         val (P', visibility) = Context.lookup_visibility H x
         val P'' = unify P P'
@@ -640,9 +645,11 @@ struct
         [] BY (fn _ => ``x)
       end
 
+    fun Hypothesis i (H >> P) = Hypothesis_ (Context.nth H i) (H >> P)
+
     fun Assumption (H >> P) =
       case Context.search H (fn x => Syntax.eq (P, x)) of
-           SOME (x, _) => Hypothesis x (H >> P)
+           SOME (x, _) => Hypothesis_ x (H >> P)
          | NONE => raise Refine
 
     fun Unfold (development, lbl) (H >> P) =
@@ -714,18 +721,19 @@ struct
       open Tacticals
       infix THEN THENL
     in
-      fun HypEqSubst (dir, z, xC, ok) (H >> P) =
+      fun HypEqSubst (dir, i, xC, ok) (H >> P) =
         let
+          val z = Context.nth H i
           val X = Context.lookup H z
         in
           case dir of
-               RIGHT => (EqSubst (X, xC, ok) THENL [Hypothesis z, ID, ID]) (H >> P)
+               RIGHT => (EqSubst (X, xC, ok) THENL [Hypothesis_ z, ID, ID]) (H >> P)
              | LEFT =>
                  let
                    val #[M,N,A] = X ^! EQ
                  in
                    (EqSubst (EQ $$ #[N,M,A], xC, ok)
-                     THENL [EqSym THEN Hypothesis z, ID, ID]) (H >> P)
+                     THENL [EqSym THEN Hypothesis_ z, ID, ID]) (H >> P)
                  end
         end
     end

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -9,7 +9,6 @@ sig
   sharing ConvTypes.Syntax = Syntax
 
   structure Development : DEVELOPMENT
-  sharing Development.Telescope.Label = Syntax.Variable
   sharing Development.Lcf = Lcf
 
   structure Rules : sig

--- a/src/ctt.sig
+++ b/src/ctt.sig
@@ -47,7 +47,7 @@ sig
     (* H, x : Unit, H'[x] >> P by UnitElim x
      * 1. H, x : Unit, H'[Ax] >> P[Ax]
      *)
-    val UnitElim : name -> Lcf.tactic
+    val UnitElim : int -> Lcf.tactic
 
     (* H >> Ax = Ax ∈ Unit *)
     val AxEq : Lcf.tactic
@@ -69,34 +69,34 @@ sig
     (* H, z : (Σx:A)B[x], H'[z] >> P[z] by ProdElim z (s, t)
      * H, z : (Σx:A)B[x], s : A, t : B[s], H'[<s,t>] >> P[<s,t>]
      *)
-    val ProdElim : name * (name * name) option -> Lcf.tactic
+    val ProdElim : int * (name * name) option -> Lcf.tactic
 
     val PairEq : name option * Level.t option -> Lcf.tactic
     val SpreadEq : term option * term option * (name * name * name) option -> Lcf.tactic
 
     val FunEq : name option -> Lcf.tactic
     val FunIntro : name option * Level.t option -> Lcf.tactic
-    val FunElim : name * term * (name * name) option -> Lcf.tactic
+    val FunElim : int * term * (name * name) option -> Lcf.tactic
     val LamEq : name option * Level.t option -> Lcf.tactic
     val ApEq : term option -> Lcf.tactic
 
     val IsectEq : name option -> Lcf.tactic
     val IsectIntro : name option * Level.t option -> Lcf.tactic
-    val IsectElim : name * term * (name * name) option -> Lcf.tactic
+    val IsectElim : int * term * (name * name) option -> Lcf.tactic
     val IsectMemberEq : name option * Level.t option -> Lcf.tactic
     val IsectMemberCaseEq : term option * term -> Lcf.tactic
 
     val SubsetEq : name option -> Lcf.tactic
     val SubsetIntro : term * name option * Level.t option -> Lcf.tactic
     val IndependentSubsetIntro : Lcf.tactic
-    val SubsetElim : name * (name * name) option -> Lcf.tactic
+    val SubsetElim : int * (name * name) option -> Lcf.tactic
     val SubsetMemberEq : name option * Level.t option -> Lcf.tactic
 
     val MemCD : Lcf.tactic
     val Witness : term -> Lcf.tactic
 
     val Assumption : Lcf.tactic
-    val Hypothesis : name -> Lcf.tactic
+    val Hypothesis : int -> Lcf.tactic
     val HypEq : Lcf.tactic
 
     val Unfold : Development.t * Development.label -> Lcf.tactic
@@ -109,7 +109,7 @@ sig
     val EqSym : Lcf.tactic
 
     datatype dir = LEFT | RIGHT
-    val HypEqSubst : dir * name * term * Level.t option -> Lcf.tactic
+    val HypEqSubst : dir * int * term * Level.t option -> Lcf.tactic
   end
 
   structure Conversions :

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -63,8 +63,8 @@ struct
         ORELSE EqEq
         ORELSE UnitEq
         ORELSE VoidEq
-        ORELSE UnivEq
         ORELSE HypEq
+        ORELSE UnivEq
         ORELSE FunEq fresh_variable
         ORELSE IsectEq fresh_variable
         ORELSE ProdEq fresh_variable

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -19,7 +19,7 @@ struct
      level : Level.t option}
 
   type elim_args =
-    {target : name,
+    {target : int,
      names : name list,
      term : term option}
 

--- a/src/ctt_util.sig
+++ b/src/ctt_util.sig
@@ -9,7 +9,7 @@ sig
      level : Level.t option}
 
   type elim_args =
-    {target : name,
+    {target : int,
      names : name list,
      term : term option}
 

--- a/src/development.fun
+++ b/src/development.fun
@@ -93,9 +93,17 @@ struct
          | _ => raise Fail "invalid rewrite rule"
   end
 
-  fun define_operator T rule =
+  structure FreeVariables = AbtFreeVariables(Syntax)
+  fun define_operator T (rule as {definiendum, definiens}) =
     let
       val lbl = rule_get_label rule
+      val LFVs = FreeVariables.free_variables definiendum
+      val RFVs = FreeVariables.free_variables definiens
+      val _ =
+        if FreeVariables.Set.subset (RFVs, LFVs) then
+          ()
+        else
+          raise Fail "FV(Definiens) must be a subset of FV(Definiendum)"
     in
       case Telescope.lookup T lbl of
            Object.Operator {arity,conversion = NONE} =>

--- a/src/development.fun
+++ b/src/development.fun
@@ -8,7 +8,6 @@ functor Development
     where type evidence = Lcf.evidence
     where type term = Syntax.t
    structure Telescope : TELESCOPE
-   sharing Telescope.Label = Syntax.Variable
    val as_custom_operator : Syntax.Operator.t -> Telescope.label) : DEVELOPMENT =
 struct
   structure Lcf = Lcf
@@ -110,7 +109,10 @@ struct
   fun lookup_definition T lbl =
     case Telescope.lookup T lbl of
          Object.Operator {conversion = SOME (_, conv),...} => Susp.force conv
-       | Object.Theorem {evidence,...} => Syntax.subst (Extract.extract (Susp.force evidence)) lbl
+       | Object.Theorem {evidence,...} => (fn tm =>
+           case List.find (fn v => Syntax.Variable.to_string v = Telescope.Label.to_string lbl) (Syntax.free_variables tm) of
+                NONE => tm
+              | SOME v => Syntax.subst (Extract.extract (Susp.force evidence)) v tm)
        | _ => raise Subscript
 
   fun lookup_theorem T lbl =

--- a/src/sequent.fun
+++ b/src/sequent.fun
@@ -4,24 +4,24 @@ struct
 
   structure Context = Context
   type name = Context.name
-  type context = term Context.context
+  type context = Context.context
   datatype sequent = >> of context * term
 
   infix >>
 
   fun to_string (H >> P) =
     let
-      val ctx = Context.to_string Syntax.to_string H
+      val ctx = Context.to_string H
       val prop = Syntax.to_string P
     in
       if Context.is_empty H then
         "⊢ " ^ prop
       else
-        Context.to_string Syntax.to_string H ^ "\n⊢ " ^ prop
+        Context.to_string H ^ "\n⊢ " ^ prop
     end
 
   fun eq (H >> P, H' >> P') =
-    Context.eq Syntax.eq (H, H') andalso Syntax.eq (P, P')
+    Context.eq (H, H') andalso Syntax.eq (P, P')
 
 end
 

--- a/src/sequent.sig
+++ b/src/sequent.sig
@@ -4,7 +4,7 @@ sig
 
   structure Context : CONTEXT
   type name = Context.name
-  type context = term Context.context
+  type context = Context.context
 
   datatype sequent = >> of context * term
 

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -6,6 +6,9 @@ group is
   ../lib/cmlib/cmlib.cm
   ../lib/parcom.cm
 
+  abt_free_variables.sig
+  abt_free_variables.fun
+
   visibility.sml
   operator.sml
   syntax.sml

--- a/src/syntax.sml
+++ b/src/syntax.sml
@@ -38,7 +38,7 @@ struct
   structure Operator = Operator (V)
   structure Abt = Abt
     (structure Operator = Operator
-     structure Variable = V.Label)
+     structure Variable = Variable ())
 
   structure MyOp = Operator
   structure ParseAbt = ParseAbt

--- a/src/syntax.sml
+++ b/src/syntax.sml
@@ -121,14 +121,6 @@ struct
            | UNIV i $ #[] =>
                "U" ^ subscript i
 
-           | SPREAD $ #[M, xyN] =>
-               let
-                 val (x, yN) = unbind xyN
-                 val (y, N) = unbind yN
-               in
-                 "let " ^ dvar (x, yN) ^ "," ^ dvar (y, N) ^ " = " ^ display M ^ " in " ^ display N
-               end
-
            | _ => to_string_open display E
 
       and dvar (x, E) =


### PR DESCRIPTION
The conceptual changes introduced in this PR are twofold:
1. To be less fragile, tactics which previously took existing names as arguments (e.g. elimination rules indexing into the context) have been reformulated to take an index, written `elim #3`, etc. This is how it works in Nuprl...
2. I had originally used a shortcut to get names in parsed terms to coincide with existing names (in contexts, or signatures, etc.), which was to use a string-based `VARIABLE` implementation. This wasn't really a good idea, but it saved me from having to deal with a lot of complexity about plumbing names through... However, it obscured a number of bugs in the implementation of JonPRL. I have instantiated the ABTs now with the generative `Variable` structure.

In order to make that tractable, I had to fix a number of issues:
- The definiens of an operator should be parsed with respect to the free variables of the definiendum.
- Open terms input into a tactic by the user must be "rebound" with respect to the context. That is, the variables must be read in and replaced with the homophonous (but different) ones which are bound in the context.
