### PR TITLE
Added membership equalities for eq-like-things

### DIFF
--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -2,7 +2,7 @@ structure Derivation =
 struct
   datatype t =
       UNIV_EQ of Level.t | CUM
-    | EQ_EQ
+    | EQ_EQ | EQ_MEMBER_EQ
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
     | PROD_EQ | PROD_INTRO | IND_PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
@@ -15,10 +15,10 @@ struct
     | NAT_EQ | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
 
     | ADMIT
-    | CEQUAL_EQ | CEQUAL_SYM | CEQUAL_STEP
+    | CEQUAL_EQ | CEQUAL_MEMBER_EQ | CEQUAL_SYM | CEQUAL_STEP
     | CEQUAL_SUBST | CEQUAL_STRUCT of Arity.t
     | CEQUAL_APPROX
-    | APPROX_EQ | APPROX_EXT_EQ | APPROX_REFL
+    | APPROX_EQ | APPROX_MEMBER_EQ | APPROX_EXT_EQ | APPROX_REFL
     | BOTTOM_DIVERGES
     | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ
 
@@ -32,13 +32,16 @@ struct
          UNIV_EQ _ => #[]
        | CUM => #[0]
        | EQ_EQ => #[0,0,0]
+       | EQ_MEMBER_EQ => #[0]
        | CEQUAL_EQ => #[0, 0]
+       | CEQUAL_MEMBER_EQ => #[0]
        | CEQUAL_SYM => #[0]
        | CEQUAL_STEP => #[0]
        | CEQUAL_SUBST => #[0, 0]
        | CEQUAL_STRUCT arity => arity
        | CEQUAL_APPROX => #[0, 0]
        | APPROX_EQ => #[0,0]
+       | APPROX_MEMBER_EQ => #[0]
        | APPROX_EXT_EQ => #[0]
        | APPROX_REFL => #[]
        | BOTTOM_DIVERGES => #[]
@@ -116,13 +119,16 @@ struct
        | VOID_ELIM => "void-elim"
 
        | EQ_EQ => "eq⁼"
+       | EQ_MEMBER_EQ => "eq-mem⁼"
        | CEQUAL_EQ => "~⁼"
+       | CEQUAL_MEMBER_EQ => "~-mem⁼"
        | CEQUAL_SYM => "~-sym"
        | CEQUAL_STEP => "~-step"
        | CEQUAL_SUBST => "~-subst"
        | CEQUAL_STRUCT _ => "~-struct"
        | CEQUAL_APPROX => "~-~<="
        | APPROX_EQ => "~<=-eq"
+       | APPROX_MEMBER_EQ => "~<=-mem-eq"
        | APPROX_EXT_EQ => "~<=-ext-eq"
        | APPROX_REFL => "~<=-refl"
        | BOTTOM_DIVERGES => "bottom-div"

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -22,17 +22,20 @@ struct
        | CUM $ _ => ax
 
        | EQ_EQ $ _ => ax
+       | EQ_MEMBER_EQ $ _ => ax
        | UNIT_EQ $ _ => ax
        | UNIT_INTRO $ _ => ax
        | UNIT_ELIM $ #[R, E] => extract E
        | AX_EQ $ _ => ax
        | EQ_SYM $ _ => ax
        | CEQUAL_EQ $ _ => ax
+       | CEQUAL_MEMBER_EQ $ _ => ax
        | CEQUAL_SYM $ _ => ax
        | CEQUAL_STEP $ _ => ax
        | CEQUAL_SUBST $ #[D, E] => extract E
        | CEQUAL_STRUCT _ $ _ => ax (* Thank god *)
        | CEQUAL_APPROX $ _ => ax
+       | APPROX_MEMBER_EQ $ _ => ax
        | APPROX_EQ $ _ => ax
        | APPROX_EXT_EQ $ _ => ax
        | APPROX_REFL $ _ => ax

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -270,6 +270,17 @@ struct
         ] BY mkEvidence EQ_EQ
       end
 
+    fun EqMemEq (H >> P) =
+      let
+        val #[M, N, E] = P ^! EQ
+        val #[] = M ^! AX
+        val #[] = N ^! AX
+        val #[M', N', T] = E ^! EQ
+      in
+        [ H >> E
+        ] BY mkEvidence EQ_MEMBER_EQ
+      end
+
     fun UnitIntro (H >> P) =
       let
         val #[] = P ^! UNIT
@@ -1294,6 +1305,17 @@ struct
                  | _ => raise Refine)
         end
 
+      fun CEqMemEq (H >> P) =
+        let
+          val #[M, N, E] = P ^! EQ
+          val #[] = M ^! AX
+          val #[] = N ^! AX
+          val #[_, _] = E ^! CEQUAL
+        in
+          [ H >> E
+          ] BY mkEvidence CEQUAL_MEMBER_EQ
+        end
+
       fun ApproxEq (H >> P) =
         let
           val #[approx1, approx2, univ] = P ^! EQ
@@ -1305,6 +1327,17 @@ struct
           [ H >> C.`> EQ $$ #[M,M',base]
           , H >> C.`> EQ $$ #[N,N',base]
           ] BY mkEvidence APPROX_EQ
+        end
+
+      fun ApproxMemEq (H >> P) =
+        let
+          val #[M, N, E] = P ^! EQ
+          val #[] = M ^! AX
+          val #[] = N ^! AX
+          val #[_, _] = E ^! APPROX
+        in
+          [ H >> E
+          ] BY mkEvidence APPROX_MEMBER_EQ
         end
 
       fun ApproxExtEq (H >> P) =

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -41,6 +41,8 @@ sig
      * 3. H >> N = N' ∈ A *)
     val EqEq : tactic
 
+    val EqMemEq : tactic
+
     (* H >> A by VoidElim
      * 1. H >> Void
      *)
@@ -176,6 +178,7 @@ sig
     val EqSym : tactic
 
     val CEqEq       : tactic
+    val CEqMemEq       : tactic
     val CEqSym      : tactic
     val CEqStep     : tactic
     val CEqSubst    : term * term -> tactic
@@ -184,6 +187,7 @@ sig
     val CEqApprox   : tactic
 
     val ApproxEq    : tactic
+    val ApproxMemEq : tactic
     val ApproxExtEq : tactic
     val ApproxRefl  : tactic
 

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -133,8 +133,11 @@ struct
     in
       AxEq
         ORELSE EqEq
+        ORELSE EqMemEq
         ORELSE CEqEq
+        ORELSE CEqMemEq
         ORELSE ApproxEq
+        ORELSE ApproxMemEq
         ORELSE UnitEq
         ORELSE VoidEq
         ORELSE HypEq


### PR DESCRIPTION
I noticed that it was possible to prove `test : =(...)` but not `=(test; test; =(...))` because `=` was witnessed by `<>` but the equality rule for `<>` only applied for unit. In order to handle this I added 3 new rules (one each for `approx`, `cequal`, `eq`) which says that `<>` is in their PER if the equality/approximation holds. 

So to prove that `=(<>; <>; =(...))` you have to prove that `=(...)` holds and likewise for `approx` and `ceq`.
