### PR TITLE
CDEEP is now bottom up (closes #177)

### DIFF
--- a/lib/sml-conv/conversionals.fun
+++ b/lib/sml-conv/conversionals.fun
@@ -7,16 +7,21 @@ struct
   infix 8 $$ \\
 
   fun CDEEP (c : conv) : conv = fn M =>
-    c M handle _ =>
-      case out M of
+    let
+      val M' =
+        (case out M of
           (* If we're at an operator, map a recursive call over all
            * subterms.
            *)
-           O $ ES => into (O $ (Vector.map (fn N => CDEEP c N) ES))
-         (* If we're at a binding site, recurse under the binder *)
-         | x \ E => into (x \ CDEEP c E)
-         (* If we're at a variable, just give up *)
-         | ` x => into (` x)
+            O $ ES => into (O $ (Vector.map (fn N => CDEEP c N) ES))
+          (* If we're at a binding site, recurse under the binder *)
+          | x \ E => into (x \ CDEEP c E)
+          (* If we're at a variable, just give up *)
+          | ` x => into (` x))
+          handle _ => M (* CDEEP should never outright fail *)
+    in
+      c M' handle _ => M'
+    end
 
   fun CTHEN (c1 : conv, c2 : conv) : conv = fn M =>
     c2 (c1 M)

--- a/lib/sml-conv/conversionals.sig
+++ b/lib/sml-conv/conversionals.sig
@@ -31,12 +31,9 @@ sig
   (* [This conversion only makes sense when the underlying term
    *  is a tree]
    *
-   * CDEEP t will run t and if it succeeds just behaves as t.
-   * If t fails CDEEP will walk to the nodes of the t and recurse with
-   * CDEEP t there. If there are no subterms then CDEEP t just behaves
-   * as CID. Note that CDEEP t will apply to *every* subterm so the conv
-   * may rewrite multiple subterms of the original supplied term. However
-   * it will never rewrite X and Y where Y occurs somewhere in X.
+   * CDEEP t will run t from the bottom up. If [t] can be applied to
+   * any subterm it will be. This means that whenever [t] is run on a term
+   * [t] has already been run on the subterms of that term.
    *)
   val CDEEP : conv -> conv
 

--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -47,9 +47,9 @@ struct
               TRACE (msg, {name = name, pos = pos}))
 
   fun parseScript w () : tactic charParser =
-    separate ((squares (commaSep ($ (parseScript w))) wth LIST)
-                   || ($ (parseFocus w) wth FOCUS)
-                   || ($ (plain w) wth APPLY)) semi
+    sepEnd' ((squares (commaSep ($ (parseScript w))) wth LIST)
+                 || ($ (parseFocus w) wth FOCUS)
+                 || ($ (plain w) wth APPLY)) semi
     wth THEN
 
   and plain w () =


### PR DESCRIPTION
This just rejiggers `CDEEP` to apply the conversion to the subterms of a term and then apply conversion to the whole thing instead of the reverse. Doesn't break anything in the compiler happily enough and 

James' example now does the right thing :) 
