### PR TITLE
Added syntax for trace tactical

### DIFF
--- a/example/trace.jonprl
+++ b/example/trace.jonprl
@@ -1,0 +1,8 @@
+Theorem sym :
+  [∀(U<0>; A.
+   ∀(A; M.
+   ∀(A; N.
+   ∀(=(M; N; A); _. =(N; M; A)))))] {
+   auto; trace "Here's a quick message\n\twith escapes";
+   symmetry; auto
+}.

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -32,6 +32,11 @@ struct
     !! (symbol "fail") wth (fn (name, pos) =>
       Lcf.annotate ({name = name, pos = pos}, FAIL))
 
+  val parseTrace : tactic charParser =
+    !! (symbol "trace") && stringLiteral
+      wth (fn ((name, pos), msg) =>
+              Lcf.annotate ({name = name, pos = pos}, (TRACE msg)))
+
   fun parseScript D () : tactic charParser =
     separate1 ((squares (commaSep ($ (parseScript D))) wth Sum.INL) <|> ($ (plain D) wth Sum.INR)) semi
     wth (foldl (fn (t1, t2) =>
@@ -46,6 +51,7 @@ struct
       || $ (parseOrelse D)
       || parseId
       || parseFail
+      || parseTrace
 
   and parseTry D () =
         middle (symbol "?{") ($ (parseScript D)) (symbol "}")
@@ -53,7 +59,7 @@ struct
 
   and parseRepeat D () =
         middle (symbol "*{") ($ (parseScript D)) (symbol "}")
-          wth LIMIT
+        wth LIMIT
 
   and parseOrelse D () =
         parens (separate1 ($ (parseScript D)) pipe)
@@ -61,4 +67,3 @@ struct
 
   fun parse D = $ (parseScript D) << opt (dot || semi)
 end
-


### PR DESCRIPTION
This just adds surface syntax for the trace tactical sml-lcf now has lying around. You can use it with `trace "A normal string"` and it will print to standard out when executed.  I've added a small example in `trace.jonprl`.

This relies on parcom's notion of a string which includes helpful things like escapes.
