### PR TITLE
Fixed several bugs in rebinding and added fun proof

### DIFF
--- a/example/proj-equal.jonprl
+++ b/example/proj-equal.jonprl
@@ -1,0 +1,15 @@
+Theorem proj-equal : [∀(U{i}; A.
+                      ∀(U{i}; B.
+                      ∀(A; a.
+                      ∀(A; a'.
+                      ∀(B; b.
+                      ∀(B; b'.
+                      ∀(=(pair(a;b);pair(a';b');Σ(A; _.B)); _.
+                        =(a;a';A))))))))] {
+  auto;
+  assert [=(spread(pair(a; b); x.y.x);
+            spread(pair(a'; b'); x.y.x);
+            A)];
+  [hyp-subst → #7 [h. =(spread(h; x.y.x); spread(pair(a'; b'); x.y.x); A)],
+   id]; reduce; auto; hypothesis #8
+}.

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -834,14 +834,15 @@ struct
 
     fun Assert (term, name) (H >> P) =
       let
-        val k =
+        val z =
             case name of
-                SOME k => k
+                SOME z => z
               | NONE => Context.fresh (H, Variable.named "H")
+        val term' = Context.rebind H term
       in
-        [ H >> term
-        , H @@ (k, term) >> P
-        ] BY (fn [D, E] => ASSERT $$ #[D, k \\ E]
+        [ H >> term'
+        , H @@ (z, term') >> P
+        ] BY (fn [D, E] => ASSERT $$ #[D, z \\ E]
                | _ => raise Refine)
       end
 


### PR DESCRIPTION
The fun proof is an interesting demo of how to prove that `fst` is injective.
