### PR TITLE
Nats

### DIFF
--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -13,3 +13,47 @@ Theorem minus-one : [Π(nat; _. nat)] {
 Theorem natrec-test : [=(natrec(succ(succ(zero)); zero; n. ih. n); succ(zero); nat)] {
   reduce; auto
 }.
+
+Operator plus : (0;0).
+[plus(M; N)] =def= [natrec(M; N; _.n.succ(n))].
+
+Tactic t {
+  unfold <plus>; auto; elim #1; reduce; auto
+}.
+
+Theorem plus-id-left : [∀(nat; n. =(plus(zero; n); n; nat))] {
+  refine <t>
+}.
+
+Theorem plus-id-right : [∀(nat; n. =(plus(n; zero); n; nat))] {
+  refine <t>
+}.
+
+Theorem succ-right : [
+  ∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))
+] {
+  refine <t>
+}.
+
+Theorem plus-commutes : [
+  ∀(nat; n.∀(nat; m. =(plus(n; m); plus(m; n); nat)))
+] {
+  ||| Kick off the induction and do the boring computation thingies.
+  refine <t>;
+
+  ||| The base case immeidately follows from plus-id-right
+  [(assert [∀(nat; n. =(plus(n; zero); n; nat))];
+    [lemma <plus-id-right>, id];
+    elim #3 [m]; auto; unfold <plus>;
+    hyp-subst → #4 [h.=(m;h;nat)];
+    auto),
+   id];
+
+  ||| In order to prove this we first rewrite by succ-right from which our
+  ||| result follows from reflexivity.
+  assert [∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))];
+  [lemma <succ-right>, id];
+  elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
+  hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
+  auto
+}.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -38,22 +38,5 @@ Theorem succ-right : [
 Theorem plus-commutes : [
   ∀(nat; n.∀(nat; m. =(plus(n; m); plus(m; n); nat)))
 ] {
-  ||| Kick off the induction and do the boring computation thingies.
-  refine <t>;
-
-  ||| The base case immeidately follows from plus-id-right
-  [(assert [∀(nat; n. =(plus(n; zero); n; nat))];
-    [lemma <plus-id-right>, id];
-    elim #3 [m]; auto; unfold <plus>;
-    hyp-subst → #4 [h.=(m;h;nat)];
-    auto),
-   id];
-
-  ||| In order to prove this we first rewrite by succ-right from which our
-  ||| result follows from reflexivity.
-  assert [∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))];
-  [lemma <succ-right>, id];
-  elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
-  hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
-  auto; eq-cd [h.nat]; auto
+  refine <t>
 }.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -9,3 +9,7 @@ Theorem minus-one : [Π(nat; _. nat)] {
   , hypothesis #2
   ]; auto
 }.
+
+Theorem natrec-test : [=(natrec(succ(succ(zero)); zero; n. ih. n); succ(zero); nat)] {
+  reduce; auto
+}.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -1,4 +1,4 @@
-Theorem nat-example : [nat] {
+Theorem natp-example : [nat] {
   witness [succ(zero)]; auto
 }.
 
@@ -55,5 +55,5 @@ Theorem plus-commutes : [
   [lemma <succ-right>, id];
   elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
   hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
-  auto
+  auto; eq-cd [h.nat]; auto
 }.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -1,3 +1,11 @@
 Theorem nat-example : [nat] {
   witness [succ(zero)]; auto
 }.
+
+Theorem minus-one : [Π(nat; _. nat)] {
+  intro <n>; [id, auto];
+  elim #1;
+  [ witness [zero]
+  , hypothesis #2
+  ]; auto
+}.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -1,0 +1,3 @@
+Theorem nat-example : [nat] {
+  witness [succ(zero)]; auto
+}.

--- a/example/top.jonprl
+++ b/example/top.jonprl
@@ -1,0 +1,10 @@
+Operator Top : ().
+[Top] =def= [⋂(void; _. void)].
+
+Theorem anything-in-top : [⋂(base; E. ∈(E; Top))] {
+  unfold <Top>; auto
+}.
+
+Theorem top-singleton : [⋂(Top; E. ⋂(Top; F. =(E; F; Top)))] {
+  unfold <Top>; auto
+}.

--- a/lib/abt-parsing-lib/parse_abt.fun
+++ b/lib/abt-parsing-lib/parse_abt.fun
@@ -78,8 +78,8 @@ struct
     fun var sigma = identifier wth (fn x => `` (SymbolTable.named sigma x))
 
     fun abt sigma w () =
-      (force (app sigma w)
-      || force (abs sigma w)
+      (force (abs sigma w)
+      || force (app sigma w)
       || var sigma) ?? "abt"
     and app sigma w () =
       ParseOperator.parseOperator w

--- a/src/ctt_frontend.sml
+++ b/src/ctt_frontend.sml
@@ -24,6 +24,7 @@ struct
            ^ "\n\n" ^ prettyException error
        | TacticEval.RemainingSubgoals goals =>
            ("Remaining subgoals:" ^ foldl (fn (g,r) => r ^ "\n" ^ Sequent.toString g ^ "\n") "" goals)
+       | Syntax.Malformed msg => "Syntax error: " ^ msg
        | _ => exnMessage E
 
   fun loadFile (initialDevelopment, name) : Development.world =

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -553,6 +553,49 @@ struct
         [] BY mkEvidence NAT_EQ
       end
 
+    fun NatElim (i, onames) (H >> C) =
+      let
+        val z = Context.nth H (i - 1)
+        val (n,ih) =
+          case onames of
+               SOME names => names
+             | NONE =>
+                 (Context.fresh (H, Variable.named "n"),
+                  Context.fresh (H, Variable.named "ih"))
+
+        val zero = ZERO $$ #[]
+        val succn = SUCC $$ #[``n]
+
+        val J = Context.empty @@ (n, NAT $$ #[]) @@ (ih, subst (``n) z C)
+        val H' = ctxSubst (Context.interposeAfter H (z, J)) succn z
+      in
+        [ ctxSubst H zero z >> subst zero z C
+        , H' >> subst succn z C
+        ] BY (fn [D,E] => NAT_ELIM $$ #[``z, D, n \\ (ih \\ E)]
+               | _ => raise Refine)
+      end
+
+    fun ZeroEq (H >> P) =
+      let
+        val #[zero1, zero2, nat] = P ^! EQ
+        val #[] = nat ^! NAT
+        val #[] = zero1 ^! ZERO
+        val #[] = zero2 ^! ZERO
+      in
+        [] BY mkEvidence ZERO_EQ
+      end
+
+    fun SuccEq (H >> P) =
+      let
+        val #[succ1, succ2, nat] = P ^! EQ
+        val #[] = nat ^! NAT
+        val #[M] = succ1 ^! SUCC
+        val #[N] = succ2 ^! SUCC
+      in
+        [ H >> EQ $$ #[M, N, NAT $$ #[]]
+        ] BY mkEvidence SUCC_EQ
+      end
+
     fun BaseEq (H >> P) =
       let
         val #[M, N, U] = P ^! EQ

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -607,6 +607,30 @@ struct
         ] BY mkEvidence SUCC_EQ
       end
 
+    fun NatRecEq (zC, onames) (H >> P) =
+      let
+        val #[rec1, rec2, out] = P ^! EQ
+        val #[n, zero, succ] = rec1 ^! NATREC
+        val #[n', zero', succ'] = rec1 ^! NATREC
+
+        val _ = unify (zC // n) out
+        val (npred, ih) =
+            case onames of
+                NONE =>
+                (Context.fresh (H, Variable.named "n'"),
+                 Context.fresh (H, Variable.named "ih"))
+              | SOME names => names
+        val H' = H @@ (npred, NAT $$ #[]) @@ (ih, zC // (`` npred))
+        val succSubst = (succ // ``npred) // ``ih
+        val succSubst' = (succ' // ``npred) // ``ih
+      in
+        [ H >> EQ $$ #[n, n', NAT $$ #[]]
+        , H >> EQ $$ #[zero, zero', zC // (ZERO $$ #[])]
+        , H' >> EQ $$ #[succSubst, succSubst', zC // (SUCC $$ #[`` npred])]
+        ] BY (fn [N, D, E] => NATREC_EQ $$ #[N, D, npred \\ (ih \\ E)]
+               | _ => raise Refine)
+      end
+
     fun BaseEq (H >> P) =
       let
         val #[M, N, U] = P ^! EQ

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -1198,18 +1198,10 @@ struct
   struct
     open Conversionals Conv
 
-    val ApBeta : conv = reductionRule
-      (fn AP $ #[LAM $ #[xE], N] => xE // into N
-        | _ => raise Conv)
-
-    val SpreadBeta : conv = reductionRule
-      (fn SPREAD $ #[PAIR $ #[M,N], xyE] => (into xyE // M) // N
-        | _ => raise Conv)
-
-    val DecideBeta : conv = reductionRule
-      (fn DECIDE $ #[INL $ #[E], N, M] => (into N // E)
-        | DECIDE $ #[INR $ #[E], N, M] => (into M // E)
-        | _ => raise Conv)
+    val Step : conv = fn M =>
+      case Semantics.step M of
+           Semantics.STEP M' => M'
+         | _ => raise Conv
   end
 end
 

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -133,6 +133,17 @@ struct
            O $ _ => if operatorIrrelevant O then () else raise Refine
          | _ => raise Refine
 
+    fun eliminationTarget i (H >> P) =
+      let
+        val z = Context.nth H (i - 1)
+        val (A, visibility) = Context.lookupVisibility H z
+      in
+        case visibility of
+             Visibility.Hidden =>
+              (assertIrrelevant (H, P); z)
+           | Visibility.Visible => z
+      end
+
     fun inferLevel (H, P) =
       case out P of
            UNIV l $ _ => Level.succ l
@@ -239,7 +250,7 @@ struct
 
     fun UnitElim i (H >> P) =
       let
-        val x = Context.nth H (i - 1)
+        val x = eliminationTarget i (H >> P)
         val #[] = Context.lookup H x ^! UNIT
         val ax = AX $$ #[]
         val H' = ctxSubst H ax x
@@ -324,7 +335,7 @@ struct
     fun FunElim (i, s, onames) (H >> P) =
       let
         val s = Context.rebind H s
-        val f = Context.nth H (i - 1)
+        val f = eliminationTarget i (H >> P)
         val #[S, xT] = Context.lookup H f ^! FUN
         val Ts = xT // s
         val (y, z) =
@@ -419,7 +430,7 @@ struct
     fun IsectElim (i, s, onames) (H >> P) =
       let
         val s = Context.rebind H s
-        val f = Context.nth H (i - 1)
+        val f = eliminationTarget i (H >> P)
         val #[S, xT] = Context.lookup H f ^! ISECT
         val Ts = xT // s
         val (y, z) =
@@ -523,7 +534,7 @@ struct
       end
 
     fun SubsetElim (i, onames) (H >> P) =
-      SubsetElim_ (Context.nth H (i - 1), onames) (H >> P)
+      SubsetElim_ (eliminationTarget i (H >> P), onames) (H >> P)
 
     fun SubsetMemberEq (oz, ok) (H >> P) =
       let
@@ -555,7 +566,7 @@ struct
 
     fun NatElim (i, onames) (H >> C) =
       let
-        val z = Context.nth H (i - 1)
+        val z = eliminationTarget i (H >> C)
         val (n,ih) =
           case onames of
                SOME names => names

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -553,22 +553,6 @@ struct
         [] BY mkEvidence NAT_EQ
       end
 
-    fun NatIntroZero (H >> P) =
-      let
-        val #[] = P ^! NAT
-      in
-        [] BY mkEvidence NAT_INTRO_ZERO
-      end
-
-    fun NatIntroSucc (H >> P) =
-      let
-        val #[] = P ^! NAT
-      in
-        [ H >> NAT $$ #[]
-        ] BY mkEvidence NAT_INTRO_SUCC
-      end
-
-
     fun BaseEq (H >> P) =
       let
         val #[M, N, U] = P ^! EQ

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -607,13 +607,17 @@ struct
         ] BY mkEvidence SUCC_EQ
       end
 
-    fun NatRecEq (zC, onames) (H >> P) =
+    fun NatRecEq (ozC, onames) (H >> P) =
       let
-        val #[rec1, rec2, out] = P ^! EQ
+        val #[rec1, rec2, A] = P ^! EQ
         val #[n, zero, succ] = rec1 ^! NATREC
         val #[n', zero', succ'] = rec1 ^! NATREC
 
-        val _ = unify (zC // n) out
+        val zC =
+          case ozC of
+               SOME zC => unify (zC // n) A
+             | NONE => Variable.named "z" \\ A
+
         val (npred, ih) =
             case onames of
                 NONE =>

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -543,6 +543,32 @@ struct
                | _ => raise Refine)
       end
 
+    fun NatEq (H >> P) =
+      let
+        val #[nat1, nat2, univ] = P ^! EQ
+        val (UNIV _, _) = asApp univ
+        val #[] = nat1 ^! NAT
+        val #[] = nat2 ^! NAT
+      in
+        [] BY mkEvidence NAT_EQ
+      end
+
+    fun NatIntroZero (H >> P) =
+      let
+        val #[] = P ^! NAT
+      in
+        [] BY mkEvidence NAT_INTRO_ZERO
+      end
+
+    fun NatIntroSucc (H >> P) =
+      let
+        val #[] = P ^! NAT
+      in
+        [ H >> NAT $$ #[]
+        ] BY mkEvidence NAT_INTRO_SUCC
+      end
+
+
     fun BaseEq (H >> P) =
       let
         val #[M, N, U] = P ^! EQ

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -139,7 +139,7 @@ sig
 
     val ZeroEq : tactic
     val SuccEq : tactic
-    val NatRecEq : term * (name * name) option -> tactic
+    val NatRecEq : term option * (name * name) option -> tactic
 
     val BaseEq : tactic
     val BaseIntro : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -128,7 +128,17 @@ sig
     val SubsetElim : int * (name * name) option -> tactic
     val SubsetMemberEq : name option * Level.t option -> tactic
 
+    (* H >> nat = nat ∈ U{k} *)
     val NatEq : tactic
+
+    (* H, z : nat, H' >> C[z]
+     *   H, z : nat, H' >> C[0]
+     *   H, z : nat, i : nat, p : C[i], H' >> C[s(i)]
+     *)
+    val NatElim : int * (name * name) option -> tactic
+
+    val ZeroEq : tactic
+    val SuccEq : tactic
 
     val BaseEq : tactic
     val BaseIntro : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -175,8 +175,6 @@ sig
 
   structure Conversions :
   sig
-    val ApBeta : conv
-    val SpreadBeta : conv
-    val DecideBeta : conv
+    val Step : conv
   end
 end

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -128,6 +128,10 @@ sig
     val SubsetElim : int * (name * name) option -> tactic
     val SubsetMemberEq : name option * Level.t option -> tactic
 
+    val NatEq : tactic
+    val NatIntroZero : tactic
+    val NatIntroSucc : tactic
+
     val BaseEq : tactic
     val BaseIntro : tactic
     val BaseMemberEq : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -139,6 +139,7 @@ sig
 
     val ZeroEq : tactic
     val SuccEq : tactic
+    val NatRecEq : term * (name * name) option -> tactic
 
     val BaseEq : tactic
     val BaseIntro : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -129,8 +129,6 @@ sig
     val SubsetMemberEq : name option * Level.t option -> tactic
 
     val NatEq : tactic
-    val NatIntroZero : tactic
-    val NatIntroSucc : tactic
 
     val BaseEq : tactic
     val BaseIntro : tactic

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -110,6 +110,7 @@ struct
                [M, N] => IsectMemberCaseEq (SOME M, N)
              | [N] => IsectMemberCaseEq (NONE, N)
              | _ => FAIL)
+        ORELSE NatEq
         ORELSE Cum level
         ORELSE EqInSupertype
     end

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -138,8 +138,7 @@ struct
     open Conversions Conversionals
     infix CORELSE
 
-    val Reduce = ApBeta CORELSE SpreadBeta CORELSE DecideBeta
-    val DeepReduce = RewriteGoal (CDEEP Reduce)
+    val DeepReduce = RewriteGoal (CDEEP Step)
   in
     val Auto =
       LIMIT (AutoIntro ORELSE AutoVoidElim ORELSE AutoEqCD)

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -63,7 +63,7 @@ struct
   fun take3 (x::y::z::_) = SOME (x,y,z)
     | take3 _ = NONE
 
-  fun list_at (xs, n) = SOME (List.nth (xs, n)) handle _ => NONE
+  fun listAt (xs, n) = SOME (List.nth (xs, n)) handle _ => NONE
 
   fun Elim {target, names, term} =
     let
@@ -71,7 +71,7 @@ struct
     in
       (VoidElim THEN Hypothesis target)
         ORELSE UnitElim target
-        ORELSE_LAZY (fn _ => BaseElimEq (target, list_at (names, 0)))
+        ORELSE_LAZY (fn _ => BaseElimEq (target, listAt (names, 0)))
         ORELSE_LAZY (fn _ => PlusElim (target, twoNames))
         ORELSE_LAZY (fn _ => ProdElim (target, twoNames))
         ORELSE_LAZY (fn _ => FunElim (target, valOf term, twoNames))
@@ -82,7 +82,7 @@ struct
 
   fun EqCD {names, level, terms} =
     let
-      val freshVariable = list_at (names, 0)
+      val freshVariable = listAt (names, 0)
     in
       AxEq
         ORELSE EqEq
@@ -100,15 +100,15 @@ struct
                                       (List.nth (terms, 1),
                                        List.nth (terms, 2),
                                        take3 names))
-        ORELSE_LAZY (fn _ => NatRecEq (List.nth (terms, 0), take2 names))
+        ORELSE NatRecEq (listAt (terms, 0), take2 names)
         ORELSE FunEq freshVariable
         ORELSE IsectEq freshVariable
         ORELSE ProdEq freshVariable
         ORELSE SubsetEq freshVariable
         ORELSE PairEq (freshVariable, level)
         ORELSE LamEq (freshVariable, level)
-        ORELSE ApEq (list_at (terms, 0))
-        ORELSE SpreadEq (list_at (terms, 0), list_at (terms, 1), take3 names)
+        ORELSE ApEq (listAt (terms, 0))
+        ORELSE SpreadEq (listAt (terms, 0), listAt (terms, 1), take3 names)
         ORELSE SubsetMemberEq (freshVariable, level)
         ORELSE IsectMemberEq (freshVariable, level)
         ORELSE_LAZY (fn _ =>

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -100,6 +100,7 @@ struct
                                       (List.nth (terms, 1),
                                        List.nth (terms, 2),
                                        take3 names))
+        ORELSE_LAZY (fn _ => NatRecEq (List.nth (terms, 0), take2 names))
         ORELSE FunEq freshVariable
         ORELSE IsectEq freshVariable
         ORELSE ProdEq freshVariable

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -66,14 +66,19 @@ struct
   fun list_at (xs, n) = SOME (List.nth (xs, n)) handle _ => NONE
 
   fun Elim {target, names, term} =
-    (VoidElim THEN Hypothesis target)
-      ORELSE UnitElim target
-      ORELSE_LAZY (fn _ => BaseElimEq (target, list_at (names, 0)))
-      ORELSE_LAZY (fn _ => PlusElim (target, take2 names))
-      ORELSE_LAZY (fn _ => ProdElim (target, take2 names))
-      ORELSE_LAZY (fn _ => FunElim (target, valOf term, take2 names))
-      ORELSE_LAZY (fn _ => IsectElim (target, valOf term, take2 names))
-      ORELSE SubsetElim (target, take2 names)
+    let
+      val twoNames = take2 names
+    in
+      (VoidElim THEN Hypothesis target)
+        ORELSE UnitElim target
+        ORELSE_LAZY (fn _ => BaseElimEq (target, list_at (names, 0)))
+        ORELSE_LAZY (fn _ => PlusElim (target, twoNames))
+        ORELSE_LAZY (fn _ => ProdElim (target, twoNames))
+        ORELSE_LAZY (fn _ => FunElim (target, valOf term, twoNames))
+        ORELSE_LAZY (fn _ => IsectElim (target, valOf term, twoNames))
+        ORELSE NatElim (target, twoNames)
+        ORELSE SubsetElim (target, twoNames)
+    end
 
   fun EqCD {names, level, terms} =
     let
@@ -111,6 +116,8 @@ struct
              | [N] => IsectMemberCaseEq (NONE, N)
              | _ => FAIL)
         ORELSE NatEq
+        ORELSE ZeroEq
+        ORELSE SuccEq
         ORELSE Cum level
         ORELSE EqInSupertype
     end

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -78,6 +78,9 @@ struct
        | SUBSET_MEMBER_EQ $ _ => ax
 
        | NAT_EQ $ _ => ax
+       | NAT_ELIM $ #[z, D, xyE] => NATREC $$ #[z, extract D, extract xyE]
+       | ZERO_EQ $ _ => ax
+       | SUCC_EQ $ _ => ax
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -78,8 +78,6 @@ struct
        | SUBSET_MEMBER_EQ $ _ => ax
 
        | NAT_EQ $ _ => ax
-       | NAT_INTRO_ZERO $ _ => ZERO $$ #[]
-       | NAT_INTRO_SUCC $ #[D] => SUCC $$ #[extract D]
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -81,6 +81,7 @@ struct
        | NAT_ELIM $ #[z, D, xyE] => NATREC $$ #[z, extract D, extract xyE]
        | ZERO_EQ $ _ => ax
        | SUCC_EQ $ _ => ax
+       | NATREC_EQ $ _ => ax
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -77,6 +77,10 @@ struct
        | SUBSET_ELIM $ #[R, stD] => extract (stD // R) // ax
        | SUBSET_MEMBER_EQ $ _ => ax
 
+       | NAT_EQ $ _ => ax
+       | NAT_INTRO_ZERO $ _ => ZERO $$ #[]
+       | NAT_INTRO_SUCC $ #[D] => SUCC $$ #[extract D]
+
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M
        | EQ_SUBST $ #[_, D, _] => extract D

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -63,6 +63,8 @@ struct
       | PLUS $ _ => CANON
       | INL $ _ => CANON
       | INR $ _ => CANON
+      | ZERO $ _ => CANON
+      | SUCC $ _ => CANON
       | DECIDE $ #[S, L, R] =>
           (case step S of
               STEP S' => STEP (DECIDE $$ #[S', L, R])

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -28,6 +28,12 @@ struct
       | INR $ #[B] => R // B
       | _ => raise Stuck (DECIDE $$ #[S, L, R])
 
+  fun stepNatrecBeta (M, Z, xyS) =
+    case out M of
+         ZERO $ #[] => Z
+       | SUCC $ #[N] => (xyS // N) // (NATREC $$ #[N, Z, xyS])
+       | _ => raise Stuck (NATREC $$ #[M, Z, xyS])
+
   fun step e =
     case out e of
         UNIV _ $ _ => CANON
@@ -57,26 +63,29 @@ struct
       | PLUS $ _ => CANON
       | INL $ _ => CANON
       | INR $ _ => CANON
-      | DECIDE $ #[S, L, R] => (
-          case step S of
+      | DECIDE $ #[S, L, R] =>
+          (case step S of
               STEP S' => STEP (DECIDE $$ #[S', L, R])
             | CANON => STEP (stepDecideBeta (S, L, R))
-            | NEUTRAL => NEUTRAL
-        )
-      | SO_APPLY $ #[L, R] => (
+            | NEUTRAL => NEUTRAL)
+      | NATREC $ #[M, Z, xyS] =>
+          (case step M of
+                STEP M' => STEP (NATREC $$ #[M', Z, xyS])
+              | CANON => STEP (stepNatrecBeta (M, Z, xyS))
+              | NEUTRAL => NEUTRAL)
+      | SO_APPLY $ #[L, R] =>
           (* This can't come up but I don't think it's wrong
            * Leaving this in here so it's an actual semantics
            * for the core type theory: not just what users
            * can say with the syntax we give.
            *)
-          case out L of
-            x \ L => STEP (subst R x L)
-           | _ =>
-             case step L of
+          (case out L of
+               x \ L => STEP (subst R x L)
+             | _ =>
+             (case step L of
                  CANON => raise Stuck (SO_APPLY $$ #[L, R])
                | STEP L' => STEP (SO_APPLY $$ #[L', R])
-               | NEUTRAL => NEUTRAL
-      )
+               | NEUTRAL => NEUTRAL))
       | CUSTOM _ $ _ => NEUTRAL (* Require unfolding elsewhere *)
       | ` _ => NEUTRAL (* Cannot step an open term *)
       | x \ e => (

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -178,7 +178,7 @@ struct
        | DECIDE_EQ => #[0, 2, 2]
 
        | NAT_EQ => #[]
-       | NAT_ELIM => #[1,0,2]
+       | NAT_ELIM => #[0,0,2]
        | ZERO_EQ => #[]
        | SUCC_EQ => #[0]
        | NATREC_EQ => #[0,0,2]

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -13,6 +13,8 @@ struct
     | SUBSET_EQ | SUBSET_INTRO | IND_SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
     | PLUS_EQ | PLUS_INTROL | PLUS_INTROR | PLUS_ELIM | INL_EQ | INR_EQ | DECIDE_EQ
 
+    | NAT_EQ | NAT_INTRO_ZERO | NAT_INTRO_SUCC | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
+
     | ADMIT | ASSERT
     | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
     | CEQUAL_SUBST | CEQUAL_STRUCT of int Vector.vector
@@ -28,6 +30,7 @@ struct
     | EQ | MEM
     | SUBSET
     | PLUS | INL | INR | DECIDE
+    | NAT | ZERO | SUCC | NATREC
     | CEQUAL | BASE
 
     | CUSTOM of {label : 'label, arity : Arity.t}
@@ -120,10 +123,21 @@ struct
     | eq (INL_EQ, INL_EQ) = true
     | eq (INR_EQ, INR_EQ) = true
     | eq (DECIDE_EQ, DECIDE_EQ) = true
+    | eq (NAT_EQ, NAT_EQ) = true
+    | eq (NAT_INTRO_ZERO, NAT_INTRO_ZERO) = true
+    | eq (NAT_INTRO_SUCC, NAT_INTRO_SUCC) = true
+    | eq (NAT_ELIM, NAT_ELIM) = true
+    | eq (ZERO_EQ, ZERO_EQ) = true
+    | eq (SUCC_EQ, SUCC_EQ) = true
+    | eq (NATREC_EQ, NATREC_EQ) = true
     | eq (PLUS, PLUS) = true
     | eq (INL, INL) = true
     | eq (INR, INR) = true
     | eq (DECIDE, DECIDE) = true
+    | eq (NAT, NAT) = true
+    | eq (ZERO, ZERO) = true
+    | eq (SUCC, SUCC) = true
+    | eq (NATREC, NATREC) = true
     | eq _ = false
 
   fun arity O =
@@ -164,6 +178,14 @@ struct
        | INL_EQ => #[0, 0]
        | INR_EQ => #[0, 0]
        | DECIDE_EQ => #[0, 2, 2]
+
+       | NAT_EQ => #[]
+       | NAT_INTRO_ZERO => #[]
+       | NAT_INTRO_SUCC => #[0]
+       | NAT_ELIM => #[1,0,2]
+       | ZERO_EQ => #[]
+       | SUCC_EQ => #[0]
+       | NATREC_EQ => #[0,0,2]
 
        | FUN_EQ => #[0,1]
        | FUN_INTRO => #[1,0]
@@ -207,6 +229,10 @@ struct
        | INL => #[0]
        | INR => #[0]
        | DECIDE => #[0, 1, 1]
+       | NAT => #[]
+       | ZERO => #[]
+       | SUCC => #[0]
+       | NATREC => #[0,0,2]
 
        | ISECT => #[0,1]
 
@@ -265,6 +291,14 @@ struct
        | INR_EQ => "inr-eq"
        | DECIDE_EQ => "decide-eq"
 
+       | NAT_EQ => "nat-eq"
+       | NAT_INTRO_ZERO => "nat-intro-zero"
+       | NAT_INTRO_SUCC => "nat-intro-succ"
+       | NAT_ELIM => "nat-elim"
+       | ZERO_EQ => "zero-eq"
+       | SUCC_EQ => "succ-eq"
+       | NATREC_EQ => "natrec-eq"
+
        | ISECT_EQ => "isect⁼"
        | ISECT_INTRO => "isect-intro"
        | ISECT_ELIM => "isect-elim"
@@ -303,6 +337,10 @@ struct
        | INL => "inl"
        | INR => "inr"
        | DECIDE => "decide"
+       | NAT => "nat"
+       | ZERO => "zero"
+       | SUCC => "succ"
+       | NATREC => "natrec"
 
        | SUBSET => "subset"
 
@@ -348,6 +386,10 @@ struct
         || string "∈" return MEM
         || string "subset" return SUBSET
         || string "so_apply" return SO_APPLY
+        || string "nat" return NAT
+        || string "zero" return ZERO
+        || string "succ" return SUCC
+        || string "natrec" return NATREC
 
     fun intensionalParseOperator lookup =
       Label.parseLabel -- (fn lbl =>

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -13,7 +13,7 @@ struct
     | SUBSET_EQ | SUBSET_INTRO | IND_SUBSET_INTRO | SUBSET_ELIM | SUBSET_MEMBER_EQ
     | PLUS_EQ | PLUS_INTROL | PLUS_INTROR | PLUS_ELIM | INL_EQ | INR_EQ | DECIDE_EQ
 
-    | NAT_EQ | NAT_INTRO_ZERO | NAT_INTRO_SUCC | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
+    | NAT_EQ | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
 
     | ADMIT | ASSERT
     | CEQUAL_EQ | CEQUAL_REFL | CEQUAL_SYM | CEQUAL_STEP
@@ -124,8 +124,6 @@ struct
     | eq (INR_EQ, INR_EQ) = true
     | eq (DECIDE_EQ, DECIDE_EQ) = true
     | eq (NAT_EQ, NAT_EQ) = true
-    | eq (NAT_INTRO_ZERO, NAT_INTRO_ZERO) = true
-    | eq (NAT_INTRO_SUCC, NAT_INTRO_SUCC) = true
     | eq (NAT_ELIM, NAT_ELIM) = true
     | eq (ZERO_EQ, ZERO_EQ) = true
     | eq (SUCC_EQ, SUCC_EQ) = true
@@ -180,8 +178,6 @@ struct
        | DECIDE_EQ => #[0, 2, 2]
 
        | NAT_EQ => #[]
-       | NAT_INTRO_ZERO => #[]
-       | NAT_INTRO_SUCC => #[0]
        | NAT_ELIM => #[1,0,2]
        | ZERO_EQ => #[]
        | SUCC_EQ => #[0]
@@ -292,8 +288,6 @@ struct
        | DECIDE_EQ => "decide-eq"
 
        | NAT_EQ => "nat-eq"
-       | NAT_INTRO_ZERO => "nat-intro-zero"
-       | NAT_INTRO_SUCC => "nat-intro-succ"
        | NAT_ELIM => "nat-elim"
        | ZERO_EQ => "zero-eq"
        | SUCC_EQ => "succ-eq"

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -357,33 +357,37 @@ struct
     val parseUniv : t charParser =
       string "U" >> middle (string "{") Level.parse (string "}") wth UNIV
 
+    fun choices xs =
+      foldl (fn (p, p') => p || try p') (fail "unknown operator") xs
+
     val extensionalParseOperator : t charParser =
-      parseUniv
-        || string "base" return BASE
-        || string "void" return VOID
-        || string "unit" return UNIT
-        || string "<>" return AX
-        || string "Σ" return PROD
-        || string "+" return PLUS
-        || string "inl" return INL
-        || string "inr" return INR
-        || string "decide" return DECIDE
-        || string "pair" return PAIR
-        || string "spread" return SPREAD
-        || string "Π" return FUN
-        || string "λ" return LAM
-        || string "ap" return AP
-        || string "∀" return ISECT
-        || string "⋂" return ISECT
-        || string "=" return EQ
-        || string "ceq" return CEQUAL
-        || string "∈" return MEM
-        || string "subset" return SUBSET
-        || string "so_apply" return SO_APPLY
-        || string "nat" return NAT
-        || string "zero" return ZERO
-        || string "succ" return SUCC
-        || string "natrec" return NATREC
+      choices
+        [parseUniv,
+         string "base" return BASE,
+         string "void" return VOID,
+         string "unit" return UNIT,
+         string "<>" return AX,
+         string "Σ" return PROD,
+         string "+" return PLUS,
+         string "inl" return INL,
+         string "inr" return INR,
+         string "decide" return DECIDE,
+         string "pair" return PAIR,
+         string "spread" return SPREAD,
+         string "Π" return FUN,
+         string "λ" return LAM,
+         string "ap" return AP,
+         string "∀" return ISECT,
+         string "⋂" return ISECT,
+         string "=" return EQ,
+         string "ceq" return CEQUAL,
+         string "∈" return MEM,
+         string "subset" return SUBSET,
+         string "so_apply" return SO_APPLY,
+         string "nat" return NAT,
+         string "zero" return ZERO,
+         string "succ" return SUCC,
+         string "natrec" return NATREC]
 
     fun intensionalParseOperator lookup =
       Label.parseLabel -- (fn lbl =>


### PR DESCRIPTION
Basic unary nats
- [x] still need to add natrec-eq rule

in addition:
- replaced hand-written conv's with call to small-step thing
- fixed unsoundness that was caused by not respecting hidden-ness of variables in eliminators
