### PR TITLE
Added an example of coinduction from isect and nat

### DIFF
--- a/example/conats.jonprl
+++ b/example/conats.jonprl
@@ -17,31 +17,37 @@ Operator conatF : (0).
 Operator conat : ().
 [conat] =def= [⋂(nat; n.iterate(n; x.conatF(x); top))].
 
+Operator czero : ().
+[czero] =def= [inl(<>)].
+
+Operator csucc : (0).
+[csucc(M)] =def= [inr(M)].
+
+Operator Y : (0).
+[Y(f)] =def= [ap(λ(x.ap(f;ap(x;x)));λ(x.ap(f;ap(x;x))))].
+
+Operator omega : ().
+[omega] =def= [Y(λ(x.csucc(x)))].
+
 Tactic unfolds {
-  *{unfold <conat iterate conatF top>}
+  *{unfold <conat czero csucc iterate conatF top omega Y>}
 }.
 
 Tactic rauto {
   *{reduce; auto} ||| May not terminate but shh
 }.
 
-Theorem zero-wf : [∈(inl(<>); conat)] {
+Theorem zero-wf : [∈(czero; conat)] {
   refine <unfolds>; refine <rauto>; elim #1; refine <rauto>
 }.
 
-Theorem succ-wf : [⋂(conat; x. ∈(inr(x); conat))] {
+Theorem succ-wf : [⋂(conat; x. ∈(csucc(x); conat))] {
   refine <unfolds>; auto;
   elim #2; focus 1 #{elim #1 [n']};
   refine <rauto>;
   hyp-subst ← #6 [h.=(h; h; natrec(n'; ⋂(void; _.void); _.x.+(unit;x)))];
   refine <rauto>
 }.
-
-Operator Y : (0).
-[Y(f)] =def= [ap(λ(x.ap(f;ap(x;x)));λ(x.ap(f;ap(x;x))))].
-
-Operator omega : ().
-[omega] =def= [Y(λ(x.inr(x)))].
 
 Theorem omega-wf : [∈(omega; conat)] {
   refine <unfolds>; unfold <omega Y>; auto; elim #1;

--- a/example/conats.jonprl
+++ b/example/conats.jonprl
@@ -1,0 +1,53 @@
+Operator iterate : (0; 1; 0).
+[iterate(N; F; B)] =def= [natrec(N; B; _.x.so_apply(F; x))].
+
+Operator top : ().
+[top] =def= [⋂(void; _.void)].
+
+Theorem top-is-top :
+  [⋂(base; x.
+   ⋂(base; y.
+   =(x; y; top)))] {
+  unfold <top>; auto
+}.
+
+Operator conatF : (0).
+[conatF(X)] =def= [+(unit; X)].
+
+Operator conat : ().
+[conat] =def= [⋂(nat; n.iterate(n; x.conatF(x); top))].
+
+Tactic unfolds {
+  *{unfold <conat iterate conatF top>}
+}.
+
+Tactic rauto {
+  *{reduce; auto} ||| May not terminate but shh
+}.
+
+Theorem zero-wf : [∈(inl(<>); conat)] {
+  refine <unfolds>; refine <rauto>; elim #1; refine <rauto>
+}.
+
+Theorem succ-wf : [⋂(conat; x. ∈(inr(x); conat))] {
+  refine <unfolds>; auto;
+  elim #2; focus 1 #{elim #1 [n']};
+  refine <rauto>;
+  hyp-subst ← #6 [h.=(h; h; natrec(n'; ⋂(void; _.void); _.x.+(unit;x)))];
+  refine <rauto>
+}.
+
+Operator Y : (0).
+[Y(f)] =def= [ap(λ(x.ap(f;ap(x;x)));λ(x.ap(f;ap(x;x))))].
+
+Operator omega : ().
+[omega] =def= [Y(λ(x.inr(x)))].
+
+Theorem omega-wf : [∈(omega; conat)] {
+  refine <unfolds>; unfold <omega Y>; auto; elim #1;
+  focus 0 #{reduce 1; auto};
+  csubst [ceq(ap(λ(x.ap(λ(x.inr(x));ap(x;x)));λ(x.ap(λ(x.inr(x));ap(x;x))));
+              inr(ap(λ(x.ap(λ(x.inr(x));ap(x;x)));λ(x.ap(λ(x.inr(x));ap(x;x))))))]
+         [h.=(h;h; natrec(succ(n'); ⋂(void; _. void); _.x.+(unit; x)))];
+  [step; step; auto, reduce 1; auto]
+}.


### PR DESCRIPTION
There are a few interesting proofs left that I'm not sure are possible but haven't disproved in my head yet
- `conat` is a fixed point of `conatF`.
- That all members of `conat` are `inr` of a `conat` or `inl(<>)` (remember all things are equal in `top`)
- `conat` is the greatest fixed point (this seems pretty much impossible to prove, but I can dream)
