### PR TITLE
Added assert tactic

### DIFF
--- a/example/assert.jonprl
+++ b/example/assert.jonprl
@@ -1,0 +1,5 @@
+Theorem trivial-assertion : [unit] {
+  assert [Π(unit; _.unit)];
+  [auto, elim #1 [<>]];
+  [auto, assumption]
+}.

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -159,6 +159,12 @@ struct
     fn w => symbol "assumption"
       wth (fn name => fn pos => ASSUMPTION {name = name, pos = pos})
 
+  val parseAssert : tactic_parser =
+   fn w => symbol "assert" && parseTm w && opt (brackets parseName)
+     wth (fn (name, (term, hyp)) => fn pos =>
+             ASSERT ({assertion = term, name = hyp},
+                     {name = name, pos = pos}))
+
   val parseMemCd : tactic_parser =
     fn w => symbol "mem-cd"
       wth (fn name => fn pos => MEM_CD {name = name, pos = pos})
@@ -207,6 +213,7 @@ struct
       || parseReduce w
       || parseMemCd w
       || parseAssumption w
+      || parseAssert w
       || parseSymmetry w
 
   val parse : world -> Tactic.t charParser =

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -830,6 +830,19 @@ struct
            SOME (x, _) => Hypothesis_ x (H >> P)
          | NONE => raise Refine
 
+    fun Assert (term, name) (H >> P) =
+      let
+        val k =
+            case name of
+                SOME k => k
+              | NONE => Context.fresh (H, Variable.named "H")
+      in
+        [ H >> term
+        , H @@ (k, term) >> P
+        ] BY (fn [D, E] => ASSERT $$ #[D, k \\ E]
+               | _ => raise Refine)
+      end
+
     fun Unfold (development, lbl) (H >> P) =
       let
         open Conversionals

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -132,6 +132,7 @@ sig
     val Witness : term -> tactic
 
     val Assumption : tactic
+    val Assert     : term * name option -> tactic
     val Hypothesis : int -> tactic
     val HypEq : tactic
     val EqInSupertype : tactic

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -71,6 +71,7 @@ struct
        | EQ_SUBST $ #[_, D, _] => extract D
 
        | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
+       | ASSERT $ #[D, E] => AP $$ #[LAM $$ #[E], extract D]
 
        | ` x => `` x
        | x \ E => x \\ extract E

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -13,7 +13,7 @@ struct
     | SUBSET_EQ | SUBSET_INTRO | IND_SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
     | PLUS_EQ | PLUS_INTROL | PLUS_INTROR | PLUS_ELIM | INL_EQ | INR_EQ | DECIDE_EQ
 
-    | ADMIT
+    | ADMIT | ASSERT
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -81,6 +81,7 @@ struct
     | eq (SUBSET_ELIM, SUBSET_ELIM) = true
     | eq (SUBSET_MEMBER_EQ, SUBSET_MEMBER_EQ) = true
     | eq (ADMIT, ADMIT) = true
+    | eq (ASSERT, ASSERT) = true
     | eq (UNIV i, UNIV j) = i = j
     | eq (VOID, VOID) = true
     | eq (UNIT, UNIT) = true
@@ -164,6 +165,7 @@ struct
        | SUBSET_MEMBER_EQ => #[0,0,1]
 
        | ADMIT => #[]
+       | ASSERT => #[0, 1]
 
        | UNIV i => #[]
        | VOID => #[]
@@ -237,6 +239,7 @@ struct
        | EQ_SUBST => "subst"
        | EQ_SYM => "sym"
        | ADMIT => "<<<<<ADMIT>>>>>"
+       | ASSERT => "assert"
 
        | SUBSET_EQ => "subset⁼"
        | SUBSET_INTRO => "subset-intro"

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -25,6 +25,7 @@ struct
     | EQ | MEM
     | SUBSET
     | PLUS | INL | INR | DECIDE
+    | CEQUAL
 
     | CUSTOM of {label : 'label, arity : Arity.t}
     | SO_APPLY
@@ -107,6 +108,7 @@ struct
     | eq (INL, INL) = true
     | eq (INR, INR) = true
     | eq (DECIDE, DECIDE) = true
+    | eq (CEQUAL, CEQUAL) = true
     | eq _ = false
 
   fun arity O =
@@ -182,6 +184,7 @@ struct
 
        | EQ => #[0,0,0]
        | MEM => #[0,0]
+       | CEQUAL => #[0, 0]
 
        | SUBSET => #[0,1]
 
@@ -254,6 +257,7 @@ struct
        | ISECT => "⋂"
        | EQ => "="
        | MEM => "∈"
+       | CEQUAL => "~"
        | PLUS => "+"
        | INL => "inl"
        | INR => "inr"
@@ -298,6 +302,7 @@ struct
         || string "∀" return ISECT
         || string "⋂" return ISECT
         || string "=" return EQ
+        || string "~" return CEQUAL
         || string "∈" return MEM
         || string "subset" return SUBSET
         || string "so_apply" return SO_APPLY

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -25,7 +25,6 @@ struct
     | EQ | MEM
     | SUBSET
     | PLUS | INL | INR | DECIDE
-    | CEQUAL
 
     | CUSTOM of {label : 'label, arity : Arity.t}
     | SO_APPLY
@@ -109,7 +108,6 @@ struct
     | eq (INL, INL) = true
     | eq (INR, INR) = true
     | eq (DECIDE, DECIDE) = true
-    | eq (CEQUAL, CEQUAL) = true
     | eq _ = false
 
   fun arity O =
@@ -186,7 +184,6 @@ struct
 
        | EQ => #[0,0,0]
        | MEM => #[0,0]
-       | CEQUAL => #[0, 0]
 
        | SUBSET => #[0,1]
 
@@ -260,7 +257,6 @@ struct
        | ISECT => "⋂"
        | EQ => "="
        | MEM => "∈"
-       | CEQUAL => "~"
        | PLUS => "+"
        | INL => "inl"
        | INR => "inr"
@@ -305,7 +301,6 @@ struct
         || string "∀" return ISECT
         || string "⋂" return ISECT
         || string "=" return EQ
-        || string "~" return CEQUAL
         || string "∈" return MEM
         || string "subset" return SUBSET
         || string "so_apply" return SO_APPLY

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -36,6 +36,8 @@ sig
       | REDUCE of int option * meta
       | MEM_CD of meta
       | ASSUMPTION of meta
+      | ASSERT of {assertion : term,
+                   name : name option} * meta
       | SYMMETRY of meta
       | TRY of t
       | LIMIT of t

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -34,9 +34,11 @@ struct
               level : level option} * meta
     | CUM of level option * meta
     | AUTO of meta
-     | REDUCE of int option * meta
+    | REDUCE of int option * meta
     | MEM_CD of meta
     | ASSUMPTION of meta
+    | ASSERT of {assertion : term,
+                 name : name option} * meta
     | SYMMETRY of meta
     | TRY of t
     | LIMIT of t

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -39,6 +39,8 @@ struct
       | REDUCE (i, a) => an a (CttUtil.Reduce i)
       | MEM_CD a => an a MemCD
       | ASSUMPTION a => an a Assumption
+      | ASSERT ({assertion = t, name = name}, a) =>
+        an a (Assert (t, name))
       | SYMMETRY a => an a EqSym
       | TRY tac => T.TRY (eval wld tac)
       | LIMIT tac => T.LIMIT (eval wld tac)


### PR DESCRIPTION
This corresponds to cut. The syntax is `assert [prop to prove] <optional name>` and leaves you with two goals
1. The prop
2. The original goal with an assumption of the prop added.

Cheers,
