### PR TITLE
Added forgotten beta conversion for decide

### DIFF
--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -51,6 +51,11 @@ Theorem test10 : [∀(U<0>; A.
   auto; elim #3; [intro #1, intro #0]; auto
 }.
 
+Theorem test11 :
+        [=(decide(inl(<>); x.x; y.y); decide(inr(<>); x.x; y.y); unit)] {
+  auto
+}.
+
 Theorem axiom-of-choice : [∀(U<0>; A. ∀(U<0>; B. ∀(Π(A; _. Π(B; _. U<0>)); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
   auto; intro [λ(w. spread(ap(φ;w); x.y.x))]; auto;
   elim #4 [a]; auto;

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -946,6 +946,11 @@ struct
     val SpreadBeta : conv = reductionRule
       (fn SPREAD $ #[PAIR $ #[M,N], xyE] => (into xyE // M) // N
         | _ => raise Conv)
+
+    val DecideBeta : conv = reductionRule
+      (fn DECIDE $ #[INL $ #[E], N, M] => (into N // E)
+        | DECIDE $ #[INR $ #[E], N, M] => (into M // E)
+        | _ => raise Conv)
   end
 end
 

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -152,5 +152,6 @@ sig
   sig
     val ApBeta : conv
     val SpreadBeta : conv
+    val DecideBeta : conv
   end
 end

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -123,7 +123,7 @@ struct
     open Conversions Conversionals
     infix CORELSE
 
-    val Reduce = ApBeta CORELSE SpreadBeta
+    val Reduce = ApBeta CORELSE SpreadBeta CORELSE DecideBeta
     val DeepReduce = RewriteGoal (CDEEP Reduce)
   in
     val Auto =


### PR DESCRIPTION
I added a conversion rule for decide so that

```
decide(inl(X);  x.M; x.N) = [X/x]M
decide(inr(X); x.M; x.N) = [X/x]N
```

and a corresponding test to make sure `auto` can prove such things.
