### PR TITLE
Add lazy theorem proving

### DIFF
--- a/example/incomplete.jonprl
+++ b/example/incomplete.jonprl
@@ -1,0 +1,4 @@
+Operator foo : ().
+Theorem obvious1 : [unit] {id}.
+Operator bar : ().
+Theorem obvious2 : [unit] {auto}.

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -32,7 +32,7 @@ struct
     let
       val (D', runProofs) =
           List.foldl (fn (decl, info) => eval_decl info decl) (D, []) decls
-      val () = List.app (fn f => f ()) runProofs
+      val () = List.app (fn f => f ()) (List.rev runProofs)
     in
       D'
     end

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -30,5 +30,11 @@ struct
         (Development.defineOperator D {definiendum = pat, definiens = term},
          pending)
 
-  fun eval D = List.foldl (fn (decl, info) => eval_decl info decl) (D, [])
+  fun eval D decls =
+    let
+      val (D', pending) =
+          List.foldl (fn (decl, info) => eval_decl info decl) (D, []) decls
+    in
+      (D', List.rev pending)
+    end
 end

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -1,6 +1,8 @@
 structure DevelopmentAstEval :
 sig
-  val eval : Development.world -> DevelopmentAst.t list -> Development.world
+  val eval : Development.world
+             -> DevelopmentAst.t list
+             -> (Development.world * Development.runProof list)
 end =
 struct
   open DevelopmentAst
@@ -28,12 +30,5 @@ struct
         (Development.defineOperator D {definiendum = pat, definiens = term},
          pending)
 
-  fun eval D decls =
-    let
-      val (D', runProofs) =
-          List.foldl (fn (decl, info) => eval_decl info decl) (D, []) decls
-      val () = List.app (fn f => f ()) (List.rev runProofs)
-    in
-      D'
-    end
+  fun eval D = List.foldl (fn (decl, info) => eval_decl info decl) (D, [])
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -65,10 +65,13 @@ struct
              (case mode of
                    CHECK_DEVELOPMENT => runAllProofs pending
                  | PRINT_DEVELOPMENT =>
-                   (CttFrontend.printDevelopment world; runAllProofs pending)
+                   if runAllProofs pending = 0 then
+                       (CttFrontend.printDevelopment world; 0)
+                   else
+                       1
                  | LIST_OPERATORS =>
                    (CttFrontend.printOperators world; runAllProofs pending)
                  | LIST_TACTICS =>
-                     (app (fn tac => print (tac ^ "\n")) listOfTactics; runAllProofs pending))
+                   (app (fn tac => print (tac ^ "\n")) listOfTactics; runAllProofs pending))
     end
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -53,11 +53,13 @@ struct
         case CttFrontend.loadFile (dev, f) of
             (dev', f) => (dev', f :: pending)
       fun runAllProofs pending =
-        (List.app (fn f => f ()) (List.rev pending); 0)
+        (List.app (fn f => f ()) pending; 0)
           handle _ => 1
-
       val oworld =
           SOME (foldl loadFile (Development.empty, []) files) handle _ => NONE
+      val oworld =
+          Option.map
+              (fn (world, runProofs) => (world, List.rev runProofs)) oworld
     in
       case oworld of
            NONE => 1

--- a/src/prover/development.sig
+++ b/src/prover/development.sig
@@ -44,7 +44,8 @@ sig
   val empty : world
 
   (* extend a development with a theorem *)
-  val prove : world -> label * judgement * tactic -> world
+  type runProof = unit -> unit
+  val prove : world -> label * judgement * tactic -> (runProof * world)
 
   (* extend a development with a custom tactic *)
   val defineTactic : world -> label * tactic -> world


### PR DESCRIPTION
This solves #109 I believe. The idea is that instead of
1. Parsing a world
2. Checking the proofs
3. Continuing with the rest of the work

when we evaluate an AST for a development it hands us back a list of `runProof`s, which are functions from `unit -> unit` and are responsible for actually running all the proofs we just gave to `eval`. This doesn't compromise the soundness of JonPRL so long as we run everything because attempting to access the proof a theorem which hasn't yet been forced (via that `evidence` suspension`) will force the proof of the theorem exactly as if we had run it properly in the first place. This does however mean that`evidence` might actually raise an exception if we force it so I've carefully arranged this code to always run handlers before forcing  any evidence.

Now that `eval` returns a bunch of `runProof`s I have `loadFile` in `ctt_frontend` return another big `runProof` which runs all the proofs in the file top to bottom and carefully pretty prints any errors that arise from this.

Finally, in `CttFrontend.loadFile` I now accumulate all of these big handlers into a list as we parse each file. This in effect means that by the end `loadFiles` call in `main.sml` we have an option of a world (with no theorems run yet) and a list of functions that will run all the proofs in each file. From there we do all the printing of operators and tactics _and then_ trigger run all the theorems.

On the other hand this is a bit of a restructuring of the proof assistant so I'd understand if this pull request should be not merged (it will live in my heart forever or something instead).

To see this work for listing operators for incomplete developments, you can run `jonprl example/incomplete.jonprl example/test.jonprl --list-operators`. Here `incomplete.jonprl` has outstanding theorems but all the operators get listed and _then_ you get the "'Complete' Failed with goal ..."
