### PR TITLE
Add ~ to JonPRL

### DIFF
--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -1,0 +1,13 @@
+Operator Y : (0).
+[Y(f)] =def= [ap(λ(x.ap(f;ap(x;x)));λ(x.ap(f;ap(x;x))))].
+
+Theorem test : [ceq(λ(x.x); λ(x.x))] {
+  sreflexivity
+}.
+
+Theorem y-is-fix-point : [
+    ∀(U<0>; A.
+    ∀(Π(A; _.A); f .
+    ceq(Y(f); ap(f;Y(f)))))] {
+  auto; unfold <Y>; step; sreflexivity
+}.

--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -11,3 +11,17 @@ Theorem y-is-fix-point : [
     ceq(Y(f); ap(f;Y(f)))))] {
   auto; unfold <Y>; step; sreflexivity
 }.
+
+Theorem transitive : [
+   ∀(U<0>; A.
+   ∀(∀(A; _.A); f.
+   ∀(∀(A; _.A); g.
+   ∀(Π(A; _.A); h.
+   ∀(ceq(f; g); _.
+   ∀(ceq(g; h); _.
+   ceq(f; h)))))))] {
+  auto; ?{sreflexivity};
+  chyp-subst → #5 [c. ceq(c; h)];
+  chyp-subst ← #6 [c. ceq(g; c)];
+  sreflexivity
+}.

--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -6,14 +6,14 @@ Theorem test : [ceq(λ(x.x); λ(x.x))] {
 }.
 
 Theorem y-is-fix-point : [
-    ∀(U<0>; A.
+    ∀(U{i}; A.
     ∀(Π(A; _.A); f .
     ceq(Y(f); ap(f;Y(f)))))] {
   auto; unfold <Y>; step; sreflexivity
 }.
 
 Theorem transitive : [
-   ∀(U<0>; A.
+   ∀(U{i}; A.
    ∀(∀(A; _.A); f.
    ∀(∀(A; _.A); g.
    ∀(Π(A; _.A); h.

--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -20,7 +20,7 @@ Theorem transitive : [
    ∀(ceq(f; g); _.
    ∀(ceq(g; h); _.
    ceq(f; h)))))))] {
-  auto; ?{sreflexivity};
+  auto;
   chyp-subst → #5 [c. ceq(c; h)];
   chyp-subst ← #6 [c. ceq(g; c)];
   sreflexivity

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -87,6 +87,25 @@ struct
                   level = k},
                  {name = name, pos = pos}))
 
+  val parseEqSubst : tactic_parser =
+    fn w => symbol "csubst"
+      && parseTm w && parseTm w
+      wth (fn (name, (M, N)) => fn pos =>
+              CEQ_SUBST ({left = M, right = N},
+                         {name = name, pos = pos}))
+
+  val parseHypSubst : tactic_parser =
+    fn w => symbol "chyp-subst"
+      && parseDir
+      && parseIndex
+      && parseTm w
+      wth (fn (name, (dir, (i, M))) => fn pos =>
+              CHYP_SUBST
+                ({dir = dir,
+                  index = i,
+                  domain = M},
+                 {name = name, pos = pos}))
+
   val parseIntroArgs =
     fn w => opt (parseTm w)
       && opt parseIndex

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -87,14 +87,14 @@ struct
                   level = k},
                  {name = name, pos = pos}))
 
-  val parseEqSubst : tactic_parser =
+  val parseCEqSubst : tactic_parser =
     fn w => symbol "csubst"
       && parseTm w && parseTm w
       wth (fn (name, (M, N)) => fn pos =>
               CEQ_SUBST ({left = M, right = N},
                          {name = name, pos = pos}))
 
-  val parseHypSubst : tactic_parser =
+  val parseCHypSubst : tactic_parser =
     fn w => symbol "chyp-subst"
       && parseDir
       && parseIndex
@@ -249,6 +249,8 @@ struct
       || parseCEqualRefl w
       || parseCEqualSym w
       || parseCEqualStep w
+      || parseCEqSubst w
+      || parseCHypSubst w
 
   val parse : world -> Tactic.t charParser =
     fn w => !! (tacticParsers w)

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -155,6 +155,18 @@ struct
     fn w => symbol "symmetry"
       wth (fn name => fn pos => SYMMETRY {name = name, pos = pos})
 
+  val parseCEqualRefl : tactic_parser =
+    fn w => symbol "sreflexivity"
+      wth (fn name => fn pos => CEQUAL_REFL {name = name, pos = pos})
+
+  val parseCEqualSym : tactic_parser =
+    fn w => symbol "ssymmetry"
+      wth (fn name => fn pos => CEQUAL_SYM {name = name, pos = pos})
+
+  val parseCEqualStep : tactic_parser =
+    fn w => symbol "step"
+      wth (fn name => fn pos => CEQUAL_STEP {name = name, pos = pos})
+
   val parseAssumption : tactic_parser =
     fn w => symbol "assumption"
       wth (fn name => fn pos => ASSUMPTION {name = name, pos = pos})
@@ -215,6 +227,9 @@ struct
       || parseAssumption w
       || parseAssert w
       || parseSymmetry w
+      || parseCEqualRefl w
+      || parseCEqualSym w
+      || parseCEqualStep w
 
   val parse : world -> Tactic.t charParser =
     fn w => !! (tacticParsers w)

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -967,6 +967,36 @@ struct
           ] BY (fn [D] => CEQUAL_STEP $$ #[D]
                  | _ => raise Refine)
         end
+
+      fun CEqSubst (eq, xC) (H >> P) =
+        let
+          val #[M, N] = eq ^! CEQUAL
+          val _ = unify P (xC // M)
+        in
+          [ H >> eq
+          , H >> xC // N
+          ] BY (fn [D, E] => CEQUAL_SUBST $$ #[D, E]
+                 | _ => raise Refine)
+        end
+
+      fun HypCEqSubst (dir, i, xC) (H >> P) =
+        let
+          val xC = Context.rebind H xC
+          val z = Context.nth H (i - 1)
+          val X = Context.lookup H z
+        in
+          case dir of
+              Dir.RIGHT =>
+              (CEqSubst (X, xC) THENL [Hypothesis_ z, ID]) (H >> P)
+            | Dir.LEFT =>
+              let
+                val #[M,N] = X ^! CEQUAL
+              in
+                (CEqSubst (CEQUAL $$ #[N,M], xC)
+                          THENL [CEqSym THEN Hypothesis_ z, ID]) (H >> P)
+              end
+        end
+
     end
 
     local

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -125,6 +125,7 @@ struct
          | MEM => true
          | UNIT => true
          | VOID => true
+         | CEQUAL => true
          | _ => false
 
     fun assertIrrelevant (H, P) =
@@ -935,6 +936,19 @@ struct
                    (EqSubst (EQ $$ #[N,M,A], xC, ok)
                      THENL [EqSym THEN Hypothesis_ z, ID, ID]) (H >> P)
                  end
+        end
+
+      fun CEqEq (H >> P) =
+        let
+          val #[M, N, U] = P ^! EQ
+          val (UNIV _, _) = asApp U
+          val #[L, R] = M ^! CEQUAL
+          val #[L', R'] = N ^! CEQUAL
+        in
+          [ H >> CEQUAL $$ #[L, L']
+          , H >> CEQUAL $$ #[R, R']
+          ] BY (fn [D, E] => CEQUAL_EQ $$ #[D, E]
+                 | _ => raise Refine)
         end
 
       fun CEqRefl (H >> P) =

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -148,6 +148,8 @@ sig
     val CEqRefl : tactic
     val CEqSym  : tactic
     val CEqStep : tactic
+    val CEqSubst : term * term -> tactic
+    val HypCEqSubst : Dir.dir * int * term -> tactic
 
     val HypEqSubst : Dir.dir * int * term * Level.t option -> tactic
   end

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -145,6 +145,7 @@ sig
     val EqSubst : term * term * Level.t option -> tactic
     val EqSym : tactic
 
+    val CEqEq : tactic
     val CEqRefl : tactic
     val CEqSym  : tactic
     val CEqStep : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -145,6 +145,10 @@ sig
     val EqSubst : term * term * Level.t option -> tactic
     val EqSym : tactic
 
+    val CEqRefl : tactic
+    val CEqSym  : tactic
+    val CEqStep : tactic
+
     val HypEqSubst : Dir.dir * int * term * Level.t option -> tactic
   end
 

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -77,6 +77,7 @@ struct
     in
       AxEq
         ORELSE EqEq
+        ORELSE CEqEq
         ORELSE UnitEq
         ORELSE VoidEq
         ORELSE HypEq

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -53,6 +53,7 @@ struct
        ORELSE IndependentProdIntro
        ORELSE_LAZY (fn _ => SubsetIntro (valOf term, freshVariable, level))
        ORELSE IndependentSubsetIntro
+       ORELSE CEqRefl
 
   fun take2 (x::y::_) = SOME (x,y)
     | take2 _ = NONE

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -29,6 +29,7 @@ struct
        | CEQUAL_REFL $ _ => ax
        | CEQUAL_SYM $ _ => ax
        | CEQUAL_STEP $ _ => ax
+       | CEQUAL_SUBST $ #[D, E] => extract E
 
        | PROD_EQ $ _ => ax
        | PROD_INTRO $ #[M, D, E, xF] => PAIR $$ #[M, extract E]

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -25,6 +25,10 @@ struct
        | UNIT_ELIM $ #[R, E] => extract E
        | AX_EQ $ _ => AX $$ #[]
        | EQ_SYM $ _ => ax
+       | CEQUAL_EQ $ _ => ax
+       | CEQUAL_REFL $ _ => ax
+       | CEQUAL_SYM $ _ => ax
+       | CEQUAL_STEP $ _ => ax
 
        | PROD_EQ $ _ => ax
        | PROD_INTRO $ #[M, D, E, xF] => PAIR $$ #[M, extract E]

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -64,6 +64,11 @@ struct
             | CANON => stepDecideBeta (S, L, R)
         )
       | SO_APPLY $ #[L, R] => (
+          (* This can't come up but I don't think it's wrong
+           * Leaving this in here so it's an actual semantics
+           * for the core type theory: not just what users
+           * can say with the syntax we give.
+           *)
           case out L of
             x \ L => STEP (subst R x L)
            | _ =>

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -1,0 +1,70 @@
+functor SmallStep (Syn : ABT_UTIL where type Operator.t = StringVariable.t OperatorType.operator)
+        : SMALL_STEP =
+struct
+  type syn = Syn.t
+
+  open Syn
+  open Operator
+  open OperatorType
+  infix $ \ $$ \\ //
+
+
+  exception Stuck of Syn.t
+  datatype t = STEP of Syn.t | CANON
+
+  fun stepSpreadBeta (P, E) =
+    case out P of
+        PAIR $ #[L, R] => R // (L // E)
+      | _ => raise Stuck (SPREAD $$ #[P, E])
+
+  fun stepApBeta (F, A) =
+    case out F of
+        LAM $ #[B] => A // B
+      | _ => raise Stuck (AP $$ #[F, A])
+
+  fun stepDecideBeta (S, L, R) =
+    case out S of
+        INL $ #[A] => A // L
+      | INR $ #[B] => B // R
+      | _ => raise Stuck (DECIDE $$ #[S, L, R])
+
+  fun step e =
+    case out e of
+        UNIV _ $ _ => CANON
+      | VOID $ _ => CANON
+      | UNIT $ _ => CANON
+      | AX $ _ => CANON
+      | PROD $ _ => CANON
+      | PAIR $ _ => CANON
+      | SPREAD $ #[P, E] =>
+        STEP (
+          case step P of
+              STEP P' => SPREAD $$ #[P', E]
+            | CANON => stepSpreadBeta (P, E)
+        )
+      | FUN $ _ => CANON
+      | LAM $ _ => CANON
+      | AP $ #[L, R] =>
+        STEP (
+          case step L of
+              STEP L' => AP $$ #[L', R]
+            | CANON => stepApBeta (L, R)
+        )
+      | ISECT $ _ => CANON
+      | EQ $ _ => CANON
+      | MEM $ _ => CANON
+      | SUBSET $ _ => CANON
+      | PLUS $ _ => CANON
+      | INL $ _ => CANON
+      | INR $ _ => CANON
+      | DECIDE $ #[S, L, R] =>
+        STEP (
+          case step S of
+              STEP S' => DECIDE $$ #[S', L, R]
+            | CANON => stepDecideBeta (S, L, R)
+        )
+      | SO_APPLY $ #[L, R] => raise Stuck e
+      | CUSTOM _ $ _ => raise Stuck e (* Require unfolding elsewhere *)
+      | ` _ => raise Stuck e (* Cannot step an open term *)
+      | _ \ _ =>raise Stuck e (* Cannot step a binder *)
+end

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -63,7 +63,14 @@ struct
               STEP S' => DECIDE $$ #[S', L, R]
             | CANON => stepDecideBeta (S, L, R)
         )
-      | SO_APPLY $ #[L, R] => raise Stuck e
+      | SO_APPLY $ #[L, R] => (
+          case out L of
+            x \ L => STEP (subst R x L)
+           | _ =>
+             case step L of
+               CANON => raise Stuck (SO_APPLY $$ #[L, R])
+              | STEP L' => STEP (SO_APPLY $$ #[L', R])
+      )
       | CUSTOM _ $ _ => raise Stuck e (* Require unfolding elsewhere *)
       | ` _ => raise Stuck e (* Cannot step an open term *)
       | _ \ _ =>raise Stuck e (* Cannot step a binder *)

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -14,18 +14,18 @@ struct
 
   fun stepSpreadBeta (P, E) =
     case out P of
-        PAIR $ #[L, R] => R // (L // E)
+        PAIR $ #[L, R] => (E // L) // R
       | _ => raise Stuck (SPREAD $$ #[P, E])
 
   fun stepApBeta (F, A) =
     case out F of
-        LAM $ #[B] => A // B
+        LAM $ #[B] => B // A
       | _ => raise Stuck (AP $$ #[F, A])
 
   fun stepDecideBeta (S, L, R) =
     case out S of
-        INL $ #[A] => A // L
-      | INR $ #[B] => B // R
+        INL $ #[A] => L // A
+      | INR $ #[B] => R // B
       | _ => raise Stuck (DECIDE $$ #[S, L, R])
 
   fun step e =

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -78,5 +78,6 @@ struct
       )
       | CUSTOM _ $ _ => raise Stuck e (* Require unfolding elsewhere *)
       | ` _ => raise Stuck e (* Cannot step an open term *)
-      | _ \ _ =>raise Stuck e (* Cannot step a binder *)
+      | _ \ _ => raise Stuck e (* Cannot step a binder *)
+      | _ => raise Stuck e
 end

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -1,5 +1,5 @@
 functor SmallStep (Syn : ABT_UTIL where type Operator.t = StringVariable.t OperatorType.operator)
-        : SMALL_STEP =
+        : SMALL_STEP where type syn = Syn.t =
 struct
   type syn = Syn.t
 
@@ -81,3 +81,5 @@ struct
       | _ \ _ => raise Stuck e (* Cannot step a binder *)
       | _ => raise Stuck e
 end
+
+structure Semantics = SmallStep(Syntax)

--- a/src/prover/small_step.sig
+++ b/src/prover/small_step.sig
@@ -1,0 +1,9 @@
+signature SMALL_STEP =
+sig
+    type syn
+
+    datatype t = STEP of syn | CANON
+    exception Stuck of syn
+
+    val step : syn -> t
+end

--- a/src/prover/sources.cm
+++ b/src/prover/sources.cm
@@ -14,6 +14,9 @@ group is
   extract.sig
   extract.fun
 
+  small_step.fun
+  small_step.sig
+
   context.fun
   context.sig
 

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -99,6 +99,7 @@ struct
     | eq (AP, AP) = true
     | eq (ISECT, ISECT) = true
     | eq (EQ, EQ) = true
+    | eq (CEQUAL, CEQUAl) = true
     | eq (MEM, MEM) = true
     | eq (SUBSET, SUBSET) = true
     | eq (CUSTOM o1, CUSTOM o2) = Label.eq (#label o1, #label o2)
@@ -317,7 +318,7 @@ struct
         || string "∀" return ISECT
         || string "⋂" return ISECT
         || string "=" return EQ
-        || string "~" return CEQUAL
+        || string "ceq" return CEQUAL
         || string "∈" return MEM
         || string "subset" return SUBSET
         || string "so_apply" return SO_APPLY

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -14,6 +14,7 @@ struct
     | PLUS_EQ | PLUS_INTROL | PLUS_INTROR | PLUS_ELIM | INL_EQ | INR_EQ | DECIDE_EQ
 
     | ADMIT | ASSERT
+    | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -25,6 +26,7 @@ struct
     | EQ | MEM
     | SUBSET
     | PLUS | INL | INR | DECIDE
+    | CEQUAL
 
     | CUSTOM of {label : 'label, arity : Arity.t}
     | SO_APPLY
@@ -50,6 +52,7 @@ struct
   fun eq (UNIV_EQ i, UNIV_EQ j) = i = j
     | eq (CUM, CUM) = true
     | eq (EQ_EQ, EQ_EQ) = true
+    | eq (CEQUAL_EQ, CEQUAL_EQ) = true
     | eq (VOID_EQ, VOID_EQ) = true
     | eq (VOID_ELIM, VOID_ELIM) = true
     | eq (UNIT_EQ, UNIT_EQ) = true
@@ -63,6 +66,9 @@ struct
     | eq (PAIR_EQ, PAIR_EQ) = true
     | eq (SPREAD_EQ, SPREAD_EQ) = true
     | eq (FUN_EQ, FUN_EQ) = true
+    | eq (CEQUAL_REFL, CEQUAL_REFL) = true
+    | eq (CEQUAL_SYM, CEQUAL_SYM) = true
+    | eq (CEQUAL_STEP, CEQUAL_STEP) = true
     | eq (FUN_INTRO, FUN_INTRO) = true
     | eq (FUN_ELIM, FUN_ELIM) = true
     | eq (LAM_EQ, LAM_EQ) = true
@@ -115,6 +121,10 @@ struct
          UNIV_EQ _ => #[]
        | CUM => #[0]
        | EQ_EQ => #[0,0,0]
+       | CEQUAL_EQ => #[0, 0]
+       | CEQUAL_REFL => #[]
+       | CEQUAL_SYM => #[0]
+       | CEQUAL_STEP => #[0]
        | VOID_EQ => #[]
        | VOID_ELIM => #[0]
 
@@ -183,6 +193,7 @@ struct
        | ISECT => #[0,1]
 
        | EQ => #[0,0,0]
+       | CEQUAL => #[0, 0]
        | MEM => #[0,0]
 
        | SUBSET => #[0,1]
@@ -198,6 +209,10 @@ struct
        | VOID_ELIM => "void-elim"
 
        | EQ_EQ => "eq⁼"
+       | CEQUAL_EQ => "~⁼"
+       | CEQUAL_REFL => "~-refl"
+       | CEQUAL_SYM => "~-sym"
+       | CEQUAL_STEP => "~-step"
        | UNIT_EQ => "unit⁼"
        | UNIT_INTRO => "unit-intro"
        | UNIT_ELIM => "unit-elim"
@@ -256,6 +271,7 @@ struct
        | AP => "ap"
        | ISECT => "⋂"
        | EQ => "="
+       | CEQUAL => "~"
        | MEM => "∈"
        | PLUS => "+"
        | INL => "inl"
@@ -301,6 +317,7 @@ struct
         || string "∀" return ISECT
         || string "⋂" return ISECT
         || string "=" return EQ
+        || string "~" return CEQUAL
         || string "∈" return MEM
         || string "subset" return SUBSET
         || string "so_apply" return SO_APPLY

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -15,6 +15,7 @@ struct
 
     | ADMIT | ASSERT
     | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
+    | CEQUAL_SUBST
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -69,6 +70,7 @@ struct
     | eq (CEQUAL_REFL, CEQUAL_REFL) = true
     | eq (CEQUAL_SYM, CEQUAL_SYM) = true
     | eq (CEQUAL_STEP, CEQUAL_STEP) = true
+    | eq (CEQUAL_SUBST, CEQUAL_SUBST) = true
     | eq (FUN_INTRO, FUN_INTRO) = true
     | eq (FUN_ELIM, FUN_ELIM) = true
     | eq (LAM_EQ, LAM_EQ) = true
@@ -126,6 +128,7 @@ struct
        | CEQUAL_REFL => #[]
        | CEQUAL_SYM => #[0]
        | CEQUAL_STEP => #[0]
+       | CEQUAL_SUBST => #[0, 0]
        | VOID_EQ => #[]
        | VOID_ELIM => #[0]
 
@@ -214,6 +217,7 @@ struct
        | CEQUAL_REFL => "~-refl"
        | CEQUAL_SYM => "~-sym"
        | CEQUAL_STEP => "~-step"
+       | CEQUAL_SUBST => "~-subst"
        | UNIT_EQ => "unit⁼"
        | UNIT_INTRO => "unit-intro"
        | UNIT_ELIM => "unit-elim"

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -19,6 +19,11 @@ sig
                       index : int,
                       domain : term,
                       level : level option} * meta
+      | CEQ_SUBST of {left : term,
+                      right : term} * meta
+      | CHYP_SUBST of {dir : Dir.dir,
+                       index : int,
+                       domain : term} * meta
       | INTRO of {term : term option,
                   rule : int option,
                   freshVariable : name option,

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -39,6 +39,9 @@ sig
       | ASSERT of {assertion : term,
                    name : name option} * meta
       | SYMMETRY of meta
+      | CEQUAL_REFL of meta
+      | CEQUAL_SYM of meta
+      | CEQUAL_STEP of meta
       | TRY of t
       | LIMIT of t
       | ORELSE of t list * meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -40,6 +40,9 @@ struct
     | ASSERT of {assertion : term,
                  name : name option} * meta
     | SYMMETRY of meta
+    | CEQUAL_REFL of meta
+    | CEQUAL_SYM of meta
+    | CEQUAL_STEP of meta
     | TRY of t
     | LIMIT of t
     | ORELSE of t list * meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -20,6 +20,11 @@ struct
                     index : int,
                     domain : term,
                     level : level option} * meta
+    | CEQ_SUBST of {left : term,
+                    right : term} * meta
+    | CHYP_SUBST of {dir : Dir.dir,
+                     index : int,
+                     domain : term} * meta
     | INTRO of {term : term option,
                 rule : int option,
                 freshVariable : name option,

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -42,6 +42,9 @@ struct
       | ASSERT ({assertion = t, name = name}, a) =>
         an a (Assert (t, name))
       | SYMMETRY a => an a EqSym
+      | CEQUAL_REFL a => an a CEqRefl
+      | CEQUAL_SYM a => an a CEqSym
+      | CEQUAL_STEP a => an a CEqStep
       | TRY tac => T.TRY (eval wld tac)
       | LIMIT tac => T.LIMIT (eval wld tac)
       | ORELSE (tacs, a) => an a (List.foldl T.ORELSE T.FAIL (map (eval wld) tacs))

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -23,6 +23,10 @@ struct
         an a (EqSubst (left, right, level))
       | HYP_SUBST ({dir, index, domain, level}, a) =>
         an a (HypEqSubst (dir, index, domain, level))
+      | CEQ_SUBST ({left, right}, a) =>
+        an a (CEqSubst (left, right))
+      | CHYP_SUBST ({dir, index, domain}, a) =>
+        an a (HypCEqSubst (dir, index, domain))
       | INTRO ({term, rule, freshVariable, level}, a) =>
         an a (CttUtil.Intro {term = term,
                              rule = rule,


### PR DESCRIPTION
_This pull request is a WIP_

In order to allow reasoning about untyped programs in JonPRL we need a notion of equality purely based around computation denoted ~ in NuPRL. This pull request adds this.
- [x] Add small step semantics for JonPRL's core type theory
- [x] Add a new type `CEQUAL` which is computationally trivial but has 3 inferences
  
  ```
                     e'  ~ e           e |-> e'   e' ~ e''
  ------            --------           --------------------
  e ~ e            e ~ e'                  e ~ e''
  ```

That `e |-> e'` won't appear as a goal to the user since whether or not a term takes a step in the untyped computation system can be inferred. After this has been added we need a few new tactics
- [x] `srefl`, `ssymmetry` (symmetry and reflexivity for ~ instead of =)
- [x] `ssubst` (rewrite with an ~ equality)
