### PR TITLE
Fixed braces to accept whitespace properly

### DIFF
--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -32,6 +32,9 @@ struct
                           "Search"])
   open TP
 
+  (* Make sure that our version of braces smartly handles whitespace *)
+  val braces = fn p => braces (spaces >> p << spaces)
+
   fun parseTm fvs w =
     squares (Syntax.parseAbt w (Syntax.initialState fvs))
 


### PR DESCRIPTION
This addresses the parser bug discussed in #183. Eventually it may be worth considering if there's a more robust way to handle this, like a proper lexer/parser separation.
