### PR TITLE
Better error messages

### DIFF
--- a/src/development.fun
+++ b/src/development.fun
@@ -85,8 +85,6 @@ struct
 
   val empty = Telescope.empty
 
-  exception RemainingSubgoals of judgement list
-
   fun prove T (lbl, goal, tac) =
     let
       val (subgoals, validation) = tac goal
@@ -96,7 +94,7 @@ struct
                   {statement = goal,
                    script = tac,
                    evidence = Susp.delay (fn _ => validation [])})
-         | _ => raise RemainingSubgoals subgoals
+         | _ => raise Fail "Subgoals not discharged"
     end
 
   fun defineTactic T (lbl, tac) =

--- a/src/development.sig
+++ b/src/development.sig
@@ -38,7 +38,6 @@ sig
 
   (* extend a development with a theorem *)
   val prove : world -> label * judgement * tactic -> world
-  exception RemainingSubgoals of judgement list
 
   (* extend a development with a custom tactic *)
   val defineTactic : world -> label * tactic -> world

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -32,7 +32,6 @@ functor DevelopmentParser
 
    val declareOperator : TacticScript.world -> (Tactic.label * Arity.t) -> TacticScript.world
    val lookupOperator : TacticScript.world -> Tactic.label -> Arity.t
-
    val stringToLabel  : string -> Tactic.label) : DEVELOPMENT_PARSER =
 struct
   type world = TacticScript.world
@@ -61,9 +60,10 @@ struct
   fun parseTheorem D =
     reserved "Theorem" >> parseLabel << colon
       && parseTm [] D
-      && braces (TacticScript.parse D)
-      wth (fn (thm, (M, tac)) =>
-             (D, DevelopmentAst.THEOREM (thm, M, tac)))
+      && braces (!! (TacticScript.parse D))
+      wth (fn (thm, (M, (tac, pos))) =>
+             (D, DevelopmentAst.THEOREM
+               (thm, M, Tactic.COMPLETE (tac, {name = "COMPLETE", pos = pos}))))
 
   val parseInt =
     repeat1 digit wth valOf o Int.fromString o String.implode

--- a/src/development_parser.fun
+++ b/src/development_parser.fun
@@ -30,9 +30,7 @@ functor DevelopmentParser
      where type tactic = Tactic.t
      where type world = world
 
-   val declareOperator : TacticScript.world
-                          -> (Tactic.label * Arity.t)
-                          -> TacticScript.world
+   val declareOperator : TacticScript.world -> (Tactic.label * Arity.t) -> TacticScript.world
    val lookupOperator : TacticScript.world -> Tactic.label -> Arity.t
 
    val stringToLabel  : string -> Tactic.label) : DEVELOPMENT_PARSER =

--- a/src/main.sml
+++ b/src/main.sml
@@ -7,9 +7,7 @@ struct
 
       fun loadFile (f, dev) = CttFrontend.loadFile (dev, f)
 
-      val D =
-        SOME (foldl loadFile Development.empty files)
-        handle e => (print (exnMessage e); NONE)
+      val D = SOME (foldl loadFile Development.empty files) handle _ => NONE
     in
       case D of
            NONE => 1

--- a/src/tactic.sig
+++ b/src/tactic.sig
@@ -37,9 +37,10 @@ sig
       | SYMMETRY of meta
       | TRY of t
       | LIMIT of t
-      | ORELSE of t list
+      | ORELSE of t list * meta
       | THEN of (t, t list) Sum.sum list
       | ID of meta
       | FAIL of meta
       | TRACE of string * meta
+      | COMPLETE of t * meta
 end

--- a/src/tactic.sml
+++ b/src/tactic.sml
@@ -38,9 +38,10 @@ struct
     | SYMMETRY of meta
     | TRY of t
     | LIMIT of t
-    | ORELSE of t list
+    | ORELSE of t list * meta
     | THEN of (t, t list) Sum.sum list
     | ID of meta
     | FAIL of meta
+    | COMPLETE of t * meta
     | TRACE of string * meta
 end

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -1,11 +1,13 @@
 structure TacticEval :
 sig
+  exception RemainingSubgoals of Development.judgement list
   val eval : Development.world -> Tactic.t -> Ctt.tactic
 end =
 struct
   open Tactic
   open Ctt.Rules
   structure T = ProgressTacticals(Lcf)
+  exception RemainingSubgoals = T.RemainingSubgoals
 
   fun an a t = AnnotatedLcf.annotate (a, t)
 
@@ -38,7 +40,7 @@ struct
       | SYMMETRY a => an a EqSym
       | TRY tac => T.TRY (eval wld tac)
       | LIMIT tac => T.LIMIT (eval wld tac)
-      | ORELSE tacs => List.foldl T.ORELSE T.FAIL (map (eval wld) tacs)
+      | ORELSE (tacs, a) => an a (List.foldl T.ORELSE T.FAIL (map (eval wld) tacs))
       | THEN ts =>
         List.foldl
           (fn (Sum.INL x, rest) => T.THEN (rest, (eval wld) x)
@@ -48,4 +50,5 @@ struct
       | ID a => an a T.ID
       | FAIL a => an a T.FAIL
       | TRACE (msg, a) => an a (T.TRACE msg)
+      | COMPLETE (t, a) => an a (T.COMPLETE (eval wld t))
 end

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -40,10 +40,11 @@ struct
       | LIMIT tac => T.LIMIT (eval wld tac)
       | ORELSE tacs => List.foldl T.ORELSE T.FAIL (map (eval wld) tacs)
       | THEN ts =>
-        List.foldl (fn (Sum.INL x, rest) => T.THEN (rest, (eval wld) x)
-                     | (Sum.INR xs, rest) => T.THENL (rest, map (eval wld) xs))
-                   T.ID
-                   ts
+        List.foldl
+          (fn (Sum.INL x, rest) => T.THEN (rest, (eval wld) x)
+            | (Sum.INR xs, rest) => T.THENL (rest, map (eval wld) xs))
+          T.ID
+          ts
       | ID a => an a T.ID
       | FAIL a => an a T.FAIL
       | TRACE (msg, a) => an a (T.TRACE msg)

--- a/src/tactic_script.fun
+++ b/src/tactic_script.fun
@@ -43,6 +43,7 @@ struct
       || $ (parseTry D)
       || $ (parseRepeat D)
       || $ (parseOrelse D)
+      || $ (parseComplete D)
       || parseId
       || parseFail
       || parseTrace
@@ -56,8 +57,12 @@ struct
     wth LIMIT
 
   and parseOrelse D () =
-    parens (separate1 ($ (parseScript D)) pipe)
-    wth ORELSE
+    !! (parens (separate1 ($ (parseScript D)) pipe))
+    wth (fn (ts, pos) => ORELSE (ts, {name = "ORELSE", pos = pos}))
+
+  and parseComplete D () =
+    !! (middle (symbol "!{") ($ (parseScript D)) (symbol "}"))
+    wth (fn (t, pos) => COMPLETE (t, {name = "COMPLETE", pos = pos}))
 
   fun parse D = $ (parseScript D) << opt (dot || semi)
 end

--- a/src/tactic_script.sig
+++ b/src/tactic_script.sig
@@ -2,5 +2,6 @@ signature TACTIC_SCRIPT =
 sig
   type tactic
   type world
+
   val parse : world -> tactic CharParser.charParser
 end


### PR DESCRIPTION
- use `COMPLETE` tactical

Essentially, this PR makes it so that "Remaining Subgoals" gets the standard presentation with a source position.
