### PR TITLE
Fixed bug in level solver

### DIFF
--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -1035,7 +1035,6 @@ struct
     fun Lemma (world, lbl) (H >> P) =
       let
         val {statement, evidence} = Development.lookupTheorem world lbl
-        val H' >> P' = statement
         val constraints = SequentLevelSolver.generateConstraints (statement, H >> P)
         val substitution = LevelSolver.Level.resolve constraints
         val shovedEvidence = LevelSolver.subst substitution (Susp.force evidence)

--- a/src/prover/level_solver.fun
+++ b/src/prover/level_solver.fun
@@ -25,7 +25,7 @@ struct
           end
       | go H (x \ E, y \ F) R = go (insert H x y) (out E, out F) R
       | go H (O1 $ ES1, O2 $ ES2) R =
-        if Operator.eq (O1, O2) then
+        if eqModLevel (O1, O2) then
             case (getLevelParameter O1, getLevelParameter O2) of
                 (SOME k, SOME l) => goes H (ES1, ES2) (Level.unify (k,l) :: R)
               | (NONE, NONE) => goes H (ES1, ES2) R
@@ -70,6 +70,10 @@ struct
   fun getLevelParameter (OperatorType.UNIV k) = SOME k
     | getLevelParameter (OperatorType.UNIV_EQ k) = SOME k
     | getLevelParameter _ = NONE
+
+  fun eqModLevel (OperatorType.UNIV _, OperatorType.UNIV _) = true
+    | eqModLevel (OperatorType.UNIV_EQ _, OperatorType.UNIV_EQ _) = true
+    | eqModLevel (o1, o2) = Operator.eq (o1, o2)
 end
 
 functor SequentLevelSolver

--- a/src/prover/level_solver.sig
+++ b/src/prover/level_solver.sig
@@ -16,4 +16,5 @@ sig
 
   val mapLevel : Level.substitution -> Operator.t -> Operator.t
   val getLevelParameter : Operator.t -> Level.t option
+  val eqModLevel : Operator.t * Operator.t -> bool
 end


### PR DESCRIPTION
There was a small bug in the level solver: when we compared to operators to be equal, we (actually, me I think) failed to account for the fact that operators at different levels aren't equal. To fix this I added an extra value to the `SYNTAX_WITH_UNIVERSES` signature: `eqModLevel` which checks if two operators are the same operator at different levels.

Then we compare using _that_ when generating constraints.

Notably, this fixes `example/universe-levels.jonprl`. 
