### PR TITLE
Allow empty tactic scripts (closes #118)

### DIFF
--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -33,7 +33,7 @@ struct
               TRACE (msg, {name = name, pos = pos}))
 
   fun parseScript w () : tactic charParser =
-    separate1 ((squares (commaSep ($ (parseScript w))) wth Sum.INR)
+    separate ((squares (commaSep ($ (parseScript w))) wth Sum.INR)
                    <|> ($ (plain w) wth Sum.INL)) semi
     wth THEN
 


### PR DESCRIPTION
A one character fix. It turns out that `tactic_eval.sml` was perfectly fine with exactly what was proposed!
