### PR TITLE
Fix backwards definition of has-value (?)

### DIFF
--- a/src/refiner/builtins.sml
+++ b/src/refiner/builtins.sml
@@ -127,8 +127,8 @@ struct
       makeConv HASVALUE (fn #[T] =>
         let
           val ax = `> AX $$ #[]
-          val v = Variable.named ""
-          val cbv = `> CBV $$ #[ax,v \\ T]
+          val v = Variable.named "_"
+          val cbv = `> CBV $$ #[T,v \\ ax]
         in
           `> APPROX $$ #[ax,cbv]
         end


### PR DESCRIPTION
@vrahli I think that the definition of `has-value` was backwards. In Nuprl, it is:

```
has-value(A) =def= 0 <~ let x := A in 0
```

So I think in JonPRL, it would be

```
has-value(A) =def= Ax <~ cbv(A; x. Ax)
```

Is this right?
