### PR TITLE
Correctly recognize two stuck terms as equal

### DIFF
--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -5,6 +5,10 @@ Theorem test : [ceq(λ(x.x); λ(x.x))] {
   auto
 }.
 
+Theorem test2 : [ceq(spread(λ(x.x); x.y.x); spread(λ(x.x); x.y.y))] {
+  auto
+}.
+
 Theorem y-is-fix-point : [
   ∀(U{i}; A. ∀(Π(A; _.A); f . ceq(Y(f); ap(f; Y(f)))))
 ] {

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -996,14 +996,22 @@ struct
                  | _ => raise Refine)
         end
 
+      local
+          fun bothStuck M N =
+            (Semantics.step M; raise Refine)
+            handle Semantics.Stuck _ =>
+                   (Semantics.step N; raise Refine)
+                   handle Semantics.Stuck _ => ()
+      in
       fun CEqRefl (H >> P) =
         let
           val #[M, N] = P ^! CEQUAL
-          val _ = unify M N
+          val () = (unify M N; ()) handle Refine => bothStuck M N
         in
             [] BY (fn [] => CEQUAL_REFL $$ #[]
                    | _  => raise Refine)
         end
+      end
 
       fun CEqSym (H >> P) =
         let


### PR DESCRIPTION
This is just baked into `CEqRefl` so `auto` will now handle such things.
