### PR TITLE
standardize coding style

### DIFF
--- a/lib/abt-parsing-lib/parse_abt.fun
+++ b/lib/abt-parsing-lib/parse_abt.fun
@@ -61,7 +61,7 @@ struct
     fun dict_from_fvs fvs =
       let
         fun go [] R = R
-          | go (x::xs) R = go xs (StringListDict.insert R (Variable.to_string x) x)
+          | go (x::xs) R = go xs (StringListDict.insert R (Variable.toString x) x)
       in
         go fvs StringListDict.empty
       end
@@ -84,7 +84,7 @@ struct
       || force (abs sigma env)
       || var sigma) ?? "abt"
     and app sigma env () =
-      ParseOperator.parse_operator env
+      ParseOperator.parseOperator env
         && opt (parens (force (args sigma env)))
         wth (fn (O, ES) => O $$ getOpt (ES, #[])) ?? "app"
     and abs sigma env () =
@@ -97,7 +97,7 @@ struct
     and args sigma env () = separate (force (abt sigma env)) (symbol ";") wth Vector.fromList ?? "args"
 
   in
-    fun parse_abt fvs env =
+    fun parseAbt fvs env =
       force (abt (SymbolTable.empty fvs) env)
 
   end

--- a/lib/abt-parsing-lib/parse_abt.fun
+++ b/lib/abt-parsing-lib/parse_abt.fun
@@ -58,7 +58,7 @@ struct
           v
         end
 
-    fun dict_from_fvs fvs =
+    fun dictFromFvs fvs =
       let
         fun go [] R = R
           | go (x::xs) R = go xs (StringListDict.insert R (Variable.toString x) x)
@@ -68,15 +68,13 @@ struct
 
     fun empty fvs : t =
       {bound = StringListDict.empty,
-       free = ref (dict_from_fvs fvs)}
+       free = ref (dictFromFvs fvs)}
   end
 
   fun parens p = (symbol "(" >> spaces) >> p << (spaces >> symbol ")")
-  fun >>= (p : 'a charParser, q : 'a -> 'b charParser) : 'b charParser = join (p wth q)
-  infix >>=
 
   local
-    val new_variable = identifier wth (fn x => (x, Variable.named x))
+    val newVariable = identifier wth (fn x => (x, Variable.named x))
     fun var sigma = identifier wth (fn x => `` (SymbolTable.named sigma x))
 
     fun abt sigma env () =
@@ -88,7 +86,7 @@ struct
         && opt (parens (force (args sigma env)))
         wth (fn (O, ES) => O $$ getOpt (ES, #[])) ?? "app"
     and abs sigma env () =
-      (new_variable << spaces << symbol "." << spaces >>= (fn (n,v) =>
+      (newVariable << spaces << symbol "." << spaces -- (fn (n,v) =>
         let
           val sigma' = SymbolTable.bind sigma (n,v)
         in
@@ -99,6 +97,5 @@ struct
   in
     fun parseAbt fvs env =
       force (abt (SymbolTable.empty fvs) env)
-
   end
 end

--- a/lib/abt-parsing-lib/parse_abt.sig
+++ b/lib/abt-parsing-lib/parse_abt.sig
@@ -5,6 +5,6 @@ sig
   structure ParseOperator : PARSE_OPERATOR
   sharing Operator = ParseOperator
 
-  val parse_abt : Variable.t list -> ParseOperator.env -> t CharParser.charParser
+  val parseAbt : Variable.t list -> ParseOperator.env -> t CharParser.charParser
 end
 

--- a/lib/abt-parsing-lib/parse_abt_test.fun
+++ b/lib/abt-parsing-lib/parse_abt_test.fun
@@ -2,7 +2,7 @@ functor ParseAbtTest () =
 struct
   datatype oper = LAM | AX | AP
 
-  structure O : PARSE_OPERATOR =
+  structure O : parseOperator =
   struct
     type env = unit
     type t = oper
@@ -10,15 +10,15 @@ struct
     fun arity LAM = #[1]
       | arity AX = #[]
       | arity AP = #[0,0]
-    fun to_string LAM = "λ"
-      | to_string AX = "<>"
-      | to_string AP = "ap"
+    fun toString LAM = "λ"
+      | toString AX = "<>"
+      | toString AP = "ap"
 
     open ParserCombinators CharParser
     infix 2 return
     infixr 1 ||
 
-    fun parse_operator () =
+    fun parseOperator () =
       string "λ" return LAM
         || string "<>" return AX
         || string "ap" return AP
@@ -27,8 +27,8 @@ struct
   structure Syn = AbtUtil(Abt(structure Operator = O and Variable = Variable()))
   structure ParseSyn = ParseAbt(structure Syntax = Syn and Operator = O)
 
-  fun print_res pr = print (Sum.sumR (fn b => Syn.to_string b ^ "\n") pr)
-  fun doit s = print_res (CharParser.parseString (ParseSyn.parse_abt ()) s)
+  fun printRes pr = print (Sum.sumR (fn b => Syn.toString b ^ "\n") pr)
+  fun doit s = printRes (CharParser.parseString (ParseSyn.parseAbt ()) s)
 
   val _ =
     (doit "λ(x.λ(x.ap(x;<>)))";

--- a/lib/abt-parsing-lib/parse_operator.sig
+++ b/lib/abt-parsing-lib/parse_operator.sig
@@ -3,5 +3,5 @@ sig
   include OPERATOR
 
   type env
-  val parse_operator : env -> t CharParser.charParser
+  val parseOperator : env -> t CharParser.charParser
 end

--- a/lib/telescopes/telescope.fun
+++ b/lib/telescopes/telescope.fun
@@ -1,7 +1,7 @@
 functor MergeDict (Dict : DICT) =
 struct
   exception DictsNotDisjoint
-  fun merge_dict (d1, d2) =
+  fun mergeDict (d1, d2) =
     Dict.foldl (fn (a, b, d3) =>
       case Dict.find d3 a of
            NONE => Dict.insert d3 a b
@@ -27,7 +27,7 @@ struct
 
   exception LabelExists
 
-  fun interpose_after (SOME {first,last,preds,nexts,vals,names}) (lbl, SOME tele) = SOME
+  fun interposeAfter (SOME {first,last,preds,nexts,vals,names}) (lbl, SOME tele) = SOME
     {first = first,
      last = case SOME (Dict.lookup nexts lbl) handle _ => NONE of
                  NONE => #last tele
@@ -40,7 +40,7 @@ struct
                 NONE => preds'
               | SOME lblpst => Dict.insert preds' lblpst (#last tele)
        in
-         MergeDict.merge_dict (#preds tele, preds'')
+         MergeDict.mergeDict (#preds tele, preds'')
        end,
      nexts =
        let
@@ -50,12 +50,12 @@ struct
                 NONE => nexts'
               | SOME lblpst => Dict.insert nexts' (#last tele) lblpst
        in
-         MergeDict.merge_dict (#nexts tele, nexts'')
+         MergeDict.mergeDict (#nexts tele, nexts'')
        end,
-     vals = MergeDict.merge_dict (vals, #vals tele),
-     names = MergeStringListDict.merge_dict (names, #names tele)}
-    | interpose_after tele (lbl, NONE) = tele
-    | interpose_after NONE (lbl, tele) = tele
+     vals = MergeDict.mergeDict (vals, #vals tele),
+     names = MergeStringListDict.mergeDict (names, #names tele)}
+    | interposeAfter tele (lbl, NONE) = tele
+    | interposeAfter NONE (lbl, tele) = tele
 
   fun modify NONE _ = NONE
     | modify (SOME {first,last,preds,nexts,vals,names}) (lbl, f) =
@@ -79,7 +79,7 @@ struct
     | find _ _ = NONE
 
   fun fresh (SOME tele : 'a telescope, lbl) =
-    if StringListDict.member (#names tele) (Label.to_string lbl) then
+    if StringListDict.member (#names tele) (Label.toString lbl) then
       fresh (SOME tele, L.prime lbl)
     else
       lbl
@@ -94,11 +94,11 @@ struct
      nexts = Dict.empty,
      preds = Dict.empty,
      vals = Dict.insert Dict.empty lbl a,
-     names = StringListDict.insert StringListDict.empty (Label.to_string lbl) lbl}
+     names = StringListDict.insert StringListDict.empty (Label.toString lbl) lbl}
 
-  fun cons (lbl, a) tele = interpose_after (singleton (lbl, a)) (lbl, tele)
+  fun cons (lbl, a) tele = interposeAfter (singleton (lbl, a)) (lbl, tele)
 
-  fun snoc (SOME tele) (lbl, a) = interpose_after (SOME tele) (#last tele, singleton (lbl, a))
+  fun snoc (SOME tele) (lbl, a) = interposeAfter (SOME tele) (#last tele, singleton (lbl, a))
     | snoc NONE (lbl, a) = singleton (lbl, a)
 
   fun map NONE f = NONE
@@ -169,8 +169,8 @@ struct
             Cons (first, Dict.lookup vals first, tail)
           end
 
-    fun out_after NONE lbl = Empty
-      | out_after (SOME {first,last,preds,nexts,vals,names}) lbl =
+    fun outAfter NONE lbl = Empty
+      | outAfter (SOME {first,last,preds,nexts,vals,names}) lbl =
          out (SOME
           {first = lbl,
            last = last,
@@ -186,8 +186,8 @@ struct
   local
     open ConsView
   in
-    fun map_after NONE (lbl, f) = NONE
-      | map_after (SOME tele) (lbl, f) =
+    fun mapAfter NONE (lbl, f) = NONE
+      | mapAfter (SOME tele) (lbl, f) =
           let
             val {first,last,preds,nexts,vals,names} = tele
             fun go Empty D = D
@@ -203,11 +203,11 @@ struct
                names = names}
           end
 
-    fun to_string pretty tele =
+    fun toString pretty tele =
       let
         fun go Empty r = r
           | go (Cons (lbl, a, tele')) r =
-              go (out tele') (r ^ ", " ^ L.to_string lbl ^ " : " ^ pretty a)
+              go (out tele') (r ^ ", " ^ L.toString lbl ^ " : " ^ pretty a)
       in
         go (out tele) "·"
       end

--- a/lib/telescopes/telescope.sig
+++ b/lib/telescopes/telescope.sig
@@ -21,7 +21,7 @@ sig
      | Cons of label * 'a * 'r
 
   val out : 'a telescope -> ('a, 'a telescope) view
-  val out_after : 'a telescope -> label -> ('a, 'a telescope) view
+  val outAfter : 'a telescope -> label -> ('a, 'a telescope) view
   val into : ('a, 'a telescope) view -> 'a telescope
 end
 
@@ -29,7 +29,7 @@ signature LABEL =
 sig
   include ORDERED
 
-  val to_string : t -> string
+  val toString : t -> string
   val prime : t -> t
 end
 
@@ -56,16 +56,16 @@ sig
 
   (* manipulation *)
   val map : 'a telescope -> ('a -> 'b) -> 'b telescope
-  val map_after : 'a telescope -> label * ('a -> 'a) -> 'a telescope
+  val mapAfter : 'a telescope -> label * ('a -> 'a) -> 'a telescope
   val modify : 'a telescope -> label * ('a -> 'a) -> 'a telescope
-  val interpose_after : 'a telescope -> label * 'a telescope -> 'a telescope
+  val interposeAfter : 'a telescope -> label * 'a telescope -> 'a telescope
 
   (* comparison *)
   val subtelescope : ('a * 'a -> bool) -> 'a telescope * 'a telescope -> bool
   val eq : ('a * 'a -> bool) -> 'a telescope * 'a telescope -> bool
 
   (* pretty printing *)
-  val to_string : ('a -> string) -> 'a telescope -> string
+  val toString : ('a -> string) -> 'a telescope -> string
 
   (* These views may be used to lazily walk along a telescope *)
   structure SnocView : SNOC_VIEW

--- a/src/abt_free_variables.fun
+++ b/src/abt_free_variables.fun
@@ -1,4 +1,4 @@
-functor AbtFreeVariables (Abt : ABT) : ABT_FREE_VARIABLES =
+functor AbtFreeVariables (Abt : ABT) : ABT_freeVariables =
 struct
   structure Abt = Abt
 
@@ -13,7 +13,7 @@ struct
       | go B (`x) R = if Set.member B x then R else Set.insert R x
       | go B (x \ E) R = go (Set.insert B x) (out E) R
   in
-    fun free_variables M =
+    fun freeVariables M =
       go Set.empty (out M) Set.empty
   end
 end

--- a/src/abt_free_variables.sig
+++ b/src/abt_free_variables.sig
@@ -1,8 +1,8 @@
-signature ABT_FREE_VARIABLES =
+signature ABT_freeVariables =
 sig
   structure Abt : ABT
   structure Set : SET
   sharing type Set.elem = Abt.Variable.t
 
-  val free_variables : Abt.t -> Set.set
+  val freeVariables : Abt.t -> Set.set
 end

--- a/src/context.fun
+++ b/src/context.fun
@@ -12,10 +12,10 @@ struct
   fun insert H k vis v =
     Tel.snoc H (k, (v, vis))
 
-  val interpose_after = Tel.interpose_after
+  val interposeAfter = Tel.interposeAfter
   val fresh = Tel.fresh
 
-  fun is_empty (ctx : context) =
+  fun isEmpty (ctx : context) =
     let
       open Tel.SnocView
     in
@@ -29,10 +29,10 @@ struct
   fun modify (ctx : context) (k : V.t) f =
     Tel.modify ctx (k, fn (a, vis) => (f a, vis))
 
-  fun lookup_visibility (ctx : context) k =
+  fun lookupVisibility (ctx : context) k =
     (Tel.lookup ctx k)
 
-  fun lookup ctx k = #1 (lookup_visibility ctx k)
+  fun lookup ctx k = #1 (lookupVisibility ctx k)
 
   fun nth ctx i =
     let
@@ -49,7 +49,7 @@ struct
          SOME (lbl, (a, vis)) => SOME (lbl, a)
        | NONE => NONE
 
-  fun list_items ctx =
+  fun listItems ctx =
     let
       open Tel.SnocView
       fun go Empty r = r
@@ -61,21 +61,21 @@ struct
   fun map f ctx =
     Tel.map ctx (fn (a, vis) => (f a, vis))
 
-  fun map_after k f ctx =
-    Tel.map_after ctx (k, fn (a, vis) => (f a, vis))
+  fun mapAfter k f ctx =
+    Tel.mapAfter ctx (k, fn (a, vis) => (f a, vis))
 
-  fun to_string tele =
+  fun toString tele =
     let
       open Tel.ConsView
       fun go i Empty r = r
         | go i (Cons (lbl, (a, vis), tele')) r =
             let
-              val pretty_lbl =
+              val prettyLbl =
                 case vis of
-                     Visibility.Visible => V.to_string lbl
-                   | Visibility.Hidden => "[" ^ V.to_string lbl ^ "]"
+                     Visibility.Visible => V.toString lbl
+                   | Visibility.Hidden => "[" ^ V.toString lbl ^ "]"
             in
-              go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ pretty_lbl ^ " : " ^ Syntax.to_string a)
+              go (i + 1) (out tele') (r ^ "\n" ^ Int.toString i ^ ". " ^ prettyLbl ^ " : " ^ Syntax.toString a)
             end
     in
       go 1 (out tele) ""
@@ -90,10 +90,10 @@ struct
     let
       open Tel.SnocView
 
-      fun make_var_table vs =
+      fun makeVarTable vs =
         let
           fun go [] R = R
-            | go (x::xs) R = go xs (StringListDict.insert R (V.to_string x) x)
+            | go (x::xs) R = go xs (StringListDict.insert R (V.toString x) x)
         in
           go vs StringListDict.empty
         end
@@ -104,7 +104,7 @@ struct
              tm
            else
              let
-               val vstr = V.to_string v
+               val vstr = V.toString v
              in
                case StringListDict.find tbl vstr of
                     NONE =>
@@ -114,7 +114,7 @@ struct
                       (Syntax.subst (Syntax.``v) v' tm)
              end
     in
-      go (out ctx) (make_var_table (Syntax.free_variables tm)) tm
+      go (out ctx) (makeVarTable (Syntax.freeVariables tm)) tm
     end
 end
 

--- a/src/context.sig
+++ b/src/context.sig
@@ -8,26 +8,26 @@ sig
   val fresh : context * name -> name
 
   val empty : context
-  val is_empty : context -> bool
+  val isEmpty : context -> bool
 
   val insert : context -> name -> Visibility.t -> term -> context
-  val interpose_after : context -> name * context -> context
+  val interposeAfter : context -> name * context -> context
 
   val modify : context -> name -> (term -> term) -> context
 
   exception NotFound of name
   val lookup : context -> name -> term
-  val lookup_visibility : context -> name -> term * Visibility.t
+  val lookupVisibility : context -> name -> term * Visibility.t
 
   val nth : context -> int -> name
 
   val search : context -> (term -> bool) -> (name * term) option
 
   val map : (term -> term) -> context -> context
-  val map_after : name -> (term -> term) -> context -> context
-  val list_items : context -> (name * Visibility.t * term) list
+  val mapAfter : name -> (term -> term) -> context -> context
+  val listItems : context -> (name * Visibility.t * term) list
 
-  val to_string : context -> string
+  val toString : context -> string
 
   val eq : context * context -> bool
   val subcontext : context * context -> bool

--- a/src/conv_types.fun
+++ b/src/conv_types.fun
@@ -6,7 +6,7 @@ struct
 
   open Syntax
 
-  fun reduction_rule red M = red (map out (out M))
+  fun reductionRule red M = red (map out (out M))
   exception Conv
 end
 
@@ -24,11 +24,11 @@ struct
 
   exception InvalidTemplate
 
-  fun compute_chart (M,N) =
+  fun computeChart (M,N) =
     case (out M, out N) of
          (p $ es, p' $ es') =>
            let
-             val _ = if p <> p' then raise InvalidTemplate else ()
+             val _ = if Operator.eq (p, p') then () else raise InvalidTemplate
              open Vector
              val zipped = tabulate (length es, fn n => (sub (es, n), sub (es', n)))
 
@@ -50,9 +50,9 @@ struct
     let
       val inop $ inargs = out definiendum handle _ => raise Conv
       val outop $ outargs = out definiens handle _ => raise Conv
-      val Mop $ M_args = out M handle _ => raise Conv
+      val Mop $ MArgs = out M handle _ => raise Conv
       val _ = if Operator.eq (Mop, inop) then () else raise Conv
-      val chart = compute_chart (definiendum, M)
+      val chart = computeChart (definiendum, M)
 
       fun go H (p $ es) = p $$ Vector.map (go H o out) es
         | go H (x \ E) = x \\ go (Set.insert H x) (out E)

--- a/src/conv_types.sig
+++ b/src/conv_types.sig
@@ -5,7 +5,7 @@ sig
   type conv = Syntax.t -> Syntax.t
   type red = Syntax.t Syntax.view Syntax.view -> Syntax.t
 
-  val reduction_rule : red -> conv
+  val reductionRule : red -> conv
 
   exception Conv
 end

--- a/src/ctt_frontend.sml
+++ b/src/ctt_frontend.sml
@@ -2,40 +2,40 @@ structure CttFrontend =
 struct
   structure Extract = Extract(Syntax)
 
-  fun print_development development =
+  fun printDevelopment development =
     let
       open Development.Telescope
       fun go ConsView.Empty = ()
         | go (ConsView.Cons (lbl, obj, tele)) =
-            (print (Development.Object.to_string (lbl, obj) ^ "\n\n");
+            (print (Development.Object.toString (lbl, obj) ^ "\n\n");
              go (ConsView.out tele))
     in
       go (ConsView.out (Development.out development))
     end
 
-  fun load_file (initial_development, name) : Development.t =
+  fun loadFile (initialDevelopment, name) : Development.t =
     let
       val instream = TextIO.openIn name
-      val char_stream = Stream.fromProcess (fn () => TextIO.input1 instream)
+      val charStream = Stream.fromProcess (fn () => TextIO.input1 instream)
       fun is_eol s =
         case Stream.front s of
              Stream.Nil => true
            | Stream.Cons (x, s') => x = #"\n"
-      val coord_stream = CoordinatedStream.coordinate is_eol (Coord.init name) char_stream
+      val coordStream = CoordinatedStream.coordinate is_eol (Coord.init name) charStream
 
       open CttDevelopmentParser
     in
-      (case (CharParser.parseChars (parse initial_development) coord_stream) of
+      (case (CharParser.parseChars (parse initialDevelopment) coordStream) of
            Sum.INL e => raise Fail e
          | Sum.INR x => x)
       handle
           Development.RemainingSubgoals goals =>
-            (print ("\n\nRemaining subgoals:" ^ foldl (fn (g,r) => r ^ "\n" ^ Lcf.goal_to_string g ^ "\n") "" goals ^ "\n\n");
+            (print ("\n\nRemaining subgoals:" ^ foldl (fn (g,r) => r ^ "\n" ^ Lcf.goalToString g ^ "\n") "" goals ^ "\n\n");
             raise Development.RemainingSubgoals goals)
         | AnnotatedLcf.RefinementFailed (exn as {error, goal, metadata as {name,pos}}) =>
             (print
               ("\n\n[" ^ Pos.toString pos
-                 ^ "]: tactic '" ^ name ^ "' failed (" ^ exnMessage error ^ ") with goal: \n" ^ Sequent.to_string goal ^ "\n\n");
+                 ^ "]: tactic '" ^ name ^ "' failed (" ^ exnMessage error ^ ") with goal: \n" ^ Sequent.toString goal ^ "\n\n");
             raise AnnotatedLcf.RefinementFailed exn)
     end
 end

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -2,7 +2,7 @@ functor CttRuleParser
   (structure Lcf : ANNOTATED_LCF where type metadata = TacticMetadata.metadata
    structure Ctt : CTT_UTIL where type Development.Telescope.Label.t = string
    structure Operator : PARSE_OPERATOR
-    where type env = Ctt.Development.label -> int vector
+    where type env = Ctt.Development.label -> Arity.t
    sharing type Ctt.Lcf.goal = Lcf.goal
    sharing type Ctt.Lcf.evidence = Lcf.evidence
    sharing Ctt.Syntax.Operator = Operator):

--- a/src/ctt_rule_parser.fun
+++ b/src/ctt_rule_parser.fun
@@ -9,7 +9,7 @@ functor CttRuleParser
 sig
   structure Lcf : ANNOTATED_LCF
   type env = Ctt.Development.t
-  val parse_rule : env -> Lcf.tactic CharParser.charParser
+  val parseRule : env -> Lcf.tactic CharParser.charParser
 end =
 struct
   structure AnnLcf = Lcf
@@ -47,175 +47,175 @@ struct
 
   type env = Development.t
 
-  val parse_int =
+  val parseInt =
     repeat1 digit wth valOf o Int.fromString o String.implode
 
-  val parse_level =
-    lexeme (symbol "@" >> parse_int)
+  val parseLevel =
+    lexeme (symbol "@" >> parseInt)
 
-  val parse_index =
-    lexeme (symbol "#" >> parse_int)
+  val parseIndex =
+    lexeme (symbol "#" >> parseInt)
 
-  fun parse_opt p =
+  fun parseOpt p =
     symbol "_" return NONE
       || p wth SOME
 
-  val parse_name =
+  val parseName =
     identifier
       wth Syntax.Variable.named
 
-  fun decorate_tac tac =
+  fun decorateTac tac =
     fn (name, args) => fn (pos : Pos.t) =>
       Lcf.annotate ({name = name, pos = pos}, tac args)
 
-  fun name_tac name tac =
+  fun nameTac name tac =
     fn (pos : Pos.t) =>
       Lcf.annotate ({name = name, pos = pos}, tac)
 
   type 'a intensional_parser = Development.t -> 'a charParser
   type tactic_parser = (Pos.t -> tactic) intensional_parser
 
-  val parse_tm : term intensional_parser =
-    squares o ParseSyntax.parse_abt [] o Development.lookup_operator
+  val parseTm : term intensional_parser =
+    squares o ParseSyntax.parseAbt [] o Development.lookupOperator
 
-  val parse_cum : tactic_parser =
+  val parseCum : tactic_parser =
     fn D => symbol "cum"
-      && opt parse_level
-      wth (fn (name, k) => name_tac name (Cum k))
+      && opt parseLevel
+      wth (fn (name, k) => nameTac name (Cum k))
 
-  val parse_witness : tactic_parser =
+  val parseWitness : tactic_parser =
     fn D => symbol "witness"
-      && parse_tm D
+      && parseTm D
       wth (fn (name, tm) =>
-        name_tac name (Witness tm))
+        nameTac name (Witness tm))
 
-  val parse_hypothesis : tactic_parser =
+  val parseHypothesis : tactic_parser =
     fn D => symbol "hypothesis"
-      && parse_index
+      && parseIndex
       wth (fn (name, i) =>
-        name_tac name (Hypothesis i))
+        nameTac name (Hypothesis i))
 
-  val parse_eq_subst : tactic_parser =
+  val parseEqSubst : tactic_parser =
     fn D => symbol "subst"
-      && parse_tm D && parse_tm D && opt parse_level
+      && parseTm D && parseTm D && opt parseLevel
       wth (fn (name, (M, (N, k))) =>
-        name_tac name (EqSubst (M, N, k)))
+        nameTac name (EqSubst (M, N, k)))
 
-  val parse_dir =
+  val parseDir =
     (symbol "→" || symbol "->") return RIGHT
       || (symbol "←" || symbol "<-") return LEFT
 
-  val parse_hyp_subst : tactic_parser =
+  val parseHypSubst : tactic_parser =
     fn D => symbol "hyp-subst"
-      && parse_dir
-      && parse_index
-      && parse_tm D && opt parse_level
+      && parseDir
+      && parseIndex
+      && parseTm D && opt parseLevel
       wth (fn (name, (dir, (i, (M, k)))) =>
-        name_tac name (HypEqSubst (dir, i, M, k)))
+        nameTac name (HypEqSubst (dir, i, M, k)))
 
-  val parse_intro_args : intro_args intensional_parser =
-    fn D => opt (parse_tm D)
-      && opt (brackets parse_name)
-      && opt parse_level
+  val parseIntroArgs : intro_args intensional_parser =
+    fn D => opt (parseTm D)
+      && opt (brackets parseName)
+      && opt parseLevel
       wth (fn (tm, (z, k)) =>
             {term = tm,
-             fresh_variable = z,
+             freshVariable = z,
              level = k})
 
-  val parse_names =
-    opt (brackets (commaSep1 parse_name))
+  val parseNames =
+    opt (brackets (commaSep1 parseName))
     wth (fn SOME xs => xs
           | NONE => [])
 
-  val parse_elim_args : elim_args intensional_parser=
-    fn D => parse_index
-      && opt (parse_tm D)
-      && parse_names
+  val parseElimArgs : elim_args intensional_parser=
+    fn D => parseIndex
+      && opt (parseTm D)
+      && parseNames
       wth (fn (i, (M, names)) =>
             {target = i,
              term = M,
              names = names})
 
-  val parse_terms : term list intensional_parser =
-    fn D => opt (squares (commaSep1 (ParseSyntax.parse_abt [] (Development.lookup_operator D))))
+  val parseTerms : term list intensional_parser =
+    fn D => opt (squares (commaSep1 (ParseSyntax.parseAbt [] (Development.lookupOperator D))))
     wth (fn oxs => getOpt (oxs, []))
 
-  val parse_eq_cd_args : eq_cd_args intensional_parser =
-    fn D => (parse_terms D)
-      && parse_names
-      && opt parse_level
+  val parseEqCdArgs : eq_cd_args intensional_parser =
+    fn D => (parseTerms D)
+      && parseNames
+      && opt parseLevel
       wth (fn (Ms, (xs, k)) => {names = xs, terms = Ms, level = k})
 
-  val parse_intro =
+  val parseIntro =
     fn D => symbol "intro"
-      && parse_intro_args D
-      wth (fn (name, args) => name_tac name (Intro args))
+      && parseIntroArgs D
+      wth (fn (name, args) => nameTac name (Intro args))
 
-  val parse_elim =
+  val parseElim =
     fn D => symbol "elim"
-      && parse_elim_args D
-      wth (fn (name, args) => name_tac name (Elim args))
+      && parseElimArgs D
+      wth (fn (name, args) => nameTac name (Elim args))
 
 
-  val parse_eq_cd =
+  val parseEqCd =
     fn D => symbol "eq-cd"
-      && (parse_eq_cd_args D)
-      wth (fn (name, args) => name_tac name (EqCD args))
+      && (parseEqCdArgs D)
+      wth (fn (name, args) => nameTac name (EqCD args))
 
-  val parse_symmetry : tactic_parser =
+  val parseSymmetry : tactic_parser =
     fn D => symbol "symmetry"
-      wth (fn name => name_tac name EqSym)
+      wth (fn name => nameTac name EqSym)
 
-  val parse_assumption : tactic_parser =
+  val parseAssumption : tactic_parser =
     fn D => symbol "assumption"
-      wth (fn name => name_tac name Assumption)
+      wth (fn name => nameTac name Assumption)
 
-  val parse_mem_cd : tactic_parser =
+  val parseMemCd : tactic_parser =
     fn D => symbol "mem-cd"
-      wth (fn name => name_tac name MemCD)
+      wth (fn name => nameTac name MemCD)
 
-  val parse_auto : tactic_parser =
+  val parseAuto : tactic_parser =
     fn D => symbol "auto"
-      wth (fn name => name_tac name Auto)
+      wth (fn name => nameTac name Auto)
 
-  val parse_lemma : tactic_parser =
+  val parseLemma : tactic_parser =
     fn D => symbol "lemma"
       && brackets identifier
       wth (fn (name, lbl) => fn pos =>
              Lcf.annotate ({name = name, pos = pos}, Lemma (D, lbl)))
 
-  val parse_unfold : tactic_parser =
+  val parseUnfold : tactic_parser =
     fn D => symbol "unfold"
       && brackets (separate identifier whiteSpace)
       wth (fn (name, lbls) => fn pos =>
              Lcf.annotate ({name = name, pos = pos}, Unfolds (D, lbls)))
 
-  val parse_custom_tactic : tactic_parser =
+  val parseCustomTactic : tactic_parser =
     fn D => symbol "refine"
       >> brackets identifier
       wth (fn lbl => fn (pos : Pos.t) =>
             Lcf.annotate ({name = lbl, pos = pos}, fn goal =>
-              Development.lookup_tactic D lbl goal))
+              Development.lookupTactic D lbl goal))
 
-  fun tactic_parsers D =
-    parse_lemma D
-      || parse_unfold D
-      || parse_custom_tactic D
-      || parse_witness D
-      || parse_hypothesis D
-      || parse_eq_subst D
-      || parse_hyp_subst D
-      || parse_intro D
-      || parse_elim D
-      || parse_eq_cd D
-      || parse_cum D
-      || parse_auto D
-      || parse_mem_cd D
-      || parse_assumption D
-      || parse_symmetry D
+  fun tacticParsers D =
+    parseLemma D
+      || parseUnfold D
+      || parseCustomTactic D
+      || parseWitness D
+      || parseHypothesis D
+      || parseEqSubst D
+      || parseHypSubst D
+      || parseIntro D
+      || parseElim D
+      || parseEqCd D
+      || parseCum D
+      || parseAuto D
+      || parseMemCd D
+      || parseAssumption D
+      || parseSymmetry D
 
-  val parse_rule : Development.t -> tactic charParser =
-    fn D => !! (tactic_parsers D)
+  val parseRule : Development.t -> tactic charParser =
+    fn D => !! (tacticParsers D)
     wth (fn (t, pos) => t pos)
 
 end

--- a/src/ctt_util.fun
+++ b/src/ctt_util.fun
@@ -15,7 +15,7 @@ struct
 
   type intro_args =
     {term : term option,
-     fresh_variable : name option,
+     freshVariable : name option,
      level : Level.t option}
 
   type elim_args =
@@ -28,15 +28,15 @@ struct
      level : Level.t option,
      terms : term list}
 
-  fun Intro {term,fresh_variable,level} =
+  fun Intro {term,freshVariable,level} =
      MemCD
        ORELSE UnitIntro
        ORELSE Assumption
-       ORELSE FunIntro (fresh_variable, level)
-       ORELSE IsectIntro (fresh_variable, level)
-       ORELSE_LAZY (fn _ => ProdIntro (valOf term, fresh_variable, level))
+       ORELSE FunIntro (freshVariable, level)
+       ORELSE IsectIntro (freshVariable, level)
+       ORELSE_LAZY (fn _ => ProdIntro (valOf term, freshVariable, level))
        ORELSE IndependentProdIntro
-       ORELSE_LAZY (fn _ => SubsetIntro (valOf term, fresh_variable, level))
+       ORELSE_LAZY (fn _ => SubsetIntro (valOf term, freshVariable, level))
        ORELSE IndependentSubsetIntro
 
   fun take2 (x::y::_) = SOME (x,y)
@@ -57,7 +57,7 @@ struct
 
   fun EqCD {names, level, terms} =
     let
-      val fresh_variable = list_at (names, 0)
+      val freshVariable = list_at (names, 0)
     in
       AxEq
         ORELSE EqEq
@@ -65,16 +65,16 @@ struct
         ORELSE VoidEq
         ORELSE HypEq
         ORELSE UnivEq
-        ORELSE FunEq fresh_variable
-        ORELSE IsectEq fresh_variable
-        ORELSE ProdEq fresh_variable
-        ORELSE SubsetEq fresh_variable
-        ORELSE PairEq (fresh_variable, level)
-        ORELSE LamEq (fresh_variable, level)
+        ORELSE FunEq freshVariable
+        ORELSE IsectEq freshVariable
+        ORELSE ProdEq freshVariable
+        ORELSE SubsetEq freshVariable
+        ORELSE PairEq (freshVariable, level)
+        ORELSE LamEq (freshVariable, level)
         ORELSE ApEq (list_at (terms, 0))
         ORELSE SpreadEq (list_at (terms, 0), list_at (terms, 1), take3 names)
-        ORELSE SubsetMemberEq (fresh_variable, level)
-        ORELSE IsectMemberEq (fresh_variable, level)
+        ORELSE SubsetMemberEq (freshVariable, level)
+        ORELSE IsectMemberEq (freshVariable, level)
         ORELSE_LAZY (fn _ =>
           case terms of
                [M, N] => IsectMemberCaseEq (SOME M, N)
@@ -88,7 +88,7 @@ struct
       EqCD {names = [], level = NONE, terms = []}
 
     val AutoVoidElim = VoidElim THEN Assumption
-    val AutoIntro = Intro {term = NONE, fresh_variable = NONE, level = NONE}
+    val AutoIntro = Intro {term = NONE, freshVariable = NONE, level = NONE}
 
     open Conversions Conversionals
     infix CORELSE

--- a/src/ctt_util.sig
+++ b/src/ctt_util.sig
@@ -5,7 +5,7 @@ sig
 
   type intro_args =
     {term : Syntax.t option,
-     fresh_variable : name option,
+     freshVariable : name option,
      level : Level.t option}
 
   type elim_args =

--- a/src/development.fun
+++ b/src/development.fun
@@ -8,7 +8,7 @@ functor Development
     where type evidence = Lcf.evidence
     where type term = Syntax.t
    structure Telescope : TELESCOPE
-   val as_custom_operator : Syntax.Operator.t -> Telescope.label) : DEVELOPMENT =
+   val asCustomOperator : Syntax.Operator.t -> Telescope.label) : DEVELOPMENT =
 struct
   structure Lcf = Lcf
   structure Telescope = Telescope
@@ -32,29 +32,29 @@ struct
       | Tactic of Lcf.tactic
       | Operator of operator_decl
 
-    fun arity_to_string v =
+    fun arity_toString v =
       "(" ^ Vector.foldri (fn (i, s1, s2) => if i = (Vector.length v - 1) then s1 else s1 ^ "; " ^ s2) "" (Vector.map Int.toString v) ^ ")"
 
-    fun to_string (lbl, Theorem {statement, evidence,...}) =
+    fun toString (lbl, Theorem {statement, evidence,...}) =
           let
             val evidence' = Susp.force evidence
           in
-            "Theorem " ^ Telescope.Label.to_string lbl
-              ^ " : ⸤" ^ Lcf.goal_to_string statement ^ "⸥ {\n  "
-              ^ Syntax.to_string evidence' ^ "\n} ext {\n  "
-              ^ Syntax.to_string (Extract.extract evidence') ^ "\n}."
+            "Theorem " ^ Telescope.Label.toString lbl
+              ^ " : ⸤" ^ Lcf.goalToString statement ^ "⸥ {\n  "
+              ^ Syntax.toString evidence' ^ "\n} ext {\n  "
+              ^ Syntax.toString (Extract.extract evidence') ^ "\n}."
           end
-      | to_string (lbl, Tactic _) =
-          "Tactic " ^ Telescope.Label.to_string lbl ^ "."
-      | to_string (lbl, Operator {arity, conversion}) =
-          "Operator " ^ Telescope.Label.to_string lbl
-            ^ " : " ^ arity_to_string arity
+      | toString (lbl, Tactic _) =
+          "Tactic " ^ Telescope.Label.toString lbl ^ "."
+      | toString (lbl, Operator {arity, conversion}) =
+          "Operator " ^ Telescope.Label.toString lbl
+            ^ " : " ^ arity_toString arity
             ^ "."
             ^ (case conversion of
                    NONE => ""
                   | SOME ({definiendum, definiens}, _) =>
-                       "\n⸤" ^ Syntax.to_string definiendum ^ "⸥ ≝ "
-                       ^ "⸤" ^ Syntax.to_string definiens ^ "⸥.")
+                       "\n⸤" ^ Syntax.toString definiendum ^ "⸥ ≝ "
+                       ^ "⸤" ^ Syntax.toString definiens ^ "⸥.")
   end
 
   type object = Object.t
@@ -77,28 +77,28 @@ struct
          | _ => raise RemainingSubgoals subgoals
     end
 
-  fun define_tactic T (lbl, tac) =
+  fun defineTactic T (lbl, tac) =
     Telescope.snoc T (lbl, Object.Tactic tac)
 
-  fun declare_operator T (lbl, arity) =
+  fun declareOperator T (lbl, arity) =
     Telescope.snoc T (lbl, Object.Operator {arity = arity, conversion = NONE})
 
   local
     open Syntax
     infix $
   in
-    fun rule_get_label {definiendum, definiens} =
+    fun ruleGetLabel {definiendum, definiens} =
       case out definiendum of
-           operator $ _ => as_custom_operator operator
+           operator $ _ => asCustomOperator operator
          | _ => raise Fail "invalid rewrite rule"
   end
 
   structure FreeVariables = AbtFreeVariables(Syntax)
-  fun define_operator T (rule as {definiendum, definiens}) =
+  fun defineOperator T (rule as {definiendum, definiens}) =
     let
-      val lbl = rule_get_label rule
-      val LFVs = FreeVariables.free_variables definiendum
-      val RFVs = FreeVariables.free_variables definiens
+      val lbl = ruleGetLabel rule
+      val LFVs = FreeVariables.freeVariables definiendum
+      val RFVs = FreeVariables.freeVariables definiens
       val _ =
         if FreeVariables.Set.subset (RFVs, LFVs) then
           ()
@@ -114,26 +114,26 @@ struct
          | _ => raise Subscript
     end
 
-  fun lookup_definition T lbl =
+  fun lookupDefinition T lbl =
     case Telescope.lookup T lbl of
          Object.Operator {conversion = SOME (_, conv),...} => Susp.force conv
        | Object.Theorem {evidence,...} => (fn tm =>
-           case List.find (fn v => Syntax.Variable.to_string v = Telescope.Label.to_string lbl) (Syntax.free_variables tm) of
+           case List.find (fn v => Syntax.Variable.toString v = Telescope.Label.toString lbl) (Syntax.freeVariables tm) of
                 NONE => tm
               | SOME v => Syntax.subst (Extract.extract (Susp.force evidence)) v tm)
        | _ => raise Subscript
 
-  fun lookup_theorem T lbl =
+  fun lookupTheorem T lbl =
     case Telescope.lookup T lbl of
          Object.Theorem {statement,evidence,...} => {statement = statement, evidence = evidence}
        | _ => raise Subscript
 
-  fun lookup_tactic T lbl =
+  fun lookupTactic T lbl =
     case Telescope.lookup T lbl of
          Object.Tactic tac => tac
        | _ => raise Subscript
 
-  fun lookup_operator T lbl =
+  fun lookupOperator T lbl =
     case Telescope.lookup T lbl of
          Object.Operator {arity,...} => arity
        | _ => raise Subscript
@@ -148,6 +148,6 @@ structure Development : DEVELOPMENT = Development
 
    open OperatorType
 
-   fun as_custom_operator (CUSTOM {label,...}) = label
-     | as_custom_operator _ = raise Fail "not a custom operator")
+   fun asCustomOperator (CUSTOM {label,...}) = label
+     | asCustomOperator _ = raise Fail "not a custom operator")
 

--- a/src/development.fun
+++ b/src/development.fun
@@ -24,7 +24,7 @@ struct
        script : Lcf.tactic,
        evidence : Lcf.evidence Susp.susp}
     type operator_decl =
-      {arity : int vector,
+      {arity : Arity.t,
        conversion : (ConvCompiler.rule * (ConvCompiler.conv Susp.susp)) option}
 
     datatype t =

--- a/src/development.sig
+++ b/src/development.sig
@@ -31,7 +31,7 @@ sig
   val defineTactic : t -> label * Lcf.tactic -> t
 
   (* extend a development with a new operator *)
-  val declareOperator : t -> label * int vector -> t
+  val declareOperator : t -> label * Arity.t -> t
   val defineOperator : t -> ConvCompiler.rule -> t
 
   (* lookup the definiens *)

--- a/src/development.sig
+++ b/src/development.sig
@@ -12,7 +12,7 @@ sig
   structure Object :
   sig
     type t
-    val to_string : label * t -> string
+    val toString : label * t -> string
   end
 
   type t
@@ -28,21 +28,21 @@ sig
   exception RemainingSubgoals of Lcf.goal list
 
   (* extend a development with a custom tactic *)
-  val define_tactic : t -> label * Lcf.tactic -> t
+  val defineTactic : t -> label * Lcf.tactic -> t
 
   (* extend a development with a new operator *)
-  val declare_operator : t -> label * int vector -> t
-  val define_operator : t -> ConvCompiler.rule -> t
+  val declareOperator : t -> label * int vector -> t
+  val defineOperator : t -> ConvCompiler.rule -> t
 
   (* lookup the definiens *)
-  val lookup_definition : t -> label -> ConvCompiler.conv
+  val lookupDefinition : t -> label -> ConvCompiler.conv
 
   (* lookup the statement & evidence of a theorem *)
-  val lookup_theorem : t -> label -> {statement : Lcf.goal, evidence : Lcf.evidence Susp.susp}
+  val lookupTheorem : t -> label -> {statement : Lcf.goal, evidence : Lcf.evidence Susp.susp}
 
   (* lookup a custom tactic *)
-  val lookup_tactic : t -> label -> Lcf.tactic
+  val lookupTactic : t -> label -> Lcf.tactic
 
   (* lookup a custom operator *)
-  val lookup_operator : t -> label -> int vector
+  val lookupOperator : t -> label -> Arity.t
 end

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -2,7 +2,7 @@ functor DevelopmentParser
   (structure Development : DEVELOPMENT where type Telescope.Label.t = string
    structure Syntax : PARSE_ABT
     where type Operator.t = Development.Telescope.Label.t OperatorType.operator
-    where type ParseOperator.env = Development.Telescope.Label.t -> int vector
+    where type ParseOperator.env = Development.Telescope.Label.t -> Arity.t
    structure Sequent : SEQUENT
    structure TacticScript : TACTIC_SCRIPT
 

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -41,54 +41,54 @@ struct
   structure TP = TokenParser (LangDef)
   open TP
 
-  val lookup_operator = Development.lookup_operator
+  val lookupOperator = Development.lookupOperator
 
-  fun parse_tm fvs = squares o Syntax.parse_abt fvs o lookup_operator
+  fun parseTm fvs = squares o Syntax.parseAbt fvs o lookupOperator
 
-  val parse_name =
+  val parseName =
     identifier
       wth Syntax.Variable.named
 
-  fun parse_theorem D =
+  fun parseTheorem D =
     reserved "Theorem" >> identifier << colon
-      && parse_tm [] D
+      && parseTm [] D
       && braces (TacticScript.parse D)
       wth (fn (thm, (M, tac)) =>
              Development.prove D
               (thm, Sequent.>> (Sequent.Context.empty, M), tac))
 
-  val parse_int =
+  val parseInt =
     repeat1 digit wth valOf o Int.fromString o String.implode
 
-  val parse_arity =
-    parens (semiSep parse_int)
+  val parseArity =
+    parens (semiSep parseInt)
     wth Vector.fromList
 
-  fun parse_tactic D =
+  fun parseTactic D =
     reserved "Tactic" >> identifier
       && braces (TacticScript.parse D)
-      wth (fn (lbl, tac) => Development.define_tactic D (lbl, tac))
+      wth (fn (lbl, tac) => Development.defineTactic D (lbl, tac))
 
-  fun parse_operator_decl D =
-    (reserved "Operator" >> identifier << colon && parse_arity)
-    wth Development.declare_operator D
+  fun parseOperatorDecl D =
+    (reserved "Operator" >> identifier << colon && parseArity)
+    wth Development.declareOperator D
 
-  fun parse_operator_def D =
-    parse_tm [] D -- (fn (tm : Syntax.t) =>
-      succeed tm && (symbol "=def=" >> parse_tm (Syntax.free_variables tm) D)
+  fun parseOperatorDef D =
+    parseTm [] D -- (fn (tm : Syntax.t) =>
+      succeed tm && (symbol "=def=" >> parseTm (Syntax.freeVariables tm) D)
     ) wth (fn (M : Syntax.t, N : Syntax.t) =>
-      Development.define_operator D
+      Development.defineOperator D
         {definiendum = M,
          definiens = N})
 
-  fun parse_decl D =
-      parse_theorem D
-      || parse_tactic D
-      || parse_operator_decl D
-      || parse_operator_def D
+  fun parseDecl D =
+      parseTheorem D
+      || parseTactic D
+      || parseOperatorDecl D
+      || parseOperatorDef D
 
   fun parse' D () =
-    (parse_decl D << dot) -- (fn D' =>
+    (parseDecl D << dot) -- (fn D' =>
       $ (parse' D') <|>
       (whiteSpace >> not any) return D')
 

--- a/src/lcf.fun
+++ b/src/lcf.fun
@@ -6,8 +6,8 @@ struct
   type evidence = evidence
   type validation = evidence list -> evidence
   type tactic = goal -> (goal list * validation)
-  val goal_to_string = Sequent.to_string
-  val goal_apart = not o Sequent.eq
+  val goalToString = Sequent.toString
+  val goalApart = not o Sequent.eq
 end
 
 structure Lcf = Lcf

--- a/src/level.sig
+++ b/src/level.sig
@@ -1,10 +1,10 @@
 signature LEVEL =
 sig
   type t
-  val to_string : t -> string
+  val toString : t -> string
 
   exception LevelError
-  val assert_lt : t * t -> unit
+  val assertLt : t * t -> unit
   val unify : t * t -> t
   val max : t * t -> t
 end

--- a/src/level.sml
+++ b/src/level.sml
@@ -2,10 +2,10 @@ structure Level :> LEVEL where type t = int =
 struct
   type t = int
 
-  fun to_string i = Int.toString i
+  fun toString i = Int.toString i
 
   exception LevelError
-  fun assert_lt (i, j) = if i < j then () else raise LevelError
+  fun assertLt (i, j) = if i < j then () else raise LevelError
   fun unify (i, j) = if i = j then i else raise LevelError
   fun max (i, j) = Int.max (i, j)
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -3,21 +3,21 @@ struct
   fun main (_, args) =
     let
       val (opts, files) = List.partition (String.isPrefix "--") args
-      val check_mode = List.exists (fn opt => opt = "--check") opts
+      val checkMode = List.exists (fn opt => opt = "--check") opts
 
-      fun load_file (f, dev) = CttFrontend.load_file (dev, f)
+      fun loadFile (f, dev) = CttFrontend.loadFile (dev, f)
 
       val D =
-        SOME (foldl load_file Development.empty files)
+        SOME (foldl loadFile Development.empty files)
         handle e => (print (exnMessage e); NONE)
     in
       case D of
            NONE => 1
          | SOME development =>
-             if check_mode then
+             if checkMode then
                0
              else
-              (CttFrontend.print_development development; 0)
+              (CttFrontend.printDevelopment development; 0)
               handle e => (print ("Error: " ^ exnMessage e ^ "\n"); 1)
     end
 end

--- a/src/operator.sml
+++ b/src/operator.sml
@@ -24,7 +24,7 @@ struct
     | EQ | MEM
     | SUBSET
 
-    | CUSTOM of {label : 'label, arity : int vector}
+    | CUSTOM of {label : 'label, arity : Arity.t}
 end
 
 signature CTT_OPERATOR =
@@ -33,7 +33,7 @@ sig
 
   include PARSE_OPERATOR
     where type t = Label.t OperatorType.operator
-    where type env = Label.t -> int vector
+    where type env = Label.t -> Arity.t
 
 end
 
@@ -45,7 +45,7 @@ struct
   structure Label = Label
   type t = Label.t operator
 
-  type env = Label.t -> int vector
+  type env = Label.t -> Arity.t
   fun eq (UNIV_EQ, UNIV_EQ) = true
     | eq (CUM, CUM) = true
     | eq (EQ_EQ, EQ_EQ) = true

--- a/src/operator.sml
+++ b/src/operator.sml
@@ -160,7 +160,7 @@ struct
 
        | CUSTOM {arity,...} => arity
 
-  fun to_string O =
+  fun toString O =
     case O of
          UNIV_EQ => "U⁼"
        | CUM => "cum"
@@ -204,7 +204,7 @@ struct
        | SUBSET_ELIM => "subset-elim"
        | SUBSET_MEMBER_EQ => "subset-member-eq"
 
-       | UNIV i => "U<" ^ Level.to_string i ^ ">"
+       | UNIV i => "U<" ^ Level.toString i ^ ">"
        | VOID => "void"
        | UNIT => "unit"
        | AX => "⬧"
@@ -220,7 +220,7 @@ struct
 
        | SUBSET => "subset"
 
-       | CUSTOM {label,...} => Label.to_string label
+       | CUSTOM {label,...} => Label.toString label
 
   local
     open ParserCombinators CharParser
@@ -261,7 +261,7 @@ struct
              SOME arity => succeed (CUSTOM {label = lbl, arity = arity})
            | NONE => fail "no such operator")
 
-    fun parse_operator lookup =
+    fun parseOperator lookup =
       intensional_parse_operator lookup
         || extensional_parse_operator
   end

--- a/src/sequent.fun
+++ b/src/sequent.fun
@@ -9,15 +9,15 @@ struct
 
   infix >>
 
-  fun to_string (H >> P) =
+  fun toString (H >> P) =
     let
-      val ctx = Context.to_string H
-      val prop = Syntax.to_string P
+      val ctx = Context.toString H
+      val prop = Syntax.toString P
     in
-      if Context.is_empty H then
+      if Context.isEmpty H then
         "⊢ " ^ prop
       else
-        Context.to_string H ^ "\n⊢ " ^ prop
+        Context.toString H ^ "\n⊢ " ^ prop
     end
 
   fun eq (H >> P, H' >> P') =

--- a/src/sequent.sig
+++ b/src/sequent.sig
@@ -9,6 +9,6 @@ sig
   datatype sequent = >> of context * term
 
   val eq : sequent * sequent -> bool
-  val to_string : sequent -> string
+  val toString : sequent -> string
 end
 

--- a/src/syntax.sml
+++ b/src/syntax.sml
@@ -51,7 +51,7 @@ struct
     infix 8 $$ // \\
     open MyOp
   in
-    val to_string =
+    val toString =
     let
       fun enclose E =
         case out E of
@@ -65,15 +65,15 @@ struct
                let
                  val (x, B) = unbind xB
                in
-                 "⋂" ^ Variable.to_string x ^ " ∈ " ^ display A ^ ". " ^ display B
+                 "⋂" ^ Variable.toString x ^ " ∈ " ^ display A ^ ". " ^ display B
                end
 
            | FUN $ #[A, xB] =>
                let
                  val (x, B) = unbind xB
                in
-                 if has_free (B, x) then
-                   "Π" ^ Variable.to_string x ^ " ∈ " ^ display A ^ ". " ^ display B
+                 if hasFree (B, x) then
+                   "Π" ^ Variable.toString x ^ " ∈ " ^ display A ^ ". " ^ display B
                  else
                    enclose A ^ " => " ^ display B
                end
@@ -82,8 +82,8 @@ struct
                let
                  val (x, B) = unbind xB
                in
-                 if has_free (B, x) then
-                   "Σ" ^ Variable.to_string x ^ " ∈ " ^ display A ^ ". " ^ display B
+                 if hasFree (B, x) then
+                   "Σ" ^ Variable.toString x ^ " ∈ " ^ display A ^ ". " ^ display B
                  else
                    enclose A ^ " × " ^ display B
                end
@@ -92,8 +92,8 @@ struct
                let
                  val (x, B) = unbind xB
                in
-                 if has_free (B, x) then
-                   "{" ^ Variable.to_string x ^ " ∈ " ^ display A ^ " | " ^ display B ^ "}"
+                 if hasFree (B, x) then
+                   "{" ^ Variable.toString x ^ " ∈ " ^ display A ^ " | " ^ display B ^ "}"
                  else
                    "{" ^ display A ^ " | " ^ display B ^ "}"
                end
@@ -121,10 +121,10 @@ struct
            | UNIV i $ #[] =>
                "U" ^ subscript i
 
-           | _ => to_string_open display E
+           | _ => toStringOpen display E
 
       and dvar (x, E) =
-        if has_free (E, x) then Variable.to_string x else "_"
+        if hasFree (E, x) then Variable.toString x else "_"
 
       and subscript i =
         case i of

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -5,7 +5,7 @@ functor TacticScript
      where type evidence = Lcf.evidence
 
    type env
-   val parse_rule : env -> Lcf.tactic CharParser.charParser) : TACTIC_SCRIPT =
+   val parseRule : env -> Lcf.tactic CharParser.charParser) : TACTIC_SCRIPT =
 struct
   structure Lcf = Lcf
   type env = env
@@ -39,41 +39,41 @@ struct
 
   val pipe = symbol "|"
 
-  val parse_id : tactic charParser =
+  val parseId : tactic charParser =
     !! (symbol "id") wth (fn (name, pos) =>
       Lcf.annotate ({name = name, pos = pos}, ID))
 
-  val parse_fail : tactic charParser =
+  val parseFail : tactic charParser =
     !! (symbol "fail") wth (fn (name, pos) =>
       Lcf.annotate ({name = name, pos = pos}, FAIL))
 
-  fun parse_script D () : tactic charParser =
-    separate1 ((squares (commaSep ($ (parse_script D))) wth Sum.INL) <|> ($ (plain D) wth Sum.INR)) semi
+  fun parseScript D () : tactic charParser =
+    separate1 ((squares (commaSep ($ (parseScript D))) wth Sum.INL) <|> ($ (plain D) wth Sum.INR)) semi
     wth (foldl (fn (t1, t2) =>
                    case t1 of
                         Sum.INR t => THEN (t2, t)
                       | Sum.INL ts => THENL (t2, ts)) ID)
 
   and plain D () =
-    parse_rule D
-      || $ (parse_try D)
-      || $ (parse_repeat D)
-      || $ (parse_orelse D)
-      || parse_id
-      || parse_fail
+    parseRule D
+      || $ (parseTry D)
+      || $ (parseRepeat D)
+      || $ (parseOrelse D)
+      || parseId
+      || parseFail
 
-  and parse_try D () =
-        middle (symbol "?{") ($ (parse_script D)) (symbol "}")
+  and parseTry D () =
+        middle (symbol "?{") ($ (parseScript D)) (symbol "}")
           wth TRY
 
-  and parse_repeat D () =
-        middle (symbol "*{") ($ (parse_script D)) (symbol "}")
+  and parseRepeat D () =
+        middle (symbol "*{") ($ (parseScript D)) (symbol "}")
           wth LIMIT
 
-  and parse_orelse D () =
-        parens (separate1 ($ (parse_script D)) pipe)
+  and parseOrelse D () =
+        parens (separate1 ($ (parseScript D)) pipe)
         wth foldl ORELSE FAIL
 
-  fun parse D = $ (parse_script D) << opt (dot || semi)
+  fun parse D = $ (parseScript D) << opt (dot || semi)
 end
 


### PR DESCRIPTION
Now that I've seen a bit more SML code, I have a better idea of "standard" coding style:
1. `SNAKE_CASE` for signature names
2. `PascalCase` for structure & functor names
3. `snake_case` for type names
4. `camelCase` for function and value names
5. `snake_case.{sig|fun|sml}` for file names

(Honestly, the combination of all these conventions is a bit of a mess, but it seems pretty widespread, so we'll follow it.)
