### PR TITLE
Add FIAT to syntax; rename admit to fiat (#179)

### DIFF
--- a/src/parser/tactic_parser.fun
+++ b/src/parser/tactic_parser.fun
@@ -262,6 +262,12 @@ struct
       wth (fn (name, hyp) => fn (pos : Pos.t) =>
             THIN (hyp, {name = name, pos = pos}))
 
+
+  val parseFiat : tactic_parser =
+    fn w => tactic "fiat"
+      wth (fn name => fn (pos : Pos.t) =>
+            FIAT {name = name, pos = pos})
+
   fun tacticParsers w =
     parseLemma w
       || parseBHyp w
@@ -290,6 +296,7 @@ struct
       || parseBottomDiverges w
       || parseCHypSubst w
       || parseThin w
+      || parseFiat w
       || parseCustomTactic w
 
   val parse : world -> Tactic.t charParser =

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -15,7 +15,7 @@ struct
 
     | NAT_EQ | NAT_ELIM | ZERO_EQ | SUCC_EQ | NATREC_EQ
 
-    | ADMIT
+    | FIAT
     | CEQUAL_EQ | CEQUAL_MEMBER_EQ | CEQUAL_SYM | CEQUAL_STEP
     | CEQUAL_SUBST | CEQUAL_STRUCT of Arity.t
     | CEQUAL_APPROX
@@ -113,7 +113,7 @@ struct
        | SUBSET_ELIM => #[0,2]
        | SUBSET_MEMBER_EQ => #[0,0,1]
 
-       | ADMIT => #[]
+       | FIAT => #[]
        | LEMMA _ => #[]
 
   fun toString theta =
@@ -194,7 +194,7 @@ struct
        | HYP_EQ => "hyp-eq"
        | EQ_SUBST => "subst"
        | EQ_SYM => "sym"
-       | ADMIT => "<<<<<ADMIT>>>>>"
+       | FIAT => "<<<<<FIAT>>>>>"
 
        | SUBSET_EQ => "subset-eq"
        | SUBSET_INTRO => "subset-intro"

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -119,7 +119,7 @@ struct
        | WITNESS $ #[M, _] => M
        | EQ_SUBST $ #[_, D, _] => extract D
 
-       | ADMIT $ #[] => ``(Variable.named "<<<<<ADMIT>>>>>")
+       | FIAT $ #[] => raise Fail "FIAT may not appear in extract"
 
        | LEMMA {label} $ _ => ``(Variable.named label)
 

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -1226,8 +1226,8 @@ struct
           [] BY (fn _ => D.`> lemmaOperator $$ #[])
         end
 
-      fun Admit (H >> P) =
-        [] BY (fn _ => D.`> ADMIT $$ #[])
+      fun Fiat (H >> P) =
+        [] BY (fn _ => D.`> FIAT $$ #[])
 
       fun RewriteGoal (c : conv) (H >> P) =
         [ Context.map c H >> c P

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -22,7 +22,7 @@ sig
 
   structure Rules : sig
     (* Pretend you have got a proof. *)
-    val Admit : tactic
+    val Fiat : tactic
 
     (* H >> A = B ∈ U{l} by Cum k (k < l)
      * 1.  H >> A = B ∈ U{k}

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -67,6 +67,7 @@ sig
       | COMPLETE of t * meta
       | MATCH of (ctx_pattern * branch) list
       | THIN of hyp * meta
+      | FIAT of meta
     and then_tactic =
         APPLY of t
       | LIST of t list

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -65,6 +65,7 @@ struct
     | COMPLETE of t * meta
     | MATCH of (ctx_pattern * branch) list
     | THIN of hyp * meta
+    | FIAT of meta
   and then_tactic =
       APPLY of t
     | LIST of t list

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -81,4 +81,5 @@ struct
                branches)
       | THIN (hyp, a) =>
           an a (Thin hyp)
+      | FIAT a => an a Fiat
 end


### PR DESCRIPTION
The refiner had a `fiat` rule, but it was not exposed in the syntax. Obviously you don't want to use this, but it can be useful in a partial proof. The extraction throws an exception if it turns out in a computationally relevant position.

This is to resolve #179 
