### PR TITLE
Fixed bug in natrec-eq

### DIFF
--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -38,5 +38,23 @@ Theorem succ-right : [
 Theorem plus-commutes : [
   ∀(nat; n.∀(nat; m. =(plus(n; m); plus(m; n); nat)))
 ] {
-  refine <t>
+  ||| Kick off the induction and do the boring computation thingies.
+  unfold <plus>; intro; [intro, auto]; [id, auto]; elim #1; reduce;
+
+  ||| The base case immeidately follows from plus-id-right
+  [(assert [∀(nat; n. =(plus(n; zero); n; nat))];
+    [lemma <plus-id-right>, id];
+    elim #3 [m]; auto; unfold <plus>;
+    hyp-subst → #4 [h.=(m;h;nat)];
+    auto),
+   id];
+
+  ||| In order to prove this we first rewrite by succ-right from which our
+  ||| result follows from reflexivity.
+  assert [∀(nat; n. ∀(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))];
+  [lemma <succ-right>, id];
+  elim #5 [m]; auto; elim #6 [n']; unfold <plus>; auto;
+  hyp-subst → #8 [h.=(succ(natrec(n'; m; _.n.succ(n))); h; nat)];
+  auto; eq-cd; auto
+
 }.

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -612,7 +612,7 @@ struct
       let
         val #[rec1, rec2, A] = P ^! EQ
         val #[n, zero, succ] = rec1 ^! NATREC
-        val #[n', zero', succ'] = rec1 ^! NATREC
+        val #[n', zero', succ'] = rec2 ^! NATREC
 
         val zC =
           case ozC of


### PR DESCRIPTION
The bug was quite a small one but it unfortunately had a bit of an impact on the proof of `plus-commutes`. One thing I noticed is that it makes `auto` a little dangerous since if you just apply `auto` to the goal you end up completely stuck as it tries to prove `n = m` and `m = n`. Not sure if there's a good way to avoid this though..
