### PR TITLE
Added the base type to JonPRL

### DIFF
--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -12,16 +12,17 @@ Theorem y-is-fix-point : [
 }.
 
 Theorem transitive : [
-  ∀(U{i}; A.
-  ∀(∀(A; _.A); f.
-  ∀(∀(A; _.A); g.
-  ∀(Π(A; _.A); h.
-  ∀(ceq(f; g); _.
-  ∀(ceq(g; h); _.
-  ceq(f; h)))))))
+  ∀(base; a.
+  ∀(base; b.
+  ∀(base; c.
+  ∀(=(a; b; base); _.
+  ∀(=(b; c; base); _.
+    =(a; c; base))))))
 ] {
   auto;
-  chyp-subst → #5 [c. ceq(c; h)];
-  chyp-subst ← #6 [c. ceq(g; c)];
-  auto
+  elim #4;
+  elim #5;
+  chyp-subst → #6 [h. ceq(h;c)];
+  chyp-subst ← #7 [h. ceq(b;h)];
+  creflexivity
 }.

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -543,6 +543,50 @@ struct
                | _ => raise Refine)
       end
 
+    fun BaseEq (H >> P) =
+      let
+        val #[M, N, U] = P ^! EQ
+        val #[] = M ^! BASE
+        val #[] = N ^! BASE
+        val (UNIV _, _) = asApp U
+      in
+        [] BY (fn [] => BASE_EQ $$ #[]
+                | _ => raise Refine)
+      end
+
+    fun BaseIntro (H >> P) =
+      let
+        val #[] = P ^! BASE
+      in
+        [] BY (fn [] => BASE_INTRO $$ #[]
+                | _ => raise Refine)
+      end
+
+    fun BaseMemberEq (H >> P) =
+      let
+        val #[M, N, U] = P ^! EQ
+        val #[] = U ^! BASE
+      in
+        [H >> CEQUAL $$ #[M, N]
+        ] BY (fn [D] => BASE_INTRO $$ #[D]
+               | _ => raise Refine)
+      end
+
+    fun BaseElimEq (i, z) (H >> P) =
+      let
+        val eq = Context.nth H (i - 1)
+        val #[M, N, U] = Context.lookup H eq ^! EQ
+        val #[] = U ^! BASE
+        val z =
+            case z of
+                SOME z => z
+              | NONE => Context.fresh (H, Variable.named "H")
+      in
+        [H @@ (z, CEQUAL $$ #[M, N]) >> P
+        ] BY (fn [D] => BASE_ELIM_EQ $$ #[z \\ D]
+               | _ => raise Refine)
+      end
+
     fun MemCD (H >> P) =
       let
         val #[M, A] = P ^! MEM

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -568,7 +568,7 @@ struct
         val #[] = U ^! BASE
       in
         [H >> CEQUAL $$ #[M, N]
-        ] BY (fn [D] => BASE_INTRO $$ #[D]
+        ] BY (fn [D] => BASE_MEMBER_EQ $$ #[D]
                | _ => raise Refine)
       end
 

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -128,6 +128,11 @@ sig
     val SubsetElim : int * (name * name) option -> tactic
     val SubsetMemberEq : name option * Level.t option -> tactic
 
+    val BaseEq : tactic
+    val BaseIntro : tactic
+    val BaseMemberEq : tactic
+    val BaseElimEq : int * name option -> tactic
+
     val MemCD : tactic
     val Witness : term -> tactic
 

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -54,6 +54,7 @@ struct
        ORELSE_LAZY (fn _ => SubsetIntro (valOf term, freshVariable, level))
        ORELSE IndependentSubsetIntro
        ORELSE CEqRefl
+       ORELSE BaseIntro
 
   fun take2 (x::y::_) = SOME (x,y)
     | take2 _ = NONE
@@ -66,6 +67,7 @@ struct
   fun Elim {target, names, term} =
     (VoidElim THEN Hypothesis target)
       ORELSE UnitElim target
+      ORELSE_LAZY (fn _ => BaseElimEq (target, list_at (names, 0)))
       ORELSE_LAZY (fn _ => PlusElim (target, take2 names))
       ORELSE_LAZY (fn _ => ProdElim (target, take2 names))
       ORELSE_LAZY (fn _ => FunElim (target, valOf term, take2 names))
@@ -86,6 +88,8 @@ struct
         ORELSE PlusEq
         ORELSE InlEq level
         ORELSE InrEq level
+        ORELSE BaseEq
+        ORELSE BaseMemberEq
         ORELSE_LAZY (fn _ => DecideEq (List.nth (terms, 0))
                                       (List.nth (terms, 1),
                                        List.nth (terms, 2),

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -31,6 +31,11 @@ struct
        | CEQUAL_STEP $ _ => ax
        | CEQUAL_SUBST $ #[D, E] => extract E
 
+       | BASE_INTRO $ _ => ax
+       | BASE_EQ $ _ => ax
+       | BASE_MEMBER_EQ $ _ => ax
+       | BASE_ELIM_EQ $ #[D] => extract (D // ax)
+
        | PROD_EQ $ _ => ax
        | PROD_INTRO $ #[M, D, E, xF] => PAIR $$ #[M, extract E]
        | IND_PROD_INTRO $ #[D,E] => PAIR $$ #[extract D, extract E]

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -15,7 +15,7 @@ struct
 
     | ADMIT | ASSERT
     | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
-    | CEQUAL_SUBST
+    | CEQUAL_SUBST | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -27,7 +27,7 @@ struct
     | EQ | MEM
     | SUBSET
     | PLUS | INL | INR | DECIDE
-    | CEQUAL
+    | CEQUAL | BASE
 
     | CUSTOM of {label : 'label, arity : Arity.t}
     | SO_APPLY
@@ -87,9 +87,14 @@ struct
     | eq (IND_SUBSET_INTRO, IND_SUBSET_INTRO) = true
     | eq (SUBSET_ELIM, SUBSET_ELIM) = true
     | eq (SUBSET_MEMBER_EQ, SUBSET_MEMBER_EQ) = true
+    | eq (BASE_EQ, BASE_EQ) = true
+    | eq (BASE_INTRO, BASE_INTRO) = true
+    | eq (BASE_ELIM_EQ, BASE_ELIM_EQ) = true
+    | eq (BASE_MEMBER_EQ, BASE_MEMBER_EQ) =true
     | eq (ADMIT, ADMIT) = true
     | eq (ASSERT, ASSERT) = true
     | eq (UNIV i, UNIV j) = i = j
+    | eq (BASE, BASE) = true
     | eq (VOID, VOID) = true
     | eq (UNIT, UNIT) = true
     | eq (AX, AX) = true
@@ -131,6 +136,11 @@ struct
        | CEQUAL_SUBST => #[0, 0]
        | VOID_EQ => #[]
        | VOID_ELIM => #[0]
+
+       | BASE_EQ => #[]
+       | BASE_INTRO => #[]
+       | BASE_ELIM_EQ => #[1]
+       | BASE_MEMBER_EQ => #[0]
 
        | UNIT_EQ => #[]
        | UNIT_INTRO => #[]
@@ -180,6 +190,7 @@ struct
        | ASSERT => #[0, 1]
 
        | UNIV i => #[]
+       | BASE => #[]
        | VOID => #[]
        | UNIT => #[]
        | AX => #[]
@@ -223,6 +234,11 @@ struct
        | UNIT_ELIM => "unit-elim"
        | AX_EQ => "⬧⁼"
 
+       | BASE_EQ => "base⁼"
+       | BASE_INTRO => "base-intro"
+       | BASE_ELIM_EQ => "base-elim⁼"
+       | BASE_MEMBER_EQ => "base-member⁼"
+
        | PROD_EQ => "prod⁼"
        | PROD_INTRO => "prod-intro"
        | IND_PROD_INTRO => "independent-prod-intro"
@@ -265,6 +281,7 @@ struct
        | SUBSET_MEMBER_EQ => "subset-member-eq"
 
        | UNIV i => "U{" ^ Level.toString i ^ "}"
+       | BASE => "base"
        | VOID => "void"
        | UNIT => "unit"
        | AX => "⬧"
@@ -306,6 +323,7 @@ struct
 
     val extensionalParseOperator : t charParser =
       parseUniv
+        || string "base" return BASE
         || string "void" return VOID
         || string "unit" return UNIT
         || string "<>" return AX


### PR DESCRIPTION
This permits first class reasoning of arbitrary untyped programs quotiented by computational equivalence. See the new version of transitivity in `y.jonprl` to see this in action.
