### PR TITLE
Custom tactics now don't need refine (closes #129)

### DIFF
--- a/example/category.jonprl
+++ b/example/category.jonprl
@@ -30,12 +30,12 @@ Tactic autoR {
 }.
 
 Theorem RawCat_wf : [member(RawCat; U{i'})] {
-  refine <rawcat_unfold>; auto.
+  rawcat_unfold; auto.
 }.
 
 
 Theorem obj_wf : [isect(RawCat; RC. member(obj(RC); U{i}))] {
-  refine <rawcat_unfold>; auto.
+  rawcat_unfold; auto.
 }.
 
 Theorem hom_wf : [
@@ -44,7 +44,7 @@ Theorem hom_wf : [
   isect(obj(RC); B.
     member(hom(RC;A;B); U{i}))))
 ] {
-  refine <rawcat_unfold>; refine <autoR>.
+  rawcat_unfold; autoR.
 }.
 
 Theorem idn_wf : [
@@ -52,7 +52,7 @@ Theorem idn_wf : [
   isect(obj(RC); A.
     member(idn(RC;A); hom(RC;A;A))))
 ] {
-  refine <rawcat_unfold>; refine <autoR>.
+  rawcat_unfold; autoR.
 }.
 
 Theorem cmp_wf : [
@@ -64,7 +64,7 @@ Theorem cmp_wf : [
   isect(hom(RC; X; Y); g.
     member(cmp(RC;X;Y;Z;f;g); hom(RC; X;Z))))))))
 ] {
-  refine <rawcat_unfold>; refine <autoR>.
+  rawcat_unfold; autoR.
 }.
 
 Operator LeftIdentity : (0).
@@ -89,15 +89,15 @@ Operator CmpAssoc : (0).
 ].
 
 Theorem LeftIdentity_wf : [isect(RawCat; RC. member(LeftIdentity(RC); U{i}))] {
-  unfold <LeftIdentity>; refine <rawcat_unfold>; refine <autoR>.
+  unfold <LeftIdentity>; rawcat_unfold; autoR.
 }.
 
 Theorem RightIdentity_wf : [isect(RawCat; RC. member(RightIdentity(RC); U{i}))] {
-  unfold <RightIdentity>; refine <rawcat_unfold>; refine <autoR>.
+  unfold <RightIdentity>; rawcat_unfold; autoR.
 }.
 
 Theorem CmpAssoc_wf : [isect(RawCat; RC. member(CmpAssoc(RC); U{i}))] {
-  unfold <CmpAssoc>; *{refine <rawcat_unfold>; refine <autoR>}.
+  unfold <CmpAssoc>; *{rawcat_unfold; autoR}.
 }.
 
 Operator LawCat : (0).
@@ -105,12 +105,12 @@ Operator LawCat : (0).
 
 Tactic lawcat_unfold {
   unfold <LeftIdentity RightIdentity CmpAssoc LawCat>;
-  refine <rawcat_unfold>.
+  rawcat_unfold.
 }.
 
 Theorem LawCat_wf : [isect(RawCat; RC. member(LawCat(RC); U{i}))] {
   intro @i';
-  [ *{refine <lawcat_unfold>; refine <autoR>}
+  [ *{lawcat_unfold; autoR}
   , lemma <RawCat_wf>
   ]
 }.
@@ -119,12 +119,12 @@ Operator Cat : ().
 [Cat] =def= [subset(RawCat; C. LawCat(C))].
 
 Tactic cat_unfold {
-  unfold <Cat>; refine <lawcat_unfold>.
+  unfold <Cat>; lawcat_unfold.
 }.
 
 Theorem Cat-wf : [member(Cat; U{i'})] {
-  *{refine <cat_unfold>; auto};
-  elim #1; refine <autoR>
+  *{cat_unfold; auto};
+  elim #1; autoR
 }.
 
 Theorem InitialRawCat : [RawCat] {
@@ -139,18 +139,18 @@ Theorem InitialCat : [Cat] {
   intro [InitialRawCat] @i;
   unfold <InitialRawCat>;
   [id, id, cut-lemma <LawCat_wf>; elim #2 [C]];
-  *{refine <lawcat_unfold>; auto; reduce}
+  *{lawcat_unfold; auto; reduce}
 }.
 
 Theorem TerminalRawCat : [RawCat] {
   unfold <RawCat>;
-  intro [unit]; refine <autoR>;
-  intro [lam(A. lam(B. unit))]; refine <autoR>;
+  intro [unit]; autoR;
+  intro [lam(A. lam(B. unit))]; autoR;
 }.
 
 Theorem TerminalCat : [Cat] {
   unfold <Cat>;
   intro [TerminalRawCat] <C> @i; unfold <TerminalRawCat>;
-  *{refine <lawcat_unfold>; auto; reduce};
+  *{lawcat_unfold; auto; reduce};
   elim #3; auto
 }.

--- a/example/category2.jonprl
+++ b/example/category2.jonprl
@@ -43,31 +43,31 @@ Tactic rawcat-unfold {
 }.
 
 Theorem obj-wf : [isect(RawCat; C. member(obj(C); U{i}))] {
-  refine <rawcat-unfold>; auto
+  rawcat-unfold; auto
 }.
 
 Theorem arr-wf : [isect(RawCat; C. member(arr(C); U{i}))] {
-  refine <rawcat-unfold>; auto
+  rawcat-unfold; auto
 }.
 
 Theorem src-wf : [isect(RawCat; C. isect(arr(C); f. member(src(C;f); obj(C))))] {
-  refine <rawcat-unfold>; auto
+  rawcat-unfold; auto
 }.
 
 Theorem trg-wf : [isect(RawCat; C. isect(arr(C); f. member(trg(C;f); obj(C))))] {
-  refine <rawcat-unfold>; auto
+  rawcat-unfold; auto
 }.
 
 Theorem hom-wf : [isect(RawCat; C. isect(obj(C); X. isect(obj(C); Y. member(hom(C;X;Y); U{i}))))] {
-  refine <rawcat-unfold>; auto
+  rawcat-unfold; auto
 }.
 
 Theorem RawCat-wf : [member(RawCat; U{i'})] {
-  refine <rawcat-unfold>; auto;
+  rawcat-unfold; auto;
 }.
 
 Theorem InitialRawCat : [RawCat] {
-  refine <rawcat-unfold>;
+  rawcat-unfold;
   intro [void]; auto;
   intro [void]; auto;
   *{intro [lam(x.welp)]; auto}.

--- a/example/conats.jonprl
+++ b/example/conats.jonprl
@@ -40,19 +40,19 @@ Tactic rauto {
 }.
 
 Theorem zero-wf : [member(czero; conat)] {
-  refine <unfolds>; refine <rauto>; elim #1; refine <rauto>
+  unfolds; rauto; elim #1; rauto
 }.
 
 Theorem succ-wf : [isect(conat; x. member(csucc(x); conat))] {
-  refine <unfolds>; auto;
+  unfolds; auto;
   elim #2; focus 1 #{elim #1 [n']};
-  refine <rauto>;
+  rauto;
   hyp-subst ← #6 [h.=(h; h; natrec(n'; isect(void; _.void); _.x.+(unit;x)))];
-  refine <rauto>
+  rauto
 }.
 
 Theorem omega-wf : [member(omega; conat)] {
-  refine <unfolds>; unfold <omega Y>; auto; elim #1;
+  unfolds; unfold <omega Y>; auto; elim #1;
   focus 0 #{reduce 1; auto};
   csubst [ceq(ap(lam(x.inr(ap(x;x))); lam(x.inr(ap(x;x))));
               inr(ap(lam(x.inr(ap(x;x))); lam(x.inr(ap(x;x))))))]

--- a/example/monoid.jonprl
+++ b/example/monoid.jonprl
@@ -26,11 +26,11 @@ Tactic monoid-sig-unfold {
 }.
 
 Theorem MonoidSig-wf : [member(MonoidSig; U{i'})] {
-  refine <monoid-sig-unfold>; auto.
+  monoid-sig-unfold; auto.
 }.
 
 Theorem car-wf : [isect(MonoidSig; M. member(car(M); U{i}))] {
-  refine <monoid-sig-unfold>; auto.
+  monoid-sig-unfold; auto.
 }.
 
 Tactic monoid-laws-unfold {
@@ -38,31 +38,31 @@ Tactic monoid-laws-unfold {
 }.
 
 Tactic monoid-unfold {
-  unfold <Monoid>; refine <monoid-sig-unfold>; refine <monoid-laws-unfold>.
+  unfold <Monoid>; monoid-sig-unfold; monoid-laws-unfold.
 }.
 
 Tactic monoid-simplify {
-  *{ refine <monoid-unfold>; reduce; auto }.
+  *{ monoid-unfold; reduce; auto }.
 }.
 
 Theorem LeftUnit-wf : [isect(MonoidSig; M. member(LeftUnit(M); U{i}))] {
-  refine <monoid-simplify>.
+  monoid-simplify.
 }.
 
 Theorem RightUnit-wf : [isect(MonoidSig; M. member(RightUnit(M);U{i}))] {
-  refine <monoid-simplify>.
+  monoid-simplify.
 }.
 
 Theorem Assoc-wf : [isect(MonoidSig; M. member(Assoc(M); U{i}))] {
-  refine <monoid-simplify>.
+  monoid-simplify.
 }.
 
 Theorem MonoidLaws-wf : [isect(MonoidSig; M. member(MonoidLaws(M); U{i}))] {
-  refine <monoid-simplify>.
+  monoid-simplify.
 }.
 
 Theorem Monoid-wf : [member(Monoid; U{i'})] {
-  refine <monoid-simplify>.
+  monoid-simplify.
 }.
 
 Theorem UnitMonoidStruct : [MonoidSig] {
@@ -74,16 +74,16 @@ Theorem UnitMonoidStruct : [MonoidSig] {
 Theorem UnitMonoid : [Monoid] {
   unfold <Monoid>;
   intro [UnitMonoidStruct] @i; unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>;
+  monoid-simplify;
   elim #1; auto.
 }.
 
 Theorem UnitMonoid-LeftUnit : [LeftUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim #1; auto.
+  monoid-simplify; elim #1; auto.
 }.
 
 Theorem UnitMonoid-RightUnit : [RightUnit(UnitMonoidStruct)] {
   unfold <UnitMonoidStruct>;
-  refine <monoid-simplify>; elim #1; auto.
+  monoid-simplify; elim #1; auto.
 }.

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -22,24 +22,24 @@ Tactic t {
 }.
 
 Theorem plus-id-left : [isect(nat; n. =(plus(zero; n); n; nat))] {
-  refine <t>
+  t
 }.
 
 Theorem plus-id-right : [isect(nat; n. =(plus(n; zero); n; nat))] {
-  refine <t>
+  t
 }.
 
 Theorem succ-right : [
   isect(nat; n. isect(nat; m. =(plus(n; succ(m)); succ(plus(n; m)); nat)))
 ] {
-  refine <t>
+  t
 }.
 
 Theorem plus-commutes : [
   isect(nat; n.isect(nat; m. =(plus(n; m); plus(m; n); nat)))
 ] {
   ||| Kick off the induction and do the boring computation thingies.
-  refine <t>;
+  t;
 
   ||| The base case immeidately follows from plus-id-right
   focus 0 #{

--- a/example/polynomials.jonprl
+++ b/example/polynomials.jonprl
@@ -57,13 +57,13 @@ Theorem Ran_wf : [
   isect(U{i}; E. isect(U{i}; B. isect(fun(E; _. B); f. isect(fun(E; _. U{i}); φ. isect(B; b.
     member(Ran(E;B;f;φ;b); U{i}))))))
 ] {
-  unfold <Ran Power End Paths>; refine <autoR>.
+  unfold <Ran Power End Paths>; autoR.
 }.
 Theorem Lan_wf : [
   isect(U{i}; E. isect(U{i}; B. isect(fun(E; _. B); f. isect(fun(E; _. U{i}); φ. isect(B; b.
     member(Lan(E;B;f;φ;b); U{i}))))))
 ] {
-  unfold <Lan Copower Coend Paths>; refine <autoR>.
+  unfold <Lan Copower Coend Paths>; autoR.
 }.
 
 ||| Fam
@@ -85,7 +85,7 @@ Theorem dom_wf : [isect(U{i}; B. isect(Fam(B); f. member(dom(f); U{i})))] {
 Theorem map_wf : [
   isect(U{i}; B. isect(Fam(B); f. isect(dom(f); x. member(map(f;x); B))))
 ] {
-  unfold <Fam dom map fst snd>; refine <autoR>.
+  unfold <Fam dom map fst snd>; autoR.
 }.
 
 ||| Fibers of a bundle over a point
@@ -97,7 +97,7 @@ Operator Fiber : (0;0;0).
 Theorem Fiber_wf : [
   isect(U{i}; B. isect(Fam(B); f. isect(B; b. member(Fiber(B;f;b); U{i}))))
 ] {
-  unfold <Fam Fiber dom map fst snd>; refine <autoR>.
+  unfold <Fam Fiber dom map fst snd>; autoR.
 }.
 
 ||| Quantifier adjoints
@@ -116,19 +116,19 @@ Theorem Exists_wf : [
   isect(U{i}; X. isect(U{i}; Y. isect(fun(X; _. Y); f. isect(fun(X; _. U{i}); φ.
     member(ap(Exists(X;Y;f);φ); fun(Y; _. U{i}))))))
 ] {
-  unfold <Exists Lan Coend Copower Paths>; refine <autoR>.
+  unfold <Exists Lan Coend Copower Paths>; autoR.
 }.
 Theorem Invert_wf : [
   isect(U{i}; X. isect(U{i}; Y. isect(fun(X; _. Y); f. isect(fun(Y; _. U{i}); φ.
     member(ap(Invert(f);φ); fun(X; _. U{i}))))))
 ] {
-  unfold <Invert>; refine <autoR>.
+  unfold <Invert>; autoR.
 }.
 Theorem Forall_wf : [
   isect(U{i}; X. isect(U{i}; Y. isect(fun(X; _. Y); f. isect(fun(X; _. U{i}); φ.
     member(ap(Forall(X;Y;f);φ); fun(Y; _. U{i}))))))
 ] {
-  unfold <Forall Ran End Power Paths>; refine <autoR>
+  unfold <Forall Ran End Power Paths>; autoR
 }.
 
 ||| Examples
@@ -144,7 +144,7 @@ Operator Θ : (0;0).
 
 ||| <> = <> member unit
 Theorem eq_unit_unit : [Θ(unit; pair(<>; <>))] {
-  unfold <Θ δ Exists Lan Coend Copower Paths>; refine <autoR>;
+  unfold <Θ δ Exists Lan Coend Copower Paths>; autoR;
   intro [<>]; auto.
 }.
 
@@ -171,7 +171,7 @@ Operator Embed : (0).
 Theorem Embed_wf : [
   isect(U{i}; B. isect(U{i}; X. member(ap(Embed(B); X); U{i})))
 ] {
-  unfold <Embed CTT>; refine <autoR>.
+  unfold <Embed CTT>; autoR.
 }.
 
 ||| Extension functors of polynomials
@@ -183,8 +183,8 @@ Operator Ext : (0;0).
 Theorem Ext_wf : [
   isect(Polynomial; p. isect(U{i}; X. member(Ext(p;X); U{i'})))
 ] {
-  unfold <Polynomial Ext Fam base-space Embed CTT Fiber fam dom map fst snd>; refine <autoR>;
-  unfold <snd>; refine <autoR>
+  unfold <Polynomial Ext Fam base-space Embed CTT Fiber fam dom map fst snd>; autoR;
+  unfold <snd>; autoR
 }.
 
 ||| Fam pullbacks
@@ -197,5 +197,5 @@ Theorem Pullback_wf : [
   isect(U{i}; B. isect(Fam(B); f. isect(Fam(B); g.
     member(Pullback(B;f;g); U{i}))))
 ] {
-  unfold <Pullback Fam Fiber map dom fst snd>; refine <autoR>.
+  unfold <Pullback Fam Fiber map dom fst snd>; autoR.
 }.

--- a/example/sums.jonprl
+++ b/example/sums.jonprl
@@ -12,7 +12,7 @@ Theorem commutative :
         [isect(U{i}; A.
          isect(U{i}; B.
          equiv(+(A; B); +(B; A))))] {
-  unfold <equiv>; auto; elim #3; refine <constructor>
+  unfold <equiv>; auto; elim #3; constructor
 }.
 
 Theorem plus-assoc :
@@ -24,7 +24,7 @@ Theorem plus-assoc :
   [id; id, elim #5, elim #5, intro #1; intro #1];
   auto;
   [intro #0, intro #0, id, id, intro #1];
-  refine <constructor>
+  constructor
 }.
 
 Theorem void-idr :

--- a/src/ctt_frontend.sml
+++ b/src/ctt_frontend.sml
@@ -18,22 +18,18 @@ struct
       print (name ^ " " ^ Arity.toString arity ^ "\n")
 
     val labelToString = Development.Telescope.Label.toString
-
-    fun go Empty = ()
-      | go (Cons (lbl, OPERATOR {arity,...}, rest)) =
-        (printStep (labelToString lbl, arity); go (out rest))
-      | go (Cons (lbl, THEOREM {...}, rest)) =
-        (printStep (labelToString lbl, #[]); go (out rest))
-      | go (Cons (_, _, rest)) =
-        go (out rest)
   in
     fun printOperators world =
       (List.app
-        (fn x =>
-          printStep (Syntax.Operator.toString x, Syntax.Operator.arity x))
-        OperatorType.publicOperators;
-      go (out (Development.enumerate world)))
+         (fn x =>
+           printStep (Syntax.Operator.toString x, Syntax.Operator.arity x))
+         OperatorType.publicOperators;
+       List.app printStep (Development.enumerateOperators world))
   end
+
+  fun printTactics world =
+    List.app (fn x => print (x ^ "\n"))
+             (Tactic.listOfTactics @ Development.enumerateTactics world)
 
   fun prettyException E =
     case E of

--- a/src/main.sml
+++ b/src/main.sml
@@ -6,36 +6,6 @@ struct
     | LIST_OPERATORS
     | LIST_TACTICS
 
-  val listOfTactics =
-    ["intro [TERM]? #NUM? <NAME*>?",
-     "elim #NUM [TERM]? <NAME*>?",
-     "eq-cd [TERM*]? <NAME*>? @LEVEL?",
-     "ext <NAME>? @LEVEL?",
-     "symmetry",
-     "capprox",
-     "creflexivty",
-     "areflexivty",
-     "csymmetry",
-     "step",
-     "cstruct",
-     "assumption",
-     "assert [TERM] <NAME>?",
-     "mem-cd",
-     "auto NUM?",
-     "reduce NUM?",
-     "lemma <NAME>",
-     "cut-lemma <NAME>",
-     "unfold <(NAME @NUM)+>",
-     "witness [TERM]",
-     "hypothesis #NUM",
-     "bot-div #NUM",
-     "hyp-subst (←|→) #NUM [TERM] @NUM?",
-     "id",
-     "fail",
-     "trace \"MESSAGE\"",
-     "cum @NUM?",
-     "focus NUM #{TACTIC}"]
-
   local
     fun go [] = PRINT_DEVELOPMENT
       | go ("--check" :: _) = CHECK_DEVELOPMENT
@@ -69,6 +39,7 @@ struct
                    ((CttFrontend.printOperators world; 0)
                      handle E => (print (exnMessage E); 1))
                  | LIST_TACTICS =>
-                     (app (fn tac => print (tac ^ "\n")) listOfTactics; 0))
+                   ((CttFrontend.printTactics world; 0)
+                     handle E => (print (exnMessage E); 1)))
     end
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -26,7 +26,6 @@ struct
      "lemma <NAME>",
      "cut-lemma <NAME>",
      "unfold <(NAME @NUM)+>",
-     "refine <NAME>",
      "witness [TERM]",
      "hypothesis #NUM",
      "bot-div #NUM",

--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -21,6 +21,11 @@ struct
 
   open JonprlTokenParser
 
+  fun tactic s =
+      repeat1 JonprlLanguageDef.identLetter << whiteSpace
+        wth String.implode
+        suchthat (fn s' => s = s')
+
   val parseInt =
     repeat1 digit wth valOf o Int.fromString o String.implode
 
@@ -47,24 +52,24 @@ struct
     squares o ParseSyntax.parseAbt [] o lookupOperator
 
   val parseCum : tactic_parser =
-    fn w => symbol "cum"
+    fn w => tactic "cum"
       && opt parseLevel
       wth (fn (name, k) => fn pos => CUM (k, {name = name, pos = pos}))
 
   val parseWitness : tactic_parser =
-    fn w => symbol "witness"
+    fn w => tactic "witness"
       && parseTm w
       wth (fn (name, tm) => fn pos =>
               WITNESS (tm, {name = name, pos = pos}))
 
   val parseHypothesis : tactic_parser =
-    fn w => symbol "hypothesis"
+    fn w => tactic "hypothesis"
       && parseIndex
       wth (fn (name, i) => fn pos =>
         HYPOTHESIS (i, {name = name, pos = pos}))
 
   val parseEqSubst : tactic_parser =
-    fn w => symbol "subst"
+    fn w => tactic "subst"
       && parseTm w && parseTm w && opt parseLevel
       wth (fn (name, (M, (N, k))) => fn pos =>
               EQ_SUBST ({equality = M, domain = N, level = k},
@@ -75,7 +80,7 @@ struct
       || (symbol "←" || symbol "<-") return Dir.LEFT
 
   val parseHypSubst : tactic_parser =
-    fn w => symbol "hyp-subst"
+    fn w => tactic "hyp-subst"
       && parseDir
       && parseIndex
       && parseTm w && opt parseLevel
@@ -88,14 +93,14 @@ struct
                  {name = name, pos = pos}))
 
   val parseCEqSubst : tactic_parser =
-    fn w => symbol "csubst"
+    fn w => tactic "csubst"
       && parseTm w && parseTm w
       wth (fn (name, (M, N)) => fn pos =>
               CEQ_SUBST ({equality = M, domain = N},
                          {name = name, pos = pos}))
 
   val parseCHypSubst : tactic_parser =
-    fn w => symbol "chyp-subst"
+    fn w => tactic "chyp-subst"
       && parseDir
       && parseIndex
       && parseTm w
@@ -147,103 +152,102 @@ struct
       wth (fn (z,k) => {freshVariable = z, level = k})
 
   val parseIntro =
-    fn w => symbol "intro"
+    fn w => tactic "intro"
       && parseIntroArgs w
       wth (fn (name, args) => fn pos =>
               INTRO (args, {name = name, pos = pos}))
 
   val parseElim =
-    fn w => symbol "elim"
+    fn w => tactic "elim"
       && parseElimArgs w
       wth (fn (name, args) => fn pos =>
               ELIM (args, {pos = pos, name = name}))
 
   val parseEqCd =
-    fn w => symbol "eq-cd"
+    fn w => tactic "eq-cd"
       && (parseEqCdArgs w)
       wth (fn (name, args) => fn pos =>
               EQ_CD (args, {name = name, pos = pos}))
 
   val parseExt =
-    fn w => symbol "ext"
+    fn w => tactic "ext"
       && parseExtArgs w
       wth (fn (name, args) => fn pos =>
               EXT (args, {name = name, pos = pos}))
 
   val parseSymmetry : tactic_parser =
-    fn w => symbol "symmetry"
+    fn w => tactic "symmetry"
       wth (fn name => fn pos => SYMMETRY {name = name, pos = pos})
 
   val parseCEqualSym : tactic_parser =
-    fn w => symbol "csymmetry"
+    fn w => tactic "csymmetry"
       wth (fn name => fn pos => CEQUAL_SYM {name = name, pos = pos})
 
   val parseCEqualStep : tactic_parser =
-    fn w => symbol "step"
+    fn w => tactic "step"
       wth (fn name => fn pos => CEQUAL_STEP {name = name, pos = pos})
 
   val parseCEqualStruct : tactic_parser =
-    fn w => symbol "cstruct"
+    fn w => tactic "cstruct"
       wth (fn name => fn pos => CEQUAL_STRUCT {name = name, pos = pos})
 
   val parseCEqualApprox : tactic_parser =
-    fn w => symbol "capprox"
+    fn w => tactic "capprox"
       wth (fn name => fn pos => CEQUAL_APPROX {name = name, pos = pos})
 
   val parseApproxRefl : tactic_parser =
-    fn w => symbol "areflexivity"
+    fn w => tactic "areflexivity"
       wth (fn name => fn pos => APPROX_REFL {name = name, pos = pos})
 
   val parseBottomDiverges : tactic_parser =
-   fn w => symbol "bot-div"
+   fn w => tactic "bot-div"
 		  && parseIndex
 		  wth (fn (name, i) => fn pos =>
 			  BOTTOM_DIVERGES (i, {name = name, pos = pos}))
 
   val parseAssumption : tactic_parser =
-    fn w => symbol "assumption"
+    fn w => tactic "assumption"
       wth (fn name => fn pos => ASSUMPTION {name = name, pos = pos})
 
   val parseAssert : tactic_parser =
-   fn w => symbol "assert" && parseTm w && opt (brackets parseName)
+   fn w => tactic "assert" && parseTm w && opt (brackets parseName)
      wth (fn (name, (term, hyp)) => fn pos =>
              ASSERT ({assertion = term, name = hyp},
                      {name = name, pos = pos}))
 
   val parseMemCd : tactic_parser =
-    fn w => symbol "mem-cd"
+    fn w => tactic "mem-cd"
       wth (fn name => fn pos => MEM_CD {name = name, pos = pos})
 
   val parseAuto : tactic_parser =
-    fn w => symbol "auto" && opt parseInt
+    fn w => tactic "auto" && opt parseInt
       wth (fn (name, oi) => fn pos => AUTO (oi, {name = name, pos = pos}))
 
   val parseReduce : tactic_parser =
-    fn w => symbol "reduce"
+    fn w => tactic "reduce"
       && opt parseInt
       wth (fn (name, n) => fn pos => REDUCE (n, {name = name, pos = pos}))
 
   val parseLemma : tactic_parser =
-    fn w => symbol "lemma"
+    fn w => tactic "lemma"
       && brackets parseLabel
       wth (fn (name, lbl) => fn pos =>
              LEMMA (lbl, {name = name, pos = pos}))
 
   val parseCutLemma : tactic_parser =
-    fn w => symbol "cut-lemma"
+    fn w => tactic "cut-lemma"
       && brackets parseLabel
       wth (fn (name, lbl) => fn pos =>
              CUT_LEMMA (lbl, {name = name, pos = pos}))
 
   val parseUnfold : tactic_parser =
-    fn w => symbol "unfold"
+    fn w => tactic "unfold"
       && brackets (separate (parseLabel && opt parseLevel) whiteSpace)
       wth (fn (name, lbls) => fn pos =>
              UNFOLD (lbls, ({name = name, pos = pos})))
 
   val parseCustomTactic : tactic_parser =
-    fn w => symbol "refine"
-      >> brackets identifier
+    fn w => identifier
       wth (fn name => fn (pos : Pos.t) =>
             CUSTOM_TACTIC (stringToLabel name, {name = name, pos = pos}))
 
@@ -251,7 +255,6 @@ struct
     parseLemma w
       || parseCutLemma w
       || parseUnfold w
-      || parseCustomTactic w
       || parseWitness w
       || parseHypothesis w
       || parseEqSubst w
@@ -275,6 +278,7 @@ struct
       || parseApproxRefl w
       || parseBottomDiverges w
       || parseCHypSubst w
+      || parseCustomTactic w
 
   val parse : world -> Tactic.t charParser =
     fn w => !! (tacticParsers w)

--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -37,19 +37,19 @@ struct
 
   fun parseScript w () : tactic charParser =
     separate ((squares (commaSep ($ (parseScript w))) wth LIST)
-                   <|> ($ (plain w) wth APPLY)
-                   <|> $ (parseFocus w) wth FOCUS) semi
+                   <|> ($ (parseFocus w) wth FOCUS)
+                   <|> ($ (plain w) wth APPLY)) semi
     wth THEN
 
   and plain w () =
-    RuleParser.parse w
-      || $ (parseTry w)
+    $ (parseTry w)
       || $ (parseRepeat w)
       || $ (parseOrelse w)
       || $ (parseComplete w)
       || parseId
       || parseFail
       || parseTrace
+      || RuleParser.parse w
 
   and parseFocus w () =
       symbol "focus" && parseInt &&

--- a/src/prover/development.fun
+++ b/src/prover/development.fun
@@ -90,6 +90,19 @@ struct
       go (out t) []
     end
 
+  fun enumerateTactics t =
+    let
+      open Telescope.SnocView
+      fun go Empty bind = bind
+        | go (Snoc (rest, lbl, Object.TACTIC _)) bind =
+          go (out rest) (lbl :: bind)
+        | go (Snoc (rest, lbl, Object.THEOREM {...})) bind =
+          go (out rest) bind
+        | go (Snoc (rest, lbl, Object.OPERATOR {...})) bind =
+          go (out rest) bind
+    in
+      go (out t) []
+    end
 
   val empty = Telescope.empty
 

--- a/src/prover/development.sig
+++ b/src/prover/development.sig
@@ -39,6 +39,7 @@ sig
   (* enumerate the objects and knowledge available at a world *)
   val enumerate : world -> object Telescope.telescope
   val enumerateOperators : world -> (label * Arity.t) list
+  val enumerateTactics : world -> label list
 
   (* the empty world *)
   val empty : world

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -63,4 +63,6 @@ sig
         APPLY of t
       | LIST of t list
       | FOCUS of int * t
+
+    val listOfTactics : string list
 end

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -64,4 +64,34 @@ struct
       APPLY of t
     | LIST of t list
     | FOCUS of int * t
+
+  val listOfTactics =
+    ["intro [TERM]? #NUM? <NAME*>?",
+     "elim #NUM [TERM]? <NAME*>?",
+     "eq-cd [TERM*]? <NAME*>? @LEVEL?",
+     "ext <NAME>? @LEVEL?",
+     "symmetry",
+     "capprox",
+     "creflexivty",
+     "areflexivty",
+     "csymmetry",
+     "step",
+     "cstruct",
+     "assumption",
+     "assert [TERM] <NAME>?",
+     "mem-cd",
+     "auto NUM?",
+     "reduce NUM?",
+     "lemma <NAME>",
+     "cut-lemma <NAME>",
+     "unfold <(NAME @NUM)+>",
+     "witness [TERM]",
+     "hypothesis #NUM",
+     "bot-div #NUM",
+     "hyp-subst (←|→) #NUM [TERM] @NUM?",
+     "id",
+     "fail",
+     "trace \"MESSAGE\"",
+     "cum @NUM?",
+     "focus NUM #{TACTIC}"]
 end


### PR DESCRIPTION
The basic adjustment was to make sure that `parseCustomTactic` is last. This is because otherwise we just slurp everything with it. Furthermore, we had to replace some calls to `symbol` with a greedy version called `tactic` (naming flexible) in `parse_ctt_rule.fun`. This is because otherwise the `auto` parser will eat `autoR` when it shouldn't.

I also touched up the examples.
