### PR TITLE
Add Print and Eval commands to vernacular (#155)

### DIFF
--- a/example/image.jonprl
+++ b/example/image.jonprl
@@ -2,9 +2,9 @@ Theorem squash_wf : [ isect(U{i};t.member(squash(t);U{i})) ] {
   unfold <squash>; auto
 }.
 
-Theorem implies_squash : [ isect(U{i};t.t => squash(t)) ] {
+Theorem implies_squash : [ {T:U{i}} T => squash(T) ] {
   *{intro; focus 1 #{auto}};
-  @{ [H:t |- _] => witness [lam(_.<>) H]};
+  @{ [H: 'T |- _] => witness [lam(_.<>) H]};
   unfold <squash>; auto
 }.
 
@@ -21,12 +21,10 @@ Theorem approx_id_refl_wf : [
 }.
 
 Theorem test_image_elim : [
-  fun(nat;n.fun(nat;m.fun(squash(=(n;m;nat));x.=(x;x;squash(=(n;m;nat))) -> =(n;m;nat))))
+  {n:nat} {m:nat} {x:squash(=(n; m; nat))} member(x; squash(=(n; m; nat))) => =(n; m; nat)
 ] {
- intro;[ id, auto ];[id];
- intro;[ id, auto ];[id];
- intro;[ id, *{unfold <squash>;auto} ];[id];
- intro;[ id, *{unfold <squash>;auto} ];[id];
- unfold <squash>;
- elim <x> <e>;auto
+  unfold <squash member>;
+  *{intro; focus 1 #{auto}};
+  @{[H : image(_;_) |- _] => elim <H>};
+  auto
 }.

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -6,7 +6,18 @@ struct
   open DevelopmentAst
   exception Open of Syntax.t
 
-  fun eval_decl D ast =
+  fun evalCommand D cmd =
+    case cmd of
+         PRINT lbl =>
+         let
+           open Development
+           val object = lookupObject D lbl
+           val declString = Object.toString (lbl, object)
+         in
+           print ("\n" ^ declString ^ "\n"); D
+         end
+
+  fun evalDecl D ast =
     case ast of
         THEOREM (lbl, term, tac) =>
         let
@@ -26,6 +37,8 @@ struct
         Development.defineTactic D (lbl, TacticEval.eval D tac)
       | DEFINITION (pat, term) =>
         Development.defineOperator D {definiendum = pat, definiens = term}
+      | COMMAND cmd =>
+        evalCommand D cmd
 
-  fun eval D = List.foldl (fn (decl, D) => eval_decl D decl) D
+  fun eval D = List.foldl (fn (decl, D) => evalDecl D decl) D
 end

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -8,12 +8,18 @@ struct
 
   structure SmallStep = SmallStepUtil (SmallStep (Syntax))
 
+  val operatorToLabel = Syntax.Operator.toString
+
   fun evalCommand D cmd =
     case cmd of
-         PRINT lbl =>
+         PRINT theta =>
          let
            open Development
-           val declString = Object.toString (lbl, lookupObject D lbl)
+           val lbl = operatorToLabel theta
+           val declString =
+             case SOME (lookupObject D lbl) handle _ => NONE of
+                  SOME obj => Object.toString (lbl, obj)
+                | NONE => "Operator " ^ lbl ^ " : " ^ Arity.toString (Syntax.Operator.arity theta) ^ "."
          in
            print ("\n" ^ declString ^ "\n")
          end

--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -7,12 +7,13 @@ functor DevelopmentParser
   (structure ParserContext : PARSER_CONTEXT
    structure Tactic : TACTIC
      where type label = ParserContext.label
-   structure Syntax : PARSE_ABT
-     where type ParseOperator.world = Tactic.label -> Arity.t
    structure DevelopmentAst : DEVELOPMENT_AST
-     where type Syntax.t = Syntax.t
      where type Tactic.t = Tactic.t
      where type label = ParserContext.label
+   structure Syntax : PARSE_ABT
+     where type ParseOperator.world = Tactic.label -> Arity.t
+     where type t = DevelopmentAst.Syntax.t
+     where type Operator.t = DevelopmentAst.Syntax.Operator.t
 
    structure TacticScript : TACTIC_SCRIPT
      where type tactic = Tactic.t
@@ -37,6 +38,8 @@ struct
 
   fun parseTm fvs w =
     squares (Syntax.parseAbt (lookupOperator w) (Syntax.initialState fvs))
+
+  val parseOperator = Syntax.ParseOperator.parseOperator o lookupOperator
 
   val parsePattern = parseTm []
 
@@ -79,8 +82,9 @@ struct
     ) wth (fn (P : Syntax.t, N : Syntax.t) =>
               (w, DevelopmentAst.DEFINITION (P, N)))
 
-  val parsePrint =
-    reserved "Print" >> parseLabel
+  fun parsePrint (w : world) =
+    reserved "Print" >>
+      parseOperator w
       wth DevelopmentAst.PRINT
 
   fun parseEval w =
@@ -89,7 +93,7 @@ struct
       wth (fn (gas, M) => DevelopmentAst.EVAL (M, gas))
 
   fun parseCommand w =
-    (parsePrint || parseEval w)
+    (parsePrint w || parseEval w)
     wth (fn cmd => (w, DevelopmentAst.COMMAND cmd))
 
   fun parseDecl w =

--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -32,7 +32,7 @@ struct
 
   structure TP = TokenParser
     (open JonprlLanguageDef
-     val reservedNames = ["Theorem", "Tactic", "Operator"])
+     val reservedNames = ["Theorem", "Tactic", "Operator", "Print"])
   open TP
 
   fun parseTm fvs w =
@@ -79,11 +79,16 @@ struct
     ) wth (fn (P : Syntax.t, N : Syntax.t) =>
               (w, DevelopmentAst.DEFINITION (P, N)))
 
+  val parseCommand =
+    reserved "Print" >> parseLabel
+      wth DevelopmentAst.COMMAND o DevelopmentAst.PRINT
+
   fun parseDecl w =
       parseTheorem w
       || parseTactic w
       || parseOperatorDecl w
       || parseOperatorDef w
+      || parseCommand wth (fn r => (w,r))
 
   fun parse' w ast () =
     whiteSpace >>

--- a/src/prover/builtins.sig
+++ b/src/prover/builtins.sig
@@ -3,6 +3,7 @@ sig
   structure Conv : CONV
 
   type label
-  val unfold : label -> Conv.conv
+  type operator
+  val unfold : label -> operator * Conv.conv
 end
 

--- a/src/prover/builtins.sml
+++ b/src/prover/builtins.sml
@@ -7,12 +7,14 @@ struct
   open OperatorType Syntax Conv
   infix $ $$ \\
 
+  type operator = Syntax.Operator.t
+
   local
-    fun makeConv oper f tbl =
-      StringListDict.insert tbl (Operator.toString oper) (fn P =>
+    fun makeConv theta f tbl =
+      StringListDict.insert tbl (Operator.toString theta) (theta, fn P =>
         case out P of
-             oper' $ es =>
-               if Operator.eq (oper, oper') then
+             theta' $ es =>
+               if Operator.eq (theta, theta') then
                  f es
                else
                  raise Conv

--- a/src/prover/ctt.fun
+++ b/src/prover/ctt.fun
@@ -1093,8 +1093,7 @@ struct
           | _ => raise Conv.Conv
 
       fun convLabel lbl world =
-        Builtins.unfold lbl
-          handle _ => Development.lookupDefinition world lbl
+        Development.lookupDefinition world lbl
             handle Subscript => convTheorem lbl world
     in
       fun Unfolds (world, lbls) (H >> P) =

--- a/src/prover/development.fun
+++ b/src/prover/development.fun
@@ -176,6 +176,8 @@ struct
          Object.TACTIC tac => tac
        | _ => raise Subscript
 
+  val lookupObject = Telescope.lookup
+
   fun lookupOperator T lbl =
     case Telescope.lookup T lbl of
          Object.OPERATOR {arity,...} => arity

--- a/src/prover/development.sig
+++ b/src/prover/development.sig
@@ -53,9 +53,6 @@ sig
   val declareOperator : world -> label * Arity.t -> world
   val defineOperator : world -> {definiendum : term, definiens : term} -> world
 
-  (* lookup the definiens *)
-  val lookupDefinition : world -> label -> conv
-
   (* lookup the statement & evidence of a theorem *)
   val lookupTheorem : world -> label -> {statement : judgement, evidence : evidence Susp.susp}
   val lookupExtract : world -> label -> term
@@ -65,4 +62,9 @@ sig
 
   (* lookup a custom operator *)
   val lookupOperator : world -> label -> Arity.t
+
+  (* lookup the definiens *)
+  val lookupDefinition : world -> label -> conv
+
+  val lookupObject : world -> label -> Object.t
 end

--- a/src/prover/pattern_compiler.sig
+++ b/src/prover/pattern_compiler.sig
@@ -1,7 +1,17 @@
+signature PATTERN_TERM =
+sig
+  include ABT
+
+  val asInstantiate : t -> (t * t) option
+  val patternForOperator : Operator.t -> t
+end
+
 signature PATTERN_COMPILER =
 sig
+  structure PatternTerm : PATTERN_TERM
+
   type label
-  type term
+  type term = PatternTerm.t
   type conv = term -> term
 
   type rule = {definiendum : term, definiens : term}

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -1,3 +1,26 @@
+functor SmallStepUtil (S : SMALL_STEP) : SMALL_STEP_UTIL =
+struct
+  open S
+  type petrol = int
+
+  local
+    val guzzle = Option.map (fn x => x - 1)
+    fun expended (SOME x) = x <= 0
+      | expended NONE = false
+
+    fun go (M, gas) i =
+      if expended gas then
+        (M,i)
+      else
+        case step M of
+             STEP M' => go (M', guzzle gas) (i + 1)
+           | CANON => (M,i)
+           | NEUTRAL => (M,i)
+  in
+    fun steps (M, gas) = go (M, gas) 0
+  end
+end
+
 functor SmallStep (Syn : ABT_UTIL where type Operator.t = StringVariable.t OperatorType.operator)
         : SMALL_STEP where type syn = Syn.t =
 struct

--- a/src/prover/small_step.fun
+++ b/src/prover/small_step.fun
@@ -102,8 +102,10 @@ struct
       | PLUS $ _ => CANON
       | INL $ _ => CANON
       | INR $ _ => CANON
+      | NAT $ _ => CANON
       | ZERO $ _ => CANON
       | SUCC $ _ => CANON
+      | IMAGE $ _ => CANON
       | DECIDE $ #[S, L, R] =>
           (case step S of
               STEP S' => STEP (DECIDE $$ #[S', L, R])

--- a/src/prover/small_step.sig
+++ b/src/prover/small_step.sig
@@ -7,3 +7,14 @@ sig
 
   val step : syn -> t
 end
+
+signature SMALL_STEP_UTIL =
+sig
+  include SMALL_STEP
+
+  type petrol = int
+
+  (* Evaluate a term with a bit of petrol, returning the result and the amount
+   * of petrol expended. *)
+  val steps : syn * petrol option -> syn * petrol
+end

--- a/src/prover/small_step.sig
+++ b/src/prover/small_step.sig
@@ -1,9 +1,9 @@
 signature SMALL_STEP =
 sig
-    type syn
+  type syn
 
-    datatype t = STEP of syn | CANON | NEUTRAL
-    exception Stuck of syn
+  datatype t = STEP of syn | CANON | NEUTRAL
+  exception Stuck of syn
 
-    val step : syn -> t
+  val step : syn -> t
 end

--- a/src/prover/sources.cm
+++ b/src/prover/sources.cm
@@ -5,7 +5,7 @@ group is
   $libs/cmlib/cmlib.cm
   $libs/sml-lcf/lcf.cm
   $libs/sml-conv/conv.cm
-  $libs/sml-abt-unify/abt-unify.cm (bind:(anchor:libs value:$libs))
+  $libs/sml-abt-unify/abt-unify.cm
 
   sequent.fun
   sequent.sig

--- a/src/syntax/development_ast.sig
+++ b/src/syntax/development_ast.sig
@@ -9,9 +9,12 @@ sig
     where type label = label
     where type term = Syntax.t
 
+  datatype command = PRINT of label
+
   datatype t =
       THEOREM of label * Syntax.t * Tactic.t
     | OPERATOR of label * Arity.t
     | TACTIC of label * Tactic.t
     | DEFINITION of Syntax.t * Syntax.t
+    | COMMAND of command
 end

--- a/src/syntax/development_ast.sig
+++ b/src/syntax/development_ast.sig
@@ -9,7 +9,9 @@ sig
     where type label = label
     where type term = Syntax.t
 
-  datatype command = PRINT of label
+  datatype command =
+      PRINT of label
+    | EVAL of Syntax.t * int option
 
   datatype t =
       THEOREM of label * Syntax.t * Tactic.t

--- a/src/syntax/development_ast.sig
+++ b/src/syntax/development_ast.sig
@@ -10,7 +10,7 @@ sig
     where type term = Syntax.t
 
   datatype command =
-      PRINT of label
+      PRINT of Syntax.Operator.t
     | EVAL of Syntax.t * int option
 
   datatype t =

--- a/src/syntax/development_ast.sml
+++ b/src/syntax/development_ast.sml
@@ -6,7 +6,7 @@ struct
   structure Tactic  = Tactic
 
   datatype command =
-      PRINT of label
+      PRINT of Syntax.Operator.t
     | EVAL of Syntax.t * int option
 
   datatype t =

--- a/src/syntax/development_ast.sml
+++ b/src/syntax/development_ast.sml
@@ -5,9 +5,11 @@ struct
   structure Syntax = Syntax
   structure Tactic  = Tactic
 
-  datatype t
-    = THEOREM of label * Syntax.t * Tactic.t
+  datatype command = PRINT of label
+  datatype t =
+      THEOREM of label * Syntax.t * Tactic.t
     | OPERATOR of label * Arity.t
     | TACTIC of label * Tactic.t
     | DEFINITION of Syntax.t * Syntax.t
+    | COMMAND of command
 end

--- a/src/syntax/development_ast.sml
+++ b/src/syntax/development_ast.sml
@@ -5,7 +5,10 @@ struct
   structure Syntax = Syntax
   structure Tactic  = Tactic
 
-  datatype command = PRINT of label
+  datatype command =
+      PRINT of label
+    | EVAL of Syntax.t * int option
+
   datatype t =
       THEOREM of label * Syntax.t * Tactic.t
     | OPERATOR of label * Arity.t


### PR DESCRIPTION
In a development, you may now type in

```
Print something.
```

where `something` is the name of an operator/theorem/tactic and it will be printed in the JonPRL buffer. Currently this does not support the built-in operators, but that should be added.

One really cool thing I could imagine doing is adding metadata to declarations (including docstrings) that might be printed as well.

Evaluation (with an optional number of steps) is also supported:

```
Eval 10 [lam(x.x) lam(x.x)].
Eval [lam(x.x) lam(x.x)].
```

Thanks for the suggestion to implement this, @vrahli!
