### PR TITLE
Treat theorems as operators, and allow unfolding of extracts

### DIFF
--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -64,3 +64,26 @@ Theorem MonoidLaws-wf : [∀(MonoidSig; M. ∈(MonoidLaws(M); U{i}))] {
 Theorem Monoid-wf : [∈(Monoid; U{i'})] {
   refine <monoid-simplify>.
 }.
+
+Theorem UnitMonoidStruct : [MonoidSig] {
+  unfold <MonoidSig>;
+  intro [unit]; auto;
+  intro [<>] ; auto.
+}.
+
+Theorem UnitMonoid : [Monoid] {
+  unfold <Monoid>;
+  intro [UnitMonoidStruct] @i; unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>;
+  elim #1; auto.
+}.
+
+Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {
+  unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>; elim #1; auto.
+}.
+
+Theorem UnitMonoid-RightUnit : [RightUnit(UnitMonoidStruct)] {
+  unfold <UnitMonoidStruct>;
+  refine <monoid-simplify>; elim #1; auto.
+}.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -10,8 +10,8 @@ Theorem minus-one : [Π(nat; _. nat)] {
   ]; auto
 }.
 
-Theorem natrec-test : [=(natrec(succ(succ(zero)); zero; n. ih. n); succ(zero); nat)] {
-  reduce; auto
+Theorem minus-one-test : [=(ap(minus-one; succ(succ(zero))); succ(zero); nat)] {
+  unfold <minus-one>; reduce; auto
 }.
 
 Operator plus : (0;0).

--- a/example/polynomials.jonprl
+++ b/example/polynomials.jonprl
@@ -151,11 +151,11 @@ Theorem eq_unit_unit : [Θ(unit; pair(<>; <>))] {
 ||| Polynomials (non-indexed)
 
 Operator Polynomial : ().
-Operator base : (0).
+Operator base-space : (0).
 Operator fam : (0).
 
-[Polynomial] =def= [Σ(U{i}; Base. Fam(Base))].
-[base(E)] =def= [fst(E)].
+[Polynomial] =def= [Σ(U{i}; B. Fam(B))].
+[base-space(E)] =def= [fst(E)].
 [fam(E)] =def= [snd(E)].
 
 Theorem Polynomial_wf : [∈(Polynomial; U{i'})] {
@@ -178,12 +178,12 @@ Theorem Embed_wf : [
 
 Operator Ext : (0;0).
 
-[Ext(p;X)] =def= [Σ(base(p); b. ap(Embed(X); Fiber(base(p); fam(p); b)))].
+[Ext(p;X)] =def= [Σ(base-space(p); b. unit)].
 
 Theorem Ext_wf : [
   ∀(Polynomial; p. ∀(U{i}; X. ∈(Ext(p;X); U{i'})))
 ] {
-  unfold <Polynomial Ext Fam base Embed CTT Fiber fam dom map fst snd>; refine <autoR>;
+  unfold <Polynomial Ext Fam base-space Embed CTT Fiber fam dom map fst snd>; refine <autoR>;
   unfold <snd>; refine <autoR>
 }.
 

--- a/src/ctt_frontend.sml
+++ b/src/ctt_frontend.sml
@@ -39,18 +39,13 @@ struct
       val initialContext =
         StringVariableContext.new
           (Development.enumerateOperators initialDevelopment)
-      fun updateDevelopment bindings =
-        List.foldl
-          (fn (bind, wld) => Development.declareOperator wld bind)
-          initialDevelopment
-          (StringVariableContext.enumerateOperators bindings)
 
       open CttDevelopmentParser
     in
       (case CharParser.parseChars (parse initialContext) coordStream of
            Sum.INL e => raise Fail e
          | Sum.INR (bindings, ast) =>
-           DevelopmentAstEval.eval (updateDevelopment bindings) ast)
+           DevelopmentAstEval.eval initialDevelopment ast)
       handle E => (print ("\n\n" ^ prettyException E ^ "\n"); raise E)
     end
 end

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -18,7 +18,8 @@ struct
                                Sequent.>> (Sequent.Context.empty, term),
                                TacticEval.eval D tac)
         end
-      | OPERATOR (lbl, arity) => D
+      | OPERATOR (lbl, arity) =>
+        Development.declareOperator D (lbl, arity)
       | TACTIC (lbl, tac) =>
         Development.defineTactic D (lbl, TacticEval.eval D tac)
       | DEFINITION (pat, term) =>

--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -59,7 +59,7 @@ struct
       && parseTm [] w
       && braces (!! (TacticScript.parse w))
       wth (fn (thm, (M, (tac, pos))) =>
-             (w, DevelopmentAst.THEOREM
+             (declareOperator w (thm, #[]), DevelopmentAst.THEOREM
                (thm, M, Tactic.COMPLETE (tac, {name = "COMPLETE", pos = pos}))))
 
   val parseInt =

--- a/src/prover/development.fun
+++ b/src/prover/development.fun
@@ -156,6 +156,13 @@ struct
          Object.Theorem {statement,evidence,...} => {statement = statement, evidence = evidence}
        | _ => raise Subscript
 
+  fun lookupExtract T lbl =
+    let
+      val {evidence,...} = lookupTheorem T lbl
+    in
+      Extract.extract (Susp.force evidence)
+    end
+
   fun lookupTactic T lbl =
     case Telescope.lookup T lbl of
          Object.Tactic tac => tac

--- a/src/prover/development.fun
+++ b/src/prover/development.fun
@@ -77,6 +77,8 @@ struct
       fun go Empty bind = bind
         | go (Snoc (rest, lbl, Object.Operator {arity, ...})) bind =
           go (out rest) ((lbl, arity) :: bind)
+        | go (Snoc (rest, lbl, Object.Theorem {...})) bind =
+          go (out rest) ((lbl, #[]) :: bind)
         | go (Snoc (rest, lbl, _)) bind =
           go (out rest) bind
     in
@@ -162,6 +164,7 @@ struct
   fun lookupOperator T lbl =
     case Telescope.lookup T lbl of
          Object.Operator {arity,...} => arity
+       | Object.Theorem {...} => #[]
        | _ => raise Subscript
 end
 

--- a/src/prover/development.sig
+++ b/src/prover/development.sig
@@ -51,6 +51,7 @@ sig
 
   (* lookup the statement & evidence of a theorem *)
   val lookupTheorem : world -> label -> {statement : judgement, evidence : evidence Susp.susp}
+  val lookupExtract : world -> label -> term
 
   (* lookup a custom tactic *)
   val lookupTactic : world -> label -> tactic

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -115,7 +115,7 @@ struct
     | eq (MEM, MEM) = true
     | eq (SUBSET, SUBSET) = true
     | eq (CUSTOM o1, CUSTOM o2) = Label.eq (#label o1, #label o2)
-    | eq (SO_APPLY,SO_APPLY) = true
+    | eq (SO_APPLY, SO_APPLY) = true
     | eq (PLUS_EQ, PLUS_EQ) = true
     | eq (PLUS_INTROL, PLUS_INTROL) = true
     | eq (PLUS_INTROR, PLUS_INTROR) = true
@@ -350,12 +350,12 @@ struct
     val parseInt =
       repeat1 digit wth valOf o Int.fromString o String.implode
 
-    fun angles p =
-      middle (string "<") p (string ">")
-        || middle (string "〈") p  (string "〉")
+    fun braces p = middle (string "{") p (string "}")
 
     val parseUniv : t charParser =
-      string "U" >> middle (string "{") Level.parse (string "}") wth UNIV
+      string "U"
+        >> braces Level.parse
+        wth UNIV
 
     fun choices xs =
       foldl (fn (p, p') => p || try p') (fail "unknown operator") xs
@@ -397,6 +397,6 @@ struct
 
     fun parseOperator lookup =
       intensionalParseOperator lookup
-        || extensionalParseOperator
+      || extensionalParseOperator
   end
 end


### PR DESCRIPTION
This restores behavior that was lost in the transition to a development AST, but in a more principled way than it was done before.

@jozefg Would you mind reviewing this PR, since it modifies things that you wrote? In particular, I swapped out https://github.com/jonsterling/JonPRL/compare/js/extract-operator?expand=1#diff-de85aa9c257b03a5668c44cb709589b0L42 for https://github.com/jonsterling/JonPRL/compare/js/extract-operator?expand=1#diff-dd28027ba7f0fe11560e946a268cae74R22. Does that make sense?

I've run this on all the example files and it seems to work.
