### PR TITLE
Added tactic to focus on a specific subgoal

### DIFF
--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -42,11 +42,12 @@ Theorem plus-commutes : [
   refine <t>;
 
   ||| The base case immeidately follows from plus-id-right
-  [(cut-lemma <plus-id-right>;
+  focus 0 #{
+    cut-lemma <plus-id-right>;
     elim #3 [m]; auto; unfold <plus>;
     hyp-subst → #4 [h.=(m;h;nat)];
-    auto),
-   id];
+    auto
+  };
 
   ||| In order to prove this we first rewrite by succ-right from which our
   ||| result follows from reflexivity.

--- a/src/main.sml
+++ b/src/main.sml
@@ -31,7 +31,8 @@ struct
      "id",
      "fail",
      "trace \"MESSAGE\"",
-     "cum @NUM?"]
+     "cum @NUM?",
+     "focus NUM #{TACTIC}"]
 
   local
     fun go [] = PRINT_DEVELOPMENT

--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -52,8 +52,8 @@ struct
       || parseTrace
 
   and parseFocus w () =
-      symbol "focus" && parseInt
-      && middle (symbol "#{") ($ (parseScript w)) (symbol "}")
+      symbol "focus" && parseInt &&
+      whiteSpace >> middle (symbol "#{") ($ (parseScript w)) (symbol "}")
       wth (fn (_, (i, t)) => (i, t))
 
   and parseTry w () =

--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -19,6 +19,9 @@ struct
 
   val pipe = symbol "|"
 
+  val parseInt =
+    repeat1 digit wth valOf o Int.fromString o String.implode
+
   val parseId : tactic charParser =
     !! (symbol "id") wth (fn (name, pos) =>
       ID {name = name, pos = pos})
@@ -33,8 +36,9 @@ struct
               TRACE (msg, {name = name, pos = pos}))
 
   fun parseScript w () : tactic charParser =
-    separate ((squares (commaSep ($ (parseScript w))) wth Sum.INR)
-                   <|> ($ (plain w) wth Sum.INL)) semi
+    separate ((squares (commaSep ($ (parseScript w))) wth LIST)
+                   <|> ($ (plain w) wth APPLY)
+                   <|> $ (parseFocus w) wth FOCUS) semi
     wth THEN
 
   and plain w () =
@@ -46,6 +50,11 @@ struct
       || parseId
       || parseFail
       || parseTrace
+
+  and parseFocus w () =
+      symbol "focus" && parseInt
+      && middle (symbol "#{") ($ (parseScript w)) (symbol "}")
+      wth (fn (_, (i, t)) => (i, t))
 
   and parseTry w () =
     middle (symbol "?{") ($ (parseScript w)) (symbol "}")

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -52,9 +52,13 @@ sig
       | TRY of t
       | LIMIT of t
       | ORELSE of t list * meta
-      | THEN of (t, t list) Sum.sum list
+      | THEN of then_tactic list
       | ID of meta
       | FAIL of meta
       | TRACE of string * meta
       | COMPLETE of t * meta
+    and then_tactic =
+        APPLY of t
+      | LIST of t list
+      | FOCUS of int * t
 end

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -53,9 +53,13 @@ struct
     | TRY of t
     | LIMIT of t
     | ORELSE of t list * meta
-    | THEN of (t, t list) Sum.sum list
+    | THEN of then_tactic list
     | ID of meta
     | FAIL of meta
-    | COMPLETE of t * meta
     | TRACE of string * meta
+    | COMPLETE of t * meta
+  and then_tactic =
+      APPLY of t
+    | LIST of t list
+    | FOCUS of int * t
 end

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -60,8 +60,9 @@ struct
       | ORELSE (tacs, a) => an a (List.foldl T.ORELSE T.FAIL (map (eval wld) tacs))
       | THEN ts =>
         List.foldl
-          (fn (Sum.INL x, rest) => T.THEN (rest, (eval wld) x)
-            | (Sum.INR xs, rest) => T.THENL (rest, map (eval wld) xs))
+          (fn (APPLY x, rest) => T.THEN (rest, eval wld x)
+            | (LIST xs, rest) => T.THENL (rest, map (eval wld) xs)
+            | (FOCUS (i, x), rest) => T.THENF (rest, i, eval wld x))
           T.ID
           ts
       | ID a => an a T.ID


### PR DESCRIPTION
Now that sml-lcf supports focusing on a specific goal JonPRL should as well. I'm having some trouble with the parser though, specifically I thought some nice syntax for focusing was

```
  t; focus SUBGOAL_NUMBER #{ t2 }
```

but this gives me a parse error if there's any whitespace in between the number and the `#` which is a little baffling. Does anyone know what's going on here?
