### PR TITLE
Now treat _ as a true wildcard

### DIFF
--- a/example/tautology.jonprl
+++ b/example/tautology.jonprl
@@ -5,9 +5,10 @@ Tactic tautology-step {
    | [|- P -> Q] => intro
    | [|- P => Q] => intro
    | [H : void |- _] => elim <H>; thin <H>
-   | [H : P * Q |- _] => elim <H>; thin <H>
+   | [H : (x : P) * _ |- _] => elim <H>; thin <H>
    | [H : P + Q |- _] => elim <H>; thin <H>
-   | [H : P -> Q, H' : P |- _] => elim <H> [H']; thin <H>
+   | [H : (x : P) _, H' : P |- _] => elim <H> [H']; thin <H>
+   | [H : {x : P} _, H' : P |- _] => elim <H> [H']; thin <H>
    | [|- member(M;A)] => unfold <member>
    | [|- =(M;N;A)] => eq-cd
    }


### PR DESCRIPTION
This is the quick-fix for handling matching on things which may contain bound variables. Instead of treating `_` like another variable it's now specially mapped to `WILD`, a primitive operator which unifies with everything. This let's us handle things like `lam` or `fun` in our pattern matching.

As a quick example, I generalized `tautology` to handle dependent sums and products.
