### PR TITLE
Added subtyping

### DIFF
--- a/example/subtype.jonprl
+++ b/example/subtype.jonprl
@@ -4,14 +4,14 @@ Theorem reflexive : [{A : U{i}} subtype(A; A)] {
 
 Theorem trans : [{A : U{i}}{B : U{i}}{C : U{i}}
                  subtype(A; B) => subtype(B; C) => subtype(A; C)] {
-  auto; elim #4 [x'']; auto; elim #5 [x''];
-  focus 0 #{hyp-subst → #8 [h. member(h; B)]; *{unfold <member>}; auto};
-  hyp-subst → #10 [h. =(h; h; C)]; auto
+  auto; elim #4 [=(x''; x''; A)];
+  auto; elim #5 [=(x''; x''; B)];
+  auto
 }.
 
 Theorem very-strong-function : [{A : U{i}}{B : U{i}}{C : U{i}}
                                 subtype(A; B) -> (A -> B)] {
-  auto; elim #4 [x']; auto
+  auto; elim #4 [=(x'; x'; A)]; auto; witness [x']; unfold <member>; auto
 }.
 
 Theorem fun-is-id : [{A : U{i}}{B : U{i}}{x : subtype(A; B)}{a : A}

--- a/example/subtype.jonprl
+++ b/example/subtype.jonprl
@@ -1,0 +1,20 @@
+Theorem reflexive : [{A : U{i}} subtype(A; A)] {
+  auto
+}.
+
+Theorem trans : [{A : U{i}}{B : U{i}}{C : U{i}}
+                 subtype(A; B) => subtype(B; C) => subtype(A; C)] {
+  auto; elim #4 [x'']; auto; elim #5 [x''];
+  focus 0 #{hyp-subst → #8 [h. member(h; B)]; *{unfold <member>}; auto};
+  hyp-subst → #10 [h. =(h; h; C)]; auto
+}.
+
+Theorem very-strong-function : [{A : U{i}}{B : U{i}}{C : U{i}}
+                                subtype(A; B) -> (A -> B)] {
+  auto; elim #4 [x']; auto
+}.
+
+Theorem fun-is-id : [{A : U{i}}{B : U{i}}{x : subtype(A; B)}{a : A}
+                     ceq(very-strong-function x a; a)] {
+  auto; unfold <very-strong-function>; *{step}; auto
+}.

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -3,6 +3,7 @@ struct
   datatype t =
       UNIV_EQ of Level.t | CUM
     | EQ_EQ | EQ_MEMBER_EQ
+    | SUBTYPE_EQ | SUBTYPE_MEMBER_EQ | SUBTYPE_INTRO | SUBTYPE_ELIM
     | VOID_EQ | VOID_ELIM
     | UNIT_EQ | UNIT_INTRO | UNIT_ELIM | AX_EQ
     | PROD_EQ | PROD_INTRO | IND_PROD_INTRO | PROD_ELIM | PAIR_EQ | SPREAD_EQ
@@ -33,6 +34,10 @@ struct
        | CUM => #[0]
        | EQ_EQ => #[0,0,0]
        | EQ_MEMBER_EQ => #[0]
+       | SUBTYPE_EQ => #[0, 0]
+       | SUBTYPE_MEMBER_EQ => #[0]
+       | SUBTYPE_INTRO => #[1]
+       | SUBTYPE_ELIM => #[0, 0, 0, 2] (* Behaves like FUN_ELIM *)
        | CEQUAL_EQ => #[0, 0]
        | CEQUAL_MEMBER_EQ => #[0]
        | CEQUAL_SYM => #[0]
@@ -120,6 +125,10 @@ struct
 
        | EQ_EQ => "eq⁼"
        | EQ_MEMBER_EQ => "eq-mem⁼"
+       | SUBTYPE_EQ => "subtype⁼"
+       | SUBTYPE_MEMBER_EQ => "subtype-mem⁼"
+       | SUBTYPE_INTRO => "subtype-intro"
+       | SUBTYPE_ELIM => "subtype-elim"
        | CEQUAL_EQ => "~⁼"
        | CEQUAL_MEMBER_EQ => "~-mem⁼"
        | CEQUAL_SYM => "~-sym"

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -37,7 +37,7 @@ struct
        | SUBTYPE_EQ => #[0, 0]
        | SUBTYPE_MEMBER_EQ => #[0]
        | SUBTYPE_INTRO => #[1]
-       | SUBTYPE_ELIM => #[0, 0, 0, 2] (* Behaves like FUN_ELIM *)
+       | SUBTYPE_ELIM => #[0, 0, 0, 1]
        | CEQUAL_EQ => #[0, 0]
        | CEQUAL_MEMBER_EQ => #[0]
        | CEQUAL_SYM => #[0]

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -23,6 +23,10 @@ struct
 
        | EQ_EQ $ _ => ax
        | EQ_MEMBER_EQ $ _ => ax
+       | SUBTYPE_EQ $ _ => ax
+       | SUBTYPE_MEMBER_EQ $ _ => ax
+       | SUBTYPE_INTRO $ _ => ax
+       | SUBTYPE_ELIM $ #[_, term, _, rest] => (extract rest // term) // ax
        | UNIT_EQ $ _ => ax
        | UNIT_INTRO $ _ => ax
        | UNIT_ELIM $ #[R, E] => extract E

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -26,7 +26,7 @@ struct
        | SUBTYPE_EQ $ _ => ax
        | SUBTYPE_MEMBER_EQ $ _ => ax
        | SUBTYPE_INTRO $ _ => ax
-       | SUBTYPE_ELIM $ #[_, term, _, rest] => (extract rest // term) // ax
+       | SUBTYPE_ELIM $ #[_, _, _, rest] => extract rest // ax
        | UNIT_EQ $ _ => ax
        | UNIT_INTRO $ _ => ax
        | UNIT_ELIM $ #[R, E] => extract E

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -319,21 +319,22 @@ struct
                | _ => raise Refine)
       end
 
-    fun SubtypeElim (hyp, term, onames) (H >> P) =
+    fun SubtypeElim (hyp, term, oname) (H >> P) =
       let
         val term = Context.rebind H term
         val target = eliminationTarget hyp (H >> P)
+        val #[L, R, M'] = term ^! EQ
         val #[M, N] = Context.lookup H target ^! SUBTYPE
-        val (x, y) =
-          case onames of
+        val true = Syntax.eq (M, M')
+        val x =
+          case oname of
               SOME name => name
-            | NONE => (Context.fresh (H, Variable.named "x"),
-                       Context.fresh (H, Variable.named "y"))
-        val H' = H @@ (x, N) @@ (y, C.`> EQ $$ #[term, `` x, N])
+            | NONE => Context.fresh (H, Variable.named "x")
+        val H' = H @@ (x, C.`> EQ $$ #[L, R, N])
       in
-        [ H >> C.`> MEM $$ #[term, M]
+        [ H >> term
         , H' >> P
-        ] BY (fn [D, D'] => D.`> SUBTYPE_ELIM $$ #[``target, term, D, x \\ (y \\ D')]
+        ] BY (fn [D, D'] => D.`> SUBTYPE_ELIM $$ #[``target, term, D, x \\  D']
                | _ => raise Refine)
       end
 

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -180,7 +180,7 @@ sig
     val SubtypeEq : tactic
     val SubtypeMemEq : tactic
     val SubtypeIntro : name option -> tactic
-    val SubtypeElim : hyp * term * (name * name) option -> tactic
+    val SubtypeElim : hyp * term * name option -> tactic
 
     val CEqEq       : tactic
     val CEqMemEq    : tactic

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -177,8 +177,13 @@ sig
     val EqSubst : term * term * Level.t option -> tactic
     val EqSym : tactic
 
+    val SubtypeEq : tactic
+    val SubtypeMemEq : tactic
+    val SubtypeIntro : name option -> tactic
+    val SubtypeElim : hyp * term * (name * name) option -> tactic
+
     val CEqEq       : tactic
-    val CEqMemEq       : tactic
+    val CEqMemEq    : tactic
     val CEqSym      : tactic
     val CEqStep     : tactic
     val CEqSubst    : term * term -> tactic

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -92,6 +92,7 @@ struct
        ORELSE CEqRefl
        ORELSE ApproxRefl
        ORELSE BaseIntro
+       ORELSE SubtypeIntro freshVariable
        ORELSE
        (if not invertible then
             CEqStruct
@@ -121,6 +122,7 @@ struct
         ORELSE_LAZY (fn _ => ProdElim (target, twoNames))
         ORELSE_LAZY (fn _ => FunElim (target, valOf term, twoNames))
         ORELSE_LAZY (fn _ => IsectElim (target, valOf term, twoNames))
+        ORELSE_LAZY (fn _ => SubtypeElim (target, valOf term, twoNames))
         ORELSE ImageEqInd (target, fourNames)
         ORELSE ImageElim (target, listAt (names, 0))
         ORELSE NatElim (target, twoNames)
@@ -138,6 +140,8 @@ struct
         ORELSE CEqMemEq
         ORELSE ApproxEq
         ORELSE ApproxMemEq
+        ORELSE SubtypeEq
+        ORELSE SubtypeMemEq
         ORELSE UnitEq
         ORELSE VoidEq
         ORELSE HypEq

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -122,7 +122,7 @@ struct
         ORELSE_LAZY (fn _ => ProdElim (target, twoNames))
         ORELSE_LAZY (fn _ => FunElim (target, valOf term, twoNames))
         ORELSE_LAZY (fn _ => IsectElim (target, valOf term, twoNames))
-        ORELSE_LAZY (fn _ => SubtypeElim (target, valOf term, twoNames))
+        ORELSE_LAZY (fn _ => SubtypeElim (target, valOf term, listAt (names, 0)))
         ORELSE ImageEqInd (target, fourNames)
         ORELSE ImageElim (target, listAt (names, 0))
         ORELSE NatElim (target, twoNames)

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -14,7 +14,7 @@ struct
     | FIX
     | CBV
     | ISECT
-    | EQ | MEM
+    | EQ | MEM | SUBTYPE
     | SUBSET
     | PLUS | INL | INR | DECIDE
     | NAT | ZERO | SUCC | NATREC
@@ -38,7 +38,7 @@ struct
        IMAGE,
        FIX,
        CBV,
-       ISECT, EQ, MEM, SUBSET,
+       ISECT, EQ, MEM, SUBTYPE, SUBSET,
        PLUS, INL, INR, DECIDE,
        NAT, ZERO, SUCC, NATREC,
        CEQUAL, APPROX, BASE, SO_APPLY]
@@ -83,6 +83,7 @@ struct
        | CEQUAL => #[0, 0]
        | APPROX => #[0, 0]
        | MEM => #[0,0]
+       | SUBTYPE => #[0, 0]
 
        | SUBSET => #[0,1]
 
@@ -112,6 +113,7 @@ struct
        | CBV => "cbv"
        | ISECT => "isect"
        | EQ => "="
+       | SUBTYPE => "subtype"
        | CEQUAL => "ceq"
        | APPROX => "approx"
        | MEM => "member"
@@ -181,6 +183,7 @@ struct
          string "cbv" return CBV,
          string "isect" return ISECT,
          string "=" return EQ,
+         string "subtype" return SUBTYPE,
          string "ceq" return CEQUAL,
          string "approx" return APPROX,
          string "member" return MEM,
@@ -212,4 +215,3 @@ struct
     intensionalParseOperator world
     || ParseCttOperator.parseOperator wth CttCalculusInj.`>
 end
-


### PR DESCRIPTION
This adds a new operator `subtype` which internalizes the judgement `a : A >> a in B`. The introduction rule is just that and the elimination rule allows one to promote any `A` to a `B`.
