### PR TITLE
Upgrade sml-open-abt (related: #165)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: sml
 before_install:
   - sudo add-apt-repository -y ppa:hrzhu/smlnj-backport
   - sudo apt-get update -qq
-  - sudo apt-get install -y smlnj
+  - sudo apt-get install -y --force-yes smlnj
 install:
   - git submodule init
   - git submodule update --init --recursive

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -1,7 +1,5 @@
 structure Derivation =
 struct
-  type world = ParserContext.world
-
   datatype t =
       UNIV_EQ of Level.t | CUM
     | EQ_EQ
@@ -189,11 +187,6 @@ struct
        | SUBSET_ELIM => "subset-elim"
        | SUBSET_MEMBER_EQ => "subset-member-eq"
        | LEMMA {label} => Label.toString label
-
-  fun parseOperator _ =
-    ParserCombinators.fail "derivations not parsed"
 end
 
-structure DerivationInj = OperatorInjection
-  (structure Operator = Derivation
-   structure Universe = UniversalOperator.Universe)
+structure DerivationInj = OperatorInjection (Derivation)

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -1,5 +1,3 @@
-structure UniversalOperator = UniversalOperator (type world = ParserContext.world)
-
 structure CttCalculus =
 struct
   type world = ParserContext.world
@@ -201,7 +199,18 @@ struct
   end
 end
 
-structure CttCalculusInj = OperatorInjection
-  (structure Operator = CttCalculus
-   structure Universe = UniversalOperator.Universe)
+structure CttCalculusInj = OperatorInjection (CttCalculus)
+
+structure ParseOperator : PARSE_OPERATOR =
+struct
+  type world = ParserContext.world
+  open UniversalOperator
+
+  open ParserCombinators
+  infix wth
+
+  fun parseOperator lookup =
+    CttCalculus.parseOperator lookup
+      wth CttCalculusInj.`>
+end
 

--- a/src/syntax/syntax.sml
+++ b/src/syntax/syntax.sml
@@ -8,9 +8,8 @@ struct
 
   structure ParseAbt = ParseAbt
     (structure Syntax = AbtUtil(Abt)
-     structure Operator = UniversalOperator)
+     structure Operator = ParseOperator)
   open CttCalculus ParseAbt
-
 
   local
     open JonprlTokenParser


### PR DESCRIPTION
From `sml-open-abt`, I have removed the machinery that integrates a local parser into a global parser, since this, of all the effects in that library, was the only non-benign one. As a result, I was also able to simplify the API of `sml-open-abt` and remove a number of dependencies from it, since it doesn't need to worry about parsing.

This is related to the discussion in #165 
