### PR TITLE
Fixed small_step to understand neutral terms

### DIFF
--- a/example/struct.jonprl
+++ b/example/struct.jonprl
@@ -1,0 +1,8 @@
+Operator complex : (1; 1; 2; 0; 1).
+
+Theorem complex-ceq : [
+  ceq(complex(x.x                       ; x.unit; x.y.y; <>; x.<>);
+      complex(x.spread(pair(x;x); x._.x); x.unit; x.y.y; <>; x.<>))
+] {
+  cstruct; reduce; creflexivity
+}.

--- a/example/y.jonprl
+++ b/example/y.jonprl
@@ -9,6 +9,10 @@ Theorem test2 : [ceq(spread(λ(x.x); x.y.x); spread(λ(x.x); x.y.y))] {
   auto
 }.
 
+Theorem test3 : [ceq(λ(x.x); λ(x.spread(pair(x;x); x._.x)))] {
+  cstruct; csymmetry; step; creflexivity
+}.
+
 Theorem y-is-fix-point : [
   ∀(U{i}; A. ∀(Π(A; _.A); f . ceq(Y(f); ap(f; Y(f)))))
 ] {

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -186,6 +186,10 @@ struct
     fn w => symbol "step"
       wth (fn name => fn pos => CEQUAL_STEP {name = name, pos = pos})
 
+  val parseCEqualStruct : tactic_parser =
+    fn w => symbol "cstruct"
+      wth (fn name => fn pos => CEQUAL_STRUCT {name = name, pos = pos})
+
   val parseAssumption : tactic_parser =
     fn w => symbol "assumption"
       wth (fn name => fn pos => ASSUMPTION {name = name, pos = pos})
@@ -249,6 +253,7 @@ struct
       || parseCEqualRefl w
       || parseCEqualSym w
       || parseCEqualStep w
+      || parseCEqualStruct w
       || parseCEqSubst w
       || parseCHypSubst w
 

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -1028,7 +1028,8 @@ struct
           val M' =
               case Semantics.step M handle Semantics.Stuck _ => raise Refine of
                   Semantics.STEP M' => M'
-                | CANON => raise Refine
+                | Semantics.CANON => raise Refine
+                | Semantics.NEUTRAL => raise Refine
         in
           [ H >> CEQUAL $$ #[M', N]
           ] BY (fn [D] => CEQUAL_STEP $$ #[D]

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -156,6 +156,7 @@ sig
     val CEqStep : tactic
     val CEqSubst : term * term -> tactic
     val HypCEqSubst : Dir.dir * int * term -> tactic
+    val CEqStruct : tactic
 
     val HypEqSubst : Dir.dir * int * term * Level.t option -> tactic
   end

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -30,6 +30,7 @@ struct
        | CEQUAL_SYM $ _ => ax
        | CEQUAL_STEP $ _ => ax
        | CEQUAL_SUBST $ #[D, E] => extract E
+       | CEQUAL_STRUCT _ $ _ => ax (* Thank god *)
 
        | BASE_INTRO $ _ => ax
        | BASE_EQ $ _ => ax

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -79,7 +79,12 @@ struct
       )
       | CUSTOM _ $ _ => NEUTRAL (* Require unfolding elsewhere *)
       | ` _ => NEUTRAL (* Cannot step an open term *)
-      | _ \ _ => raise Stuck e (* Cannot step a binder *)
+      | x \ e => (
+        case step e of
+            STEP e' => STEP (x \\ e')
+          | NEUTRAL => NEUTRAL
+          | CANON => NEUTRAL
+      )
       | _ => raise Stuck e
 end
 

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -10,7 +10,7 @@ struct
 
 
   exception Stuck of Syn.t
-  datatype t = STEP of Syn.t | CANON
+  datatype t = STEP of Syn.t | CANON | NEUTRAL
 
   fun stepSpreadBeta (P, E) =
     case out P of
@@ -36,19 +36,19 @@ struct
       | AX $ _ => CANON
       | PROD $ _ => CANON
       | PAIR $ _ => CANON
-      | SPREAD $ #[P, E] =>
-        STEP (
+      | SPREAD $ #[P, E] => (
           case step P of
-              STEP P' => SPREAD $$ #[P', E]
-            | CANON => stepSpreadBeta (P, E)
-        )
+              STEP P' => STEP (SPREAD $$ #[P', E])
+            | CANON => STEP (stepSpreadBeta (P, E))
+            | NEUTRAL => NEUTRAL
+      )
       | FUN $ _ => CANON
       | LAM $ _ => CANON
-      | AP $ #[L, R] =>
-        STEP (
+      | AP $ #[L, R] => (
           case step L of
-              STEP L' => AP $$ #[L', R]
-            | CANON => stepApBeta (L, R)
+              STEP L' => STEP (AP $$ #[L', R])
+            | CANON => STEP (stepApBeta (L, R))
+            | NEUTRAL => NEUTRAL
         )
       | ISECT $ _ => CANON
       | EQ $ _ => CANON
@@ -57,11 +57,11 @@ struct
       | PLUS $ _ => CANON
       | INL $ _ => CANON
       | INR $ _ => CANON
-      | DECIDE $ #[S, L, R] =>
-        STEP (
+      | DECIDE $ #[S, L, R] => (
           case step S of
-              STEP S' => DECIDE $$ #[S', L, R]
-            | CANON => stepDecideBeta (S, L, R)
+              STEP S' => STEP (DECIDE $$ #[S', L, R])
+            | CANON => STEP (stepDecideBeta (S, L, R))
+            | NEUTRAL => NEUTRAL
         )
       | SO_APPLY $ #[L, R] => (
           (* This can't come up but I don't think it's wrong
@@ -73,11 +73,12 @@ struct
             x \ L => STEP (subst R x L)
            | _ =>
              case step L of
-               CANON => raise Stuck (SO_APPLY $$ #[L, R])
-              | STEP L' => STEP (SO_APPLY $$ #[L', R])
+                 CANON => raise Stuck (SO_APPLY $$ #[L, R])
+               | STEP L' => STEP (SO_APPLY $$ #[L', R])
+               | NEUTRAL => NEUTRAL
       )
-      | CUSTOM _ $ _ => STEP e (* Require unfolding elsewhere *)
-      | ` _ => raise Stuck e (* Cannot step an open term *)
+      | CUSTOM _ $ _ => NEUTRAL (* Require unfolding elsewhere *)
+      | ` _ => NEUTRAL (* Cannot step an open term *)
       | _ \ _ => raise Stuck e (* Cannot step a binder *)
       | _ => raise Stuck e
 end

--- a/src/prover/small_step.sig
+++ b/src/prover/small_step.sig
@@ -2,7 +2,7 @@ signature SMALL_STEP =
 sig
     type syn
 
-    datatype t = STEP of syn | CANON
+    datatype t = STEP of syn | CANON | NEUTRAL
     exception Stuck of syn
 
     val step : syn -> t

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -15,7 +15,8 @@ struct
 
     | ADMIT | ASSERT
     | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
-    | CEQUAL_SUBST | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ
+    | CEQUAL_SUBST | CEQUAL_STRUCT of int Vector.vector
+    | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ
 
       (* Computational Type Theory *)
     | UNIV of Level.t
@@ -71,6 +72,7 @@ struct
     | eq (CEQUAL_SYM, CEQUAL_SYM) = true
     | eq (CEQUAL_STEP, CEQUAL_STEP) = true
     | eq (CEQUAL_SUBST, CEQUAL_SUBST) = true
+    | eq (CEQUAL_STRUCT i, CEQUAL_STRUCT j) = i = j
     | eq (FUN_INTRO, FUN_INTRO) = true
     | eq (FUN_ELIM, FUN_ELIM) = true
     | eq (LAM_EQ, LAM_EQ) = true
@@ -134,6 +136,7 @@ struct
        | CEQUAL_SYM => #[0]
        | CEQUAL_STEP => #[0]
        | CEQUAL_SUBST => #[0, 0]
+       | CEQUAL_STRUCT arity => arity
        | VOID_EQ => #[]
        | VOID_ELIM => #[0]
 
@@ -229,6 +232,7 @@ struct
        | CEQUAL_SYM => "~-sym"
        | CEQUAL_STEP => "~-step"
        | CEQUAL_SUBST => "~-subst"
+       | CEQUAL_STRUCT _ => "~-struct"
        | UNIT_EQ => "unit⁼"
        | UNIT_INTRO => "unit-intro"
        | UNIT_ELIM => "unit-elim"

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -47,6 +47,7 @@ sig
       | CEQUAL_REFL of meta
       | CEQUAL_SYM of meta
       | CEQUAL_STEP of meta
+      | CEQUAL_STRUCT of meta
       | TRY of t
       | LIMIT of t
       | ORELSE of t list * meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -48,6 +48,7 @@ struct
     | CEQUAL_REFL of meta
     | CEQUAL_SYM of meta
     | CEQUAL_STEP of meta
+    | CEQUAL_STRUCT of meta
     | TRY of t
     | LIMIT of t
     | ORELSE of t list * meta

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -49,6 +49,7 @@ struct
       | CEQUAL_REFL a => an a CEqRefl
       | CEQUAL_SYM a => an a CEqSym
       | CEQUAL_STEP a => an a CEqStep
+      | CEQUAL_STRUCT a => an a CEqStruct
       | TRY tac => T.TRY (eval wld tac)
       | LIMIT tac => T.LIMIT (eval wld tac)
       | ORELSE (tacs, a) => an a (List.foldl T.ORELSE T.FAIL (map (eval wld) tacs))


### PR DESCRIPTION
There's still a question in my mind as to what to do binders. Howe would say we should try to step under them and I'm inclined to do the same. The relevant line would be

```
  | x \ e => x \ step e
```

This is safe as far as I know :+1: 
