### PR TITLE
A minimal Twelf like configuration system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ smlnj:
 	build/mkexec.sh `which sml` `pwd` jonprl
 
 test:
-	bin/jonprl example/choice.jonprl example/monoid.jonprl example/squash.jonprl example/unique.jonprl
+	bin/jonprl --config example/test.cfg
 	bin/jonprl example/image.jonprl
 	bin/jonprl stdlib/*.jonprl
 	bin/jonprl example/tautology.jonprl
@@ -23,4 +23,3 @@ install:
 	rm -f $(DESTDIR)/bin/jonprl.new
 	cp bin/jonprl $(DESTDIR)/bin/jonprl.new
 	mv $(DESTDIR)/bin/jonprl.new $(DESTDIR)/bin/jonprl
-

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ smlnj:
 	build/mkexec.sh `which sml` `pwd` jonprl
 
 test:
-	bin/jonprl --config example/test.cfg
+	bin/jonprl example/test.cfg
 	bin/jonprl example/image.jonprl
 	bin/jonprl stdlib/*.jonprl
 	bin/jonprl example/tautology.jonprl

--- a/example/test.cfg
+++ b/example/test.cfg
@@ -1,0 +1,4 @@
+choice.jonprl
+monoid.jonprl
+squash.jonprl
+unique.jonprl

--- a/src/frontend.sml
+++ b/src/frontend.sml
@@ -70,4 +70,7 @@ struct
            DevelopmentAstEval.eval initialDevelopment ast)
       handle E => (print ("\n\n" ^ prettyException E ^ "\n"); raise E)
     end
+
+  fun loadFiles (initialDevelopment, names) : Development.world =
+    List.foldl (fn (f, dev) => loadFile (dev, f)) Development.empty names
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -6,7 +6,6 @@ struct
     | LIST_OPERATORS
     | LIST_TACTICS
     | HELP
-    | LOAD_CONFIG of mode
 
   local
     fun go [] = PRINT_DEVELOPMENT
@@ -14,7 +13,6 @@ struct
       | go ("--list-operators" :: _) = LIST_OPERATORS
       | go ("--list-tactics" :: _) = LIST_TACTICS
       | go ("--help" :: _) = HELP
-      | go ("--config" :: xs) = LOAD_CONFIG (go xs)
       | go (_ :: xs) = go xs
   in
     fun getMode args = go args
@@ -40,23 +38,15 @@ struct
       val (opts, files) = List.partition (String.isPrefix "--") args
       val mode = getMode opts
 
+      (* This will check the file extension to load configs as needed *)
       fun loadFiles () = Frontend.loadFiles (Development.empty, files)
-      fun loadConfigs () = Frontend.loadConfigs files
     in
       (case mode of
            CHECK_DEVELOPMENT => (loadFiles (); 0)
          | PRINT_DEVELOPMENT => (Frontend.printDevelopment (loadFiles ()); 0)
          | LIST_OPERATORS => (Frontend.printOperators (loadFiles ()); 0)
          | LIST_TACTICS => (Frontend.printTactics (loadFiles ()); 0)
-         | HELP => (print helpMessage; 0)
-         | LOAD_CONFIG CHECK_DEVELOPMENT => (loadConfigs (); 0)
-         | LOAD_CONFIG PRINT_DEVELOPMENT =>
-           (Frontend.printDevelopment (loadConfigs ()); 0)
-         | LOAD_CONFIG LIST_OPERATORS =>
-           (Frontend.printOperators (loadConfigs ()); 0)
-         | LOAD_CONFIG LIST_TACTICS =>
-           (Frontend.printTactics (loadConfigs ()); 0)
-         | _ => 1)
+         | HELP => (print helpMessage; 0))
       handle E => (print (exnMessage E); 1)
     end
 end

--- a/src/main.sml
+++ b/src/main.sml
@@ -46,7 +46,7 @@ struct
 
       fun loadFile (f, dev) = Frontend.loadFile (dev, f)
       val oworld =
-        SOME (foldl loadFile Development.empty files)
+        SOME (Frontend.loadFiles (Development.empty, files))
           handle E =>
             (print (exnMessage E); NONE)
     in

--- a/src/parser/config_parser.sml
+++ b/src/parser/config_parser.sml
@@ -1,0 +1,15 @@
+structure ConfigParser :
+  sig
+    val parse : (string list) CharParser.charParser
+  end =
+struct
+  open ParserCombinators CharParser
+
+  infix 2 return wth suchthat return guard when
+  infixr 1 || <|>
+  infixr 3 &&
+  infixr 4 << >>
+
+  val filename = repeat1 (not space >> anyChar) wth String.implode
+  val parse = spaces >> separate1 filename spaces << spaces << eos
+end

--- a/src/parser/sources.cm
+++ b/src/parser/sources.cm
@@ -13,3 +13,5 @@ group is
   development_parser.fun
   development_parser.sig
   intensional_parser.sig
+
+  config_parser.sml


### PR DESCRIPTION
This adds a new flag to jonprl `--config`. With this flag, the files supplied to JonPRL are expected to be configuration files. These files are just lists of JonPRL files and other cfg files. They are evaluated by loading each file in order. As an example, `make test` now loads `example/test.cfg` which lists out our standard suite of easy tests.

Questions: would it be easier to simply check whether a file ends in `.cfg` and load it as a configuration rather than this whole flag business?
