### PR TITLE
Fixed jonprl to no longer accept open terms

### DIFF
--- a/example/test.jonprl
+++ b/example/test.jonprl
@@ -56,7 +56,7 @@ Theorem test11 :
   reduce; auto
 }.
 
-Theorem axiom-of-choice : [∀(U{i}; A. ∀(U{i}; B. ∀(Π(A; _. Π(B; _. U{i})); Q. Π(Π(A; a. Σ(B; b. ap(ap(Q;a);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
+Theorem axiom-of-choice : [∀(U{i}; A. ∀(U{i}; B. ∀(Π(A; _. Π(B; _. U{i})); Q. Π(Π(A; c. Σ(B; b. ap(ap(Q;c);b))); φ. Σ(Π(A; _.B); f. Π(A; a. ap(ap(Q;a);ap(f;a))))))))] {
   auto; intro [λ(w. spread(ap(φ;w); x.y.x))]; auto;
   elim #4 [a]; auto; reduce;
   hyp-subst ← #7 [h. ap(ap(Q;a); spread(h; x.y.x))]; auto;

--- a/example/unique.jonprl
+++ b/example/unique.jonprl
@@ -14,7 +14,7 @@ Operator isContr : (0).
 ||| There is just one function void ⇒ A for any A.
 Theorem abort-unique : [⋂(U{i}; A. unique(Π(void; _. A); _. unit))] {
   unfold <unique>; auto;
-  intro [λ(_. baaaaaaaaaaaaaaaaang)]; auto;
+  intro [λ(x. x)]; auto;
   ext; auto
 }.
 
@@ -22,6 +22,6 @@ Theorem abort-unique : [⋂(U{i}; A. unique(Π(void; _. A); _. unit))] {
 ||| proof is just in the derivation)
 Theorem void-fun-contr : [⋂(U{i}; A. isContr(Π(void; _. A)))] {
   unfold <isContr>; auto;
-  intro [λ(_. welp)]; auto;
+  intro [λ(x. x)]; auto;
   ext; auto
 }.

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -7,9 +7,17 @@ struct
   fun eval_decl D ast =
     case ast of
         THEOREM (lbl, term, tac) =>
-        Development.prove D (lbl,
-                             Sequent.>> (Sequent.Context.empty, term),
-                             TacticEval.eval D tac)
+        let
+          val vars = Syntax.freeVariables term
+          val () =
+              case vars of
+                  [] => ()
+                | _ => raise Context.Open term
+        in
+          Development.prove D (lbl,
+                               Sequent.>> (Sequent.Context.empty, term),
+                               TacticEval.eval D tac)
+        end
       | OPERATOR (lbl, arity) => D
       | TACTIC (lbl, tac) =>
         Development.defineTactic D (lbl, TacticEval.eval D tac)

--- a/src/prover/context.sig
+++ b/src/prover/context.sig
@@ -35,5 +35,6 @@ sig
   val eq : context * context -> bool
   val subcontext : context * context -> bool
 
+  exception Open of term
   val rebind : context -> term -> term
 end

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -56,7 +56,7 @@ struct
         val (x, E) = unbind (Context.rebind H xE)
         val x' = Context.fresh (H, x)
         val H' = Context.insert H x' Visibility.Visible (Context.rebind H A)
-        val E' = Context.rebind H (subst (``x') x E)
+        val E' = subst (``x') x E
       in
         (H', x', E')
       end

--- a/src/syntax/development_ast.sig
+++ b/src/syntax/development_ast.sig
@@ -2,7 +2,7 @@ signature DEVELOPMENT_AST =
 sig
   type label
 
-  structure Syntax : ABT
+  structure Syntax : ABT_UTIL
     where type Operator.t = label OperatorType.operator
 
   structure Pattern : ABT


### PR DESCRIPTION
This involves checking in `Context.rebind` and `DevelopmentAstEval`
