### PR TITLE
Allow adding definitions for built-in operators

### DIFF
--- a/src/parser/ctt_rule_parser.fun
+++ b/src/parser/ctt_rule_parser.fun
@@ -215,10 +215,6 @@ struct
              ASSERT ({assertion = term, name = hyp},
                      {name = name, pos = pos}))
 
-  val parseMemCd : tactic_parser =
-    fn w => tactic "mem-cd"
-      wth (fn name => fn pos => MEM_CD {name = name, pos = pos})
-
   val parseAuto : tactic_parser =
     fn w => tactic "auto" && opt parseInt
       wth (fn (name, oi) => fn pos => AUTO (oi, {name = name, pos = pos}))
@@ -266,7 +262,6 @@ struct
       || parseCum w
       || parseAuto w
       || parseReduce w
-      || parseMemCd w
       || parseAssumption w
       || parseAssert w
       || parseSymmetry w

--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -3,11 +3,6 @@ signature PARSE_CTT =
     where type Operator.t = string OperatorType.operator
     where type ParseOperator.world = string -> Arity.t
 
-signature PARSE_PATTERN =
-  PARSE_ABT
-    where type Operator.t = string PatternOperatorType.operator
-    where type ParseOperator.world = string -> Arity.t
-
 functor DevelopmentParser
   (structure ParserContext : PARSER_CONTEXT
    structure Tactic : TACTIC

--- a/src/prover/builtins.sig
+++ b/src/prover/builtins.sig
@@ -1,11 +1,8 @@
 signature BUILTINS =
 sig
-  structure Syntax : ABT
   structure Conv : CONV
-    where type term = Syntax.t
 
   type label
-
   val unfold : label -> Conv.conv
 end
 

--- a/src/prover/builtins.sig
+++ b/src/prover/builtins.sig
@@ -1,0 +1,11 @@
+signature BUILTINS =
+sig
+  structure Syntax : ABT
+  structure Conv : CONV
+    where type term = Syntax.t
+
+  type label
+
+  val unfold : label -> Conv.conv
+end
+

--- a/src/prover/builtins.sml
+++ b/src/prover/builtins.sml
@@ -1,0 +1,28 @@
+structure Builtins : BUILTINS =
+struct
+  structure Syntax = Syntax
+  structure Conv = Conv
+  type label = string
+
+  open OperatorType Syntax Conv
+  infix $ $$
+
+  local
+    fun makeConv oper f tbl =
+      StringListDict.insert tbl (Operator.toString oper) (fn P =>
+        case out P of
+             oper' $ es =>
+               if Operator.eq (oper, oper') then
+                 f es
+               else
+                 raise Conv
+           | _ => raise Conv)
+
+    val unfoldMember =
+      makeConv MEM (fn #[M,A] => EQ $$ #[M,M,A] | _ => raise Conv)
+  in
+    val definitions = unfoldMember
+  end
+
+  val unfold = StringListDict.lookup (definitions StringListDict.empty)
+end

--- a/src/prover/builtins.sml
+++ b/src/prover/builtins.sml
@@ -21,6 +21,7 @@ struct
     val unfoldMember =
       makeConv MEM (fn #[M,A] => EQ $$ #[M,M,A] | _ => raise Conv)
   in
+    (* add definitions here via composition: unfoldX o unfoldY o unfoldZ... *)
     val definitions = unfoldMember
   end
 

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -686,15 +686,6 @@ struct
                | _ => raise Refine)
       end
 
-    fun MemCD (H >> P) =
-      let
-        val #[M, A] = P ^! MEM
-      in
-        [ H >> EQ $$ #[M, M, A]
-        ] BY (fn [D] => D
-               | _ => raise Refine)
-      end
-
     fun Witness M (H >> P) =
       let
         val M = Context.rebind H M

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -46,9 +46,10 @@ struct
   infix $ \
   infix 8 $$ // \\
 
+  exception Refine
+
   structure Rules =
   struct
-    exception Refine
     open Sequent
     infix >>
 

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -1003,9 +1003,9 @@ struct
       fun convTheorem lbl world M =
         case out M of
             CUSTOM {label,...} $ _ =>
-            if Development.Telescope.Label.eq (label, lbl) then
+              if Development.Telescope.Label.eq (label, lbl) then
                 Development.lookupExtract world lbl
-            else
+              else
                 raise Conv.Conv
           | _ => raise Conv.Conv
 

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -17,7 +17,10 @@ functor Ctt
 
    structure Conv : CONV where type term = Syntax.t
    structure Semantics : SMALL_STEP where type syn = Syntax.t
-   sharing type Development.term = Syntax.t) : CTT =
+   sharing type Development.term = Syntax.t
+   structure Builtins : BUILTINS
+     where type Conv.term = Conv.term
+     where type label = Development.label) : CTT =
 struct
   structure Lcf = Lcf
   structure Conv = ConvUtil(structure Conv = Conv and Syntax = Syntax)
@@ -1010,8 +1013,9 @@ struct
           | _ => raise Conv.Conv
 
       fun convLabel lbl world =
-        Development.lookupDefinition world lbl
-          handle Subscript => convTheorem lbl world
+        Builtins.unfold lbl
+          handle _ => Development.lookupDefinition world lbl
+            handle Subscript => convTheorem lbl world
     in
     fun Unfolds (world, lbls) (H >> P) =
       let
@@ -1308,4 +1312,5 @@ structure Ctt = Ctt
    structure Conv = Conv
    structure Semantics = Semantics
    structure Sequent = Sequent
-   structure Development = Development)
+   structure Development = Development
+   structure Builtins = Builtins)

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -157,7 +157,6 @@ sig
     val BaseMemberEq : tactic
     val BaseElimEq : int * name option -> tactic
 
-    val MemCD : tactic
     val Witness : term -> tactic
 
     val Assumption : tactic

--- a/src/prover/ctt.sig
+++ b/src/prover/ctt.sig
@@ -7,6 +7,8 @@ sig
   type world
   type tactic
 
+  exception Refine
+
   structure Sequent : SEQUENT
     where type term = term
 

--- a/src/prover/ctt_util.fun
+++ b/src/prover/ctt_util.fun
@@ -7,7 +7,9 @@ functor CttUtil
       where type tactic = Lcf.tactic
       where type conv = Conv.conv
       where type term = Syntax.t
-      where type name = Syntax.Variable.t) : CTT_UTIL =
+      where type name = Syntax.Variable.t
+   val operatorToLabel : Syntax.Operator.t -> Ctt.Development.label
+   sharing type Lcf.goal = Ctt.Sequent.sequent) : CTT_UTIL =
 struct
   structure Lcf = Lcf
   structure Tacticals = ProgressTacticals(Lcf)
@@ -191,9 +193,15 @@ struct
 
   local
     structure Tacticals = Tacticals (Lcf)
-    open Tacticals Sequent
+    open Tacticals Sequent Syntax
     infix THENL >>
+    infix $
   in
+    fun UnfoldHead world (goal as H >> P) =
+      case out P of
+           oper $ _ => Unfolds (world, [(operatorToLabel oper, NONE)]) goal
+         | _ => raise Refine
+
     fun CutLemma (world, lbl) =
       let
         val {statement,...} = Ctt.Development.lookupTheorem world lbl
@@ -209,4 +217,5 @@ struct
 end
 
 structure CttUtil = CttUtil
-  (structure Syntax = Syntax and Lcf = Lcf and Conv = Conv and Ctt = Ctt)
+  (structure Syntax = Syntax and Lcf = Lcf and Conv = Conv and Ctt = Ctt
+   val operatorToLabel = Syntax.Operator.toString)

--- a/src/prover/ctt_util.sig
+++ b/src/prover/ctt_util.sig
@@ -1,7 +1,7 @@
 signature CTT_UTIL =
 sig
   include CTT
-  val Auto : int option -> tactic
+  val Auto : world * int option -> tactic
 
   type intro_args =
     {term : term option,
@@ -29,9 +29,9 @@ sig
   val Elim : elim_args -> tactic
   val EqCD : eq_cd_args -> tactic
   val Ext : ext_args -> tactic
-  val UnfoldHead : Development.world -> tactic
+  val UnfoldHead : world -> tactic
 
   val Reduce : int option -> tactic
-  val CutLemma : Development.world * Development.label -> tactic
+  val CutLemma : world * Development.label -> tactic
 
 end

--- a/src/prover/ctt_util.sig
+++ b/src/prover/ctt_util.sig
@@ -29,6 +29,7 @@ sig
   val Elim : elim_args -> tactic
   val EqCD : eq_cd_args -> tactic
   val Ext : ext_args -> tactic
+  val UnfoldHead : Development.world -> tactic
 
   val Reduce : int option -> tactic
   val CutLemma : Development.world * Development.label -> tactic

--- a/src/prover/development.fun
+++ b/src/prover/development.fun
@@ -155,12 +155,7 @@ struct
                   {arity = arity,
                    conversion = conversion})
            | SOME _ => raise Subscript
-           | NONE =>
-               Telescope.snoc T (lbl,
-                 Object.OPERATOR
-                  {arity = Syntax.Operator.arity oper,
-                   conversion = conversion})
-
+           | NONE => raise Fail "Cannot define undeclared operator"
       end
   end
 

--- a/src/prover/sources.cm
+++ b/src/prover/sources.cm
@@ -35,3 +35,6 @@ group is
 
   pattern_compiler.fun
   pattern_compiler.sig
+
+  builtins.sig
+  builtins.sml

--- a/src/syntax/pattern.fun
+++ b/src/syntax/pattern.fun
@@ -1,49 +1,25 @@
 structure PatternOperatorType =
 struct
-  datatype 'label operator = APP of 'label * Arity.t
+  datatype ('builtin, 'label) operator =
+      CUSTOM of 'label * Arity.t
+    | BUILTIN of 'builtin
 end
 
-functor PatternOperator (Label : PARSE_LABEL) : PARSE_OPERATOR =
+functor PatternOperator
+  (structure Label : PARSE_LABEL
+   structure Builtin : PARSE_OPERATOR
+    where type world = Label.t -> Arity.t) : PARSE_OPERATOR =
 struct
-  open PatternOperatorType
-  type t = Label.t operator
-  type world = Label.t -> Arity.t
-
-  fun eq (APP (l,n), APP (l', n')) = Label.eq (l, l')
-
-  local
-    fun replicate n x =
-      let
-        fun go 0 R = R
-          | go i R = x :: go (i - 1) R
-      in
-        go n []
-      end
-  in
-    fun arity (APP (_, ar)) = Vector.fromList (replicate (Vector.length ar) 0)
-  end
-
-  fun toString (APP (l, _)) = Label.toString l
-
-  local
-    open ParserCombinators CharParser
-    infix 2 return wth suchthat return guard when
-    infixr 1 || <|>
-    infixr 4 << >> --
-  in
-    fun parseApp lookup =
-      Label.parseLabel -- (fn lbl =>
-        case (SOME (lookup lbl) handle _ => NONE) of
-             SOME arity => succeed (APP (lbl, arity))
-           | NONE => fail "no such operator")
-
-    val parseOperator = parseApp
-  end
+  open Builtin
+  fun arity oper =
+    Vector.map (fn _ => 0) (Builtin.arity oper)
 end
 
 structure PatternSyntax : PARSE_ABT =
 struct
-  structure PatternOperator = PatternOperator (ParseLabel (StringVariable))
+  structure PatternOperator = PatternOperator
+    (structure Label = ParseLabel (StringVariable)
+     structure Builtin = Syntax.ParseOperator)
   structure Abt = Abt
     (structure Operator = PatternOperator
      structure Variable = Syntax.Variable)

--- a/src/syntax/pattern.fun
+++ b/src/syntax/pattern.fun
@@ -1,25 +1,13 @@
-structure PatternOperatorType =
+functor PatternOperator (Operator : PARSE_OPERATOR) : PARSE_OPERATOR =
 struct
-  datatype ('builtin, 'label) operator =
-      CUSTOM of 'label * Arity.t
-    | BUILTIN of 'builtin
-end
-
-functor PatternOperator
-  (structure Label : PARSE_LABEL
-   structure Builtin : PARSE_OPERATOR
-    where type world = Label.t -> Arity.t) : PARSE_OPERATOR =
-struct
-  open Builtin
+  open Operator
   fun arity oper =
-    Vector.map (fn _ => 0) (Builtin.arity oper)
+    Vector.map (fn _ => 0) (Operator.arity oper)
 end
 
 structure PatternSyntax : PARSE_ABT =
 struct
-  structure PatternOperator = PatternOperator
-    (structure Label = ParseLabel (StringVariable)
-     structure Builtin = Syntax.ParseOperator)
+  structure PatternOperator = PatternOperator (Syntax.ParseOperator)
   structure Abt = Abt
     (structure Operator = PatternOperator
      structure Variable = Syntax.Variable)

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -39,7 +39,6 @@ sig
       | CUM of level option * meta
       | AUTO of int option * meta
       | REDUCE of int option * meta
-      | MEM_CD of meta
       | ASSUMPTION of meta
       | ASSERT of {assertion : term,
                    name : name option} * meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -40,7 +40,6 @@ struct
     | CUM of level option * meta
     | AUTO of int option * meta
     | REDUCE of int option * meta
-    | MEM_CD of meta
     | ASSUMPTION of meta
     | ASSERT of {assertion : term,
                  name : name option} * meta
@@ -79,7 +78,6 @@ struct
      "cstruct",
      "assumption",
      "assert [TERM] <NAME>?",
-     "mem-cd",
      "auto NUM?",
      "reduce NUM?",
      "lemma <NAME>",

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -43,9 +43,8 @@ struct
       | EXT ({freshVariable, level}, a) =>
         an a (CttUtil.Ext {freshVariable = freshVariable, level = level})
       | CUM (l, a) => an a (Cum l)
-      | AUTO (oi, a) => an a (CttUtil.Auto oi)
+      | AUTO (oi, a) => an a (CttUtil.Auto (wld, oi))
       | REDUCE (i, a) => an a (CttUtil.Reduce i)
-      | MEM_CD a => an a MemCD
       | ASSUMPTION a => an a Assumption
       | ASSERT ({assertion = t, name = name}, a) =>
         an a (Assert (t, name))


### PR DESCRIPTION
- [x] Clean up aspects of the "patterns" stuff for abstraction definitions, so that built-in operators & custom ones are treated at the same level
- [x] add support for querying the current development in `Auto` and related tactics (related: #39)
- [x] add intensional `soft-unfold` tactic that gets called by auto (related: #55)
- [x] hardcode built-in definitions (like the `member` operator) (related: #55)
- [x] Don't allow user to redefine builtin operators (which is otherwise permitted by the above changes)
