### PR TITLE
Make binding to context opt-in

### DIFF
--- a/example/match.jonprl
+++ b/example/match.jonprl
@@ -21,3 +21,24 @@ Theorem modus_ponens : [{A : U{i}}{B : U{i}}((B -> A) * B) -> A] {
      }
    }
 }.
+
+
+Tactic squash-intro {
+  @{
+    [|- squash(A)] =>
+       assert [A];
+       focus 1 #{
+         @{
+           [H : A |- _] =>
+             unfold <squash member>; witness [lam(_.<>) H]; auto
+         }
+       }
+  }
+}.
+
+Theorem test-binding : [(A : U{i}) -> squash(unit)] {
+  (* Note that squash-intro correctly isn't confused by the A
+   * already in the context and correctly binds a fresh variable
+   *)
+  intro; [id, auto]; squash-intro; auto
+}.

--- a/example/match.jonprl
+++ b/example/match.jonprl
@@ -1,18 +1,23 @@
 Theorem match_example : [{A : U{i}} {B : U{i}} A -> B -> A] {
   intro; [intro, auto]; [intro, auto]; [intro, auto]; [id, auto];
-  @{[H : A' |- A'] => witness [H]; auto}
+  @{[H : A |- A] => witness [H]; auto}
 }.
 
 Theorem match_example2 : [(A : U{i})(x : A)  A] {
   intro; [intro, auto]; [assert [member(x; A)], auto]; [auto, id];
-  @{[M : member(X; A') |- A'] => witness [X]; assumption}
+
+  (* The 's here at the start of A assert that we want to bind it
+   * to something in the context vs generate a lexically scoped name.
+   * It's like the opposite of Coq's ? mechanism.
+   *)
+  @{[H : member(X; 'A) |- 'A] => witness [X]; assumption}
 }.
 
-Theorem modus_ponens : [{A : U{i}}{B : U{i}}((A -> B) * A) -> B] {
+Theorem modus_ponens : [{A : U{i}}{B : U{i}}((B -> A) * B) -> A] {
   auto;
   *{
-    @{ [M' : A', M : A' -> B' |- B'] => elim #4 [M']; auto
-     | [M : X * Y |- Z] => elim #3
+    @{ [H' : A, H : A -> B |- B] => elim #4 [H']; auto
+     | [H : A * B |- C] => elim #3
      }
    }
 }.

--- a/src/syntax/rebind.fun
+++ b/src/syntax/rebind.fun
@@ -1,12 +1,13 @@
 (* A utility on ABTs for rebinding variables based on name *)
 functor Rebind(A : ABT_UTIL) :
         sig
+          val rebindPrefix : string -> A.Variable.t list -> A.t -> A.t
           val rebind : A.Variable.t list -> A.t -> A.t
         end =
 struct
   open A
 
-  fun rebind vars tm =
+  fun rebindPrefix pre vars tm =
     let
       fun makeVarTable vs =
         let
@@ -22,7 +23,7 @@ struct
              (tbl, tm)
            else
              let
-               val vstr = Variable.toString v
+               val vstr = pre ^ Variable.toString v
              in
                case StringListDict.find tbl vstr of
                     NONE => go vars' tbl tm
@@ -34,4 +35,6 @@ struct
     in
       tm'
     end
+
+  val rebind = rebindPrefix ""
 end


### PR DESCRIPTION
I forgot to include this in the last PR, but here's a pretty nice feature. With this if you don't prefix a variable with `'` it implicitly generates a binder for it like it would if you prefixed it with `?` in Coq. To bind it to a particular named variable in the context you prefix it `'`.

With this you can actually write generic match tactics which work in any context - just avoid using `'`ed variables!
