### PR TITLE
natrec-eq and fun proofs

### DIFF
--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -13,3 +13,47 @@ Theorem minus-one : [Π(nat; _. nat)] {
 Theorem natrec-test : [=(natrec(succ(succ(zero)); zero; n. ih. n); succ(zero); nat)] {
   reduce; auto
 }.
+
+Operator plus : (0;0).
+[plus(M; N)] =def= [natrec(M; N; _.n.succ(n))].
+
+Tactic t {
+  unfold <plus>; auto; elim #1; reduce; auto
+}.
+
+Theorem plus-id-left : [∀(nat; n. =(plus(zero; n); n; nat))] {
+  refine <t>
+}.
+
+Theorem plus-id-right : [∀(nat; n. =(plus(n; zero); n; nat))] {
+  refine <t>
+}.
+
+Theorem succ-right : [
+  ∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))
+] {
+  refine <t>
+}.
+
+Theorem plus-commutes : [
+  ∀(nat; n.∀(nat; m. =(plus(n; m); plus(m; n); nat)))
+] {
+  ||| Kick off the induction and do the boring computation thingies.
+  refine <t>;
+
+  ||| The base case immeidately follows from plus-id-right
+  [(assert [∀(nat; n. =(plus(n; zero); n; nat))];
+    [lemma <plus-id-right>, id];
+    elim #3 [m]; auto; unfold <plus>;
+    hyp-subst → #4 [h.=(m;h;nat)];
+    auto),
+   id];
+
+  ||| In order to prove this we first rewrite by succ-right from which our
+  ||| result follows from reflexivity.
+  assert [∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))];
+  [lemma <succ-right>, id];
+  elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
+  hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
+  auto
+}.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -1,4 +1,4 @@
-Theorem nat-example : [nat] {
+Theorem natp-example : [nat] {
   witness [succ(zero)]; auto
 }.
 
@@ -55,5 +55,5 @@ Theorem plus-commutes : [
   [lemma <succ-right>, id];
   elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
   hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
-  auto
+  auto; eq-cd [h.nat]; auto
 }.

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -607,6 +607,30 @@ struct
         ] BY mkEvidence SUCC_EQ
       end
 
+    fun NatRecEq (zC, onames) (H >> P) =
+      let
+        val #[rec1, rec2, out] = P ^! EQ
+        val #[n, zero, succ] = rec1 ^! NATREC
+        val #[n', zero', succ'] = rec1 ^! NATREC
+
+        val _ = unify (zC // n) out
+        val (npred, ih) =
+            case onames of
+                NONE =>
+                (Context.fresh (H, Variable.named "n'"),
+                 Context.fresh (H, Variable.named "ih"))
+              | SOME names => names
+        val H' = H @@ (npred, NAT $$ #[]) @@ (ih, zC // (`` npred))
+        val succSubst = (succ // ``npred) // ``ih
+        val succSubst' = (succ' // ``npred) // ``ih
+      in
+        [ H >> EQ $$ #[n, n', NAT $$ #[]]
+        , H >> EQ $$ #[zero, zero', zC // (ZERO $$ #[])]
+        , H' >> EQ $$ #[succSubst, succSubst', zC // (SUCC $$ #[`` npred])]
+        ] BY (fn [N, D, E] => NATREC_EQ $$ #[N, D, npred \\ (ih \\ E)]
+               | _ => raise Refine)
+      end
+
     fun BaseEq (H >> P) =
       let
         val #[M, N, U] = P ^! EQ

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -139,6 +139,7 @@ sig
 
     val ZeroEq : tactic
     val SuccEq : tactic
+    val NatRecEq : term * (name * name) option -> tactic
 
     val BaseEq : tactic
     val BaseIntro : tactic

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -100,6 +100,7 @@ struct
                                       (List.nth (terms, 1),
                                        List.nth (terms, 2),
                                        take3 names))
+        ORELSE_LAZY (fn _ => NatRecEq (List.nth (terms, 0), take2 names))
         ORELSE FunEq freshVariable
         ORELSE IsectEq freshVariable
         ORELSE ProdEq freshVariable

--- a/src/prover/extract.fun
+++ b/src/prover/extract.fun
@@ -81,6 +81,7 @@ struct
        | NAT_ELIM $ #[z, D, xyE] => NATREC $$ #[z, extract D, extract xyE]
        | ZERO_EQ $ _ => ax
        | SUCC_EQ $ _ => ax
+       | NATREC_EQ $ _ => ax
 
        | HYP_EQ $ _ => ax
        | WITNESS $ #[M, _] => M


### PR DESCRIPTION
I've added a first cut at a rule for natrec-eq. This is the simple version that does _no_ type inference since I'm not sure how on earth I would do such a thing. With this rule we can prove that plus commutes so I also added a proof of that.

Before I would say this is "done" I would think we should come up with some heuristic for inferring the motive of a `natrec`. Any thoughts?
