### PR TITLE
Resources

### DIFF
--- a/example/resource.jonprl
+++ b/example/resource.jonprl
@@ -1,8 +1,8 @@
 (* Obviously this is completely evil, but provides good evidence for
  * us actually using the hints
  *)
-Resource auto += { !{trace "Should Print First\n"} }.
-Resource auto += { !{trace "Should Print Second\n"} }.
+Resource auto += {trace "Should Print First\n"}.
+Resource auto += {trace "Should Print Second\n"}.
 Resource auto += {fiat}.
 
 Theorem easy-with-fiat : [void] {

--- a/example/resource.jonprl
+++ b/example/resource.jonprl
@@ -1,0 +1,23 @@
+(* Obviously this is completely evil, but provides good evidence for
+ * us actually using the hints
+ *)
+Resource auto += {fiat}.
+Resource eq-cd += {fiat}.
+Resource elim += {fiat}.
+Resource intro += {fiat}.
+
+Theorem easy-with-fiat : [void] {
+  auto
+}.
+
+Theorem easy-with-fiat2 : [void] {
+  elim #1
+}.
+
+Theorem easy-with-fiat3 : [void] {
+  intro
+}.
+
+Theorem easy-with-fiat4 : [void] {
+  eq-cd
+}.

--- a/example/resource.jonprl
+++ b/example/resource.jonprl
@@ -1,22 +1,27 @@
 (* Obviously this is completely evil, but provides good evidence for
  * us actually using the hints
  *)
+Resource auto += { !{trace "Should Print First\n"} }.
+Resource auto += { !{trace "Should Print Second\n"} }.
 Resource auto += {fiat}.
-Resource eq-cd += {fiat}.
-Resource elim += {fiat}.
-Resource intro += {fiat}.
 
 Theorem easy-with-fiat : [void] {
   auto
 }.
 
+Resource elim += {fiat}.
+
 Theorem easy-with-fiat2 : [void] {
   elim #1
 }.
 
+Resource intro += {fiat}.
+
 Theorem easy-with-fiat3 : [void] {
   intro
 }.
+
+Resource eq-cd += {fiat}.
 
 Theorem easy-with-fiat4 : [void] {
   eq-cd

--- a/src/development_ast_eval.sml
+++ b/src/development_ast_eval.sml
@@ -21,7 +21,7 @@ struct
                   SOME obj => Object.toString (lbl, obj)
                 | NONE => "Operator " ^ lbl ^ " : " ^ Arity.toString (Syntax.Operator.arity theta) ^ "."
          in
-           print ("\n" ^ declString ^ "\n")
+           print ("\n" ^ declString ^ "\n"); D
          end
        | EVAL (M, gas) =>
          let
@@ -29,8 +29,9 @@ struct
            val result = Sum.INR (SmallStep.steps (M, gas)) handle SmallStep.Stuck R => Sum.INL R
          in
            case result of
-                Sum.INR (M',n) => print ("\n" ^ termString M ^ " ⇒ " ^ termString M' ^ " in " ^ Int.toString n ^ " steps.\n")
-              | Sum.INL R => print ("\n" ^ termString M ^ " gets stuck at " ^ termString R ^ ".\n")
+               Sum.INR (M',n) => print ("\n" ^ termString M ^ " ⇒ " ^ termString M' ^ " in " ^ Int.toString n ^ " steps.\n")
+             | Sum.INL R => print ("\n" ^ termString M ^ " gets stuck at " ^ termString R ^ ".\n");
+            D
          end
        | SEARCH oper =>
          let
@@ -41,8 +42,10 @@ struct
            print ("\nResults for " ^ lbl ^ ":\n");
            List.app
              (fn (lbl, obj) => print ("\n" ^ Object.toString (lbl, obj) ^ "\n"))
-             results
+             results;
+           D
          end
+       | ADD_RESOURCE (r, t) => Development.addResource D (r, TacticEval.eval D t)
 
   fun evalDecl D ast =
     case ast of
@@ -67,8 +70,7 @@ struct
         Development.defineOperator D {definiendum = pat, definiens = term}
       | NOTATION (notation, theta) =>
         Development.declareNotation D (theta, notation)
-      | COMMAND cmd =>
-        (evalCommand D cmd; D)
+      | COMMAND cmd => evalCommand D cmd
 
   fun eval D = List.foldl (fn (decl, D) => evalDecl D decl) D
 end

--- a/src/parser/development_parser.fun
+++ b/src/parser/development_parser.fun
@@ -29,7 +29,8 @@ struct
                           "Operator",
                           "Print",
                           "Eval",
-                          "Search"])
+                          "Search",
+                          "Resource"])
   open TP
 
   (* Make sure that our version of braces smartly handles whitespace *)
@@ -109,8 +110,13 @@ struct
       parseOperator w
       wth DevelopmentAst.SEARCH
 
+  fun parseAddResource w =
+    (reserved "Resource" >> Resource.parse) &&
+      (spaces >> string "+=" >> spaces >> braces (TacticScript.parse w))
+      wth DevelopmentAst.ADD_RESOURCE
+
   fun parseCommand w =
-    (parsePrint w || parseEval w || parseSearch w)
+    (parsePrint w || parseEval w || parseSearch w || parseAddResource w)
     wth (fn cmd => (w, DevelopmentAst.COMMAND cmd))
 
   fun parseDecl w =

--- a/src/refiner/development.fun
+++ b/src/refiner/development.fun
@@ -309,7 +309,8 @@ struct
                 userDefined = false}
            end
 
-  fun lookupResource {context, resources} r = ResourcePool.lookup resources r
+  fun lookupResource {context, resources} r =
+    Option.getOpt (ResourcePool.find resources r, [])
 end
 
 structure Development : DEVELOPMENT =

--- a/src/refiner/development.fun
+++ b/src/refiner/development.fun
@@ -26,6 +26,7 @@ struct
   type evidence = Lcf.evidence
   type tactic = Lcf.tactic
   type operator = Syntax.Operator.t
+  type resource = Resource.t
 
   type conv = term -> term
 
@@ -90,11 +91,26 @@ struct
           end
   end
 
-  type object = Object.t
-  type world = object Telescope.telescope
-  fun enumerate t = t
+  structure ResourcePool = SplayDict
+    (structure Key =
+       struct
+         open Resource
+         fun toInt AUTO  = 0
+           | toInt ELIM  = 1
+           | toInt EQ_CD = 2
+           | toInt INTRO = 3
 
-  fun enumerateOperators t =
+         val eq = op=
+         fun compare (l, r) = Int.compare (toInt l, toInt r)
+       end)
+
+  type object = Object.t
+  type world = {context : object Telescope.telescope,
+                resources : tactic list ResourcePool.dict}
+
+  fun enumerate {context, resources} = context
+
+  fun enumerateOperators {context = t, resources} =
     let
       open Telescope.SnocView
       fun go Empty bind = bind
@@ -108,7 +124,7 @@ struct
       go (out t) []
     end
 
-  fun enumerateTactics t =
+  fun enumerateTactics {context = t, resources} =
     let
       open Telescope.SnocView
       fun go Empty bind = bind
@@ -122,33 +138,37 @@ struct
       go (out t) []
     end
 
-  val empty = Telescope.empty
+  val empty = {context = Telescope.empty, resources = ResourcePool.empty}
 
-  fun prove T (lbl, theta, goal, tac) =
+  fun prove {context = T, resources} (lbl, theta, goal, tac) =
     let
       val (subgoals, validation) = tac (Goal.|: (Goal.MAIN, goal))
     in
       case subgoals of
-           [] => Telescope.snoc T (lbl, Object.THEOREM
+          [] => {context =
+                  Telescope.snoc T (lbl, Object.THEOREM
                   {operator = theta,
                    statement = goal,
                    script = tac,
-                   evidence = Susp.delay (fn _ => validation [])})
-         | _ => raise Fail "Subgoals not discharged"
+                   evidence = Susp.delay (fn _ => validation [])}),
+                resources = resources}
+        | _ => raise Fail "Subgoals not discharged"
     end
 
-  fun defineTactic T (lbl, tac) =
-    Telescope.snoc T (lbl, Object.TACTIC tac)
+  fun defineTactic {context, resources} (lbl, tac) =
+      {context = Telescope.snoc context (lbl, Object.TACTIC tac),
+       resources = resources}
 
-  fun declareOperator T (lbl, operator) =
-    Telescope.snoc T
-      (lbl, Object.OPERATOR
-        {operator = operator,
-         conversion = NONE,
-         notation = NONE,
-         userDefined = true})
+  fun declareOperator {context, resources} (lbl, operator) =
+    {context = Telescope.snoc context
+                 (lbl, Object.OPERATOR
+                         {operator = operator,
+                          conversion = NONE,
+                          notation = NONE,
+                          userDefined = true}),
+     resources = resources}
 
-  fun searchObject T lbl =
+  fun searchObject {context = T, resources} lbl =
     let
       open Telescope.SnocView
       open Goal Sequent
@@ -192,7 +212,7 @@ struct
         foldl (fn (x,R) => R andalso Set.member ys' x) true xs
       end
   in
-    fun defineOperator T (rule as {definiendum, definiens}) =
+    fun defineOperator {context = T, resources} (rule as {definiendum, definiens}) =
       let
         val Syntax.$ (oper, _) = Syntax.out definiendum
         val lbl = Syntax.Operator.toString oper
@@ -207,41 +227,47 @@ struct
       in
         case Telescope.find T lbl of
              SOME (Object.OPERATOR {operator, conversion = NONE,notation, userDefined = true}) =>
-               Telescope.modify T (lbl, fn _ =>
-                 Object.OPERATOR
-                  {operator = operator,
-                   conversion = conversion,
-                   notation = notation,
-                   userDefined = true})
+               {context = Telescope.modify T (lbl, fn _ =>
+                            Object.OPERATOR
+                              {operator = operator,
+                               conversion = conversion,
+                               notation = notation,
+                               userDefined = true}),
+                resources = resources}
            | SOME _ => raise Subscript
            | NONE => raise Fail "Cannot define undeclared operator"
       end
 
-    fun declareNotation T (theta, notation) =
+    fun declareNotation {context = T, resources} (theta, notation) =
       let
         val lbl = Syntax.Operator.toString theta
       in
         case Telescope.find T lbl of
              SOME (Object.OPERATOR {operator, conversion, notation = NONE, userDefined}) =>
-               Telescope.modify T (lbl, fn _ =>
-                 Object.OPERATOR
-                  {operator = operator,
-                   conversion = conversion,
-                   notation = SOME notation,
-                   userDefined = userDefined})
+               {context = Telescope.modify T (lbl, fn _ =>
+                            Object.OPERATOR
+                              {operator = operator,
+                               conversion = conversion,
+                               notation = SOME notation,
+                               userDefined = userDefined}),
+                resources = resources}
            | SOME _ => raise Fail "Cannot redefined notation"
            | NONE =>
-               Telescope.snoc T (lbl,
-                 Object.OPERATOR
-                  {operator = theta,
-                   conversion = NONE,
-                   notation = SOME notation,
-                   userDefined = false})
+               {context = Telescope.snoc T (lbl,
+                            Object.OPERATOR
+                              {operator = theta,
+                               conversion = NONE,
+                               notation = SOME notation,
+                               userDefined = false}),
+                resources = resources}
       end
   end
 
+  fun addResource {context, resources} (r, t) =
+    {context = context,
+     resources = ResourcePool.insertMerge resources r [t] (fn ts => t :: ts)}
 
-  fun lookupDefinition T theta =
+  fun lookupDefinition {context = T, resources} theta =
     case SOME (Builtins.unfold theta) handle _ => NONE of
          NONE =>
            (case Telescope.lookup T (Syntax.Operator.toString theta) of
@@ -249,24 +275,24 @@ struct
                | _ => raise Subscript)
        | SOME conv => conv
 
-  fun lookupTheorem T theta =
+  fun lookupTheorem {context = T, resources} theta =
     case Telescope.lookup T (Syntax.Operator.toString theta) of
          Object.THEOREM {statement,evidence,...} => {statement = statement, evidence = evidence}
        | _ => raise Subscript
 
-  fun lookupExtract T theta =
+  fun lookupExtract w theta =
     let
-      val {evidence,...} = lookupTheorem T theta
+      val {evidence,...} = lookupTheorem w theta
     in
       Extract.extract (Susp.force evidence)
     end
 
-  fun lookupTactic T lbl =
+  fun lookupTactic {context = T, resources} lbl =
     case Telescope.lookup T lbl of
          Object.TACTIC tac => tac
        | _ => raise Subscript
 
-  fun lookupObject T theta =
+  fun lookupObject {context = T, resources} theta =
     case SOME (Builtins.unfold theta) handle _ => NONE of
          NONE => Telescope.lookup T (Syntax.Operator.toString theta)
        | SOME conv =>
@@ -282,6 +308,8 @@ struct
                 notation = NONE,
                 userDefined = false}
            end
+
+  fun lookupResource {context, resources} r = ResourcePool.lookup resources r
 end
 
 structure Development : DEVELOPMENT =

--- a/src/refiner/development.sig
+++ b/src/refiner/development.sig
@@ -11,6 +11,7 @@ sig
   type judgement
   type evidence
   type tactic
+  type resource
 
   type term
   type operator
@@ -55,6 +56,9 @@ sig
   val defineOperator : world -> {definiendum : term, definiens : term} -> world
   val declareNotation : world -> operator * Notation.t -> world
 
+  (* extend the resource pool with a new tactic *)
+  val addResource : world -> resource * tactic -> world
+
   (* lookup the statement & evidence of a theorem *)
   val lookupTheorem : world -> operator -> {statement : judgement, evidence : evidence Susp.susp}
   val lookupExtract : world -> operator -> term
@@ -64,6 +68,9 @@ sig
 
   (* lookup the definiens *)
   val lookupDefinition : world -> operator -> conv
+
+  (* Lookup the collection of tactics for a given resource *)
+  val lookupResource : world -> resource -> tactic list
 
   val lookupObject : world -> operator -> Object.t
   val searchObject : world -> label -> (label * Object.t) list

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -13,6 +13,7 @@ functor Refiner
      where type evidence = Lcf.evidence
      where type tactic = Lcf.tactic
      where type operator = UniversalOperator.t
+     where type resource = Resource.t
 
    structure Conv : CONV where type term = Syntax.t
    structure Semantics : SMALL_STEP where type syn = Syntax.t

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -16,6 +16,7 @@ sig
     where type tactic = tactic
     where type judgement = Sequent.sequent
     where type operator = operator
+    where type resource = Resource.t
 
   type world = Development.world
   type hyp = name HypSyn.t

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -109,7 +109,7 @@ struct
             CEqRules.Struct
         else
             ID)
-       ORELSE List.foldl (fn (t, ts) => t ORELSE ts) FAIL
+       ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) FAIL
                 (Development.lookupResource D Resource.INTRO)
 
   fun ReduceEquand dir =
@@ -220,7 +220,7 @@ struct
         ORELSE ImageRules.Elim (target, listAt (names, 0))
         ORELSE NatRules.Elim (target, twoNames)
         ORELSE SubsetRules.Elim (target, twoNames)
-        ORELSE List.foldl (fn (t, ts) => t ORELSE ts) FAIL
+        ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) FAIL
                  (Development.lookupResource world Resource.ELIM)
     end
 
@@ -279,7 +279,7 @@ struct
                ORELSE FunRules.ApEq (listAt (terms, 0))
          else
              ID)
-        ORELSE List.foldl (fn (t, ts) => t ORELSE ts) FAIL
+        ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) FAIL
                  (Development.lookupResource world Resource.EQ_CD)
 
     end
@@ -327,13 +327,13 @@ struct
              ORELSE InvAutoIntro wld
              ORELSE AutoVoidElim wld
              ORELSE InvAutoEqCD wld
-             ORELSE List.foldl (fn (t, ts) => t ORELSE ts) ID
+             ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) ID
                       (Development.lookupResource wld Resource.AUTO))
       | FinAuto (wld, n) =
         FinAuto (wld, 0)
         THEN (AutoIntro wld
               ORELSE AutoEqCD wld
-              ORELSE List.foldl (fn (t, ts) => t ORELSE ts) ID
+              ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) ID
                        (Development.lookupResource wld Resource.AUTO))
         THEN FinAuto (wld, n - 1)
 
@@ -342,7 +342,7 @@ struct
              ORELSE AutoIntro wld
              ORELSE AutoVoidElim wld
              ORELSE AutoEqCD wld
-             ORELSE List.foldl (fn (t, ts) => t ORELSE ts) ID
+             ORELSE List.foldl (fn (t, ts) => PROGRESS t ORELSE ts) ID
                       (Development.lookupResource wld Resource.AUTO))
 
     fun Auto (wld, opt) =

--- a/src/refiner/refiner_util.sig
+++ b/src/refiner/refiner_util.sig
@@ -30,7 +30,7 @@ sig
      goal   : term,
      branch : (name * term) list -> tactic} list
 
-  val Intro : intro_args -> tactic
+  val Intro : intro_args -> world -> tactic
   val Elim : elim_args -> world -> tactic
   val EqCD : eq_cd_args -> world -> tactic
   val Ext : ext_args -> tactic

--- a/src/syntax/development_ast.sig
+++ b/src/syntax/development_ast.sig
@@ -13,6 +13,7 @@ sig
       PRINT of Syntax.Operator.t
     | EVAL of Syntax.t * int option
     | SEARCH of Syntax.Operator.t
+    | ADD_RESOURCE of Resource.t * Tactic.t
 
   datatype t =
       THEOREM of label * Syntax.Operator.t * Syntax.t * Tactic.t

--- a/src/syntax/development_ast.sml
+++ b/src/syntax/development_ast.sml
@@ -9,6 +9,7 @@ struct
       PRINT of Syntax.Operator.t
     | EVAL of Syntax.t * int option
     | SEARCH of Syntax.Operator.t
+    | ADD_RESOURCE of Resource.t * Tactic.t
 
   datatype t =
       THEOREM of label * Syntax.Operator.t * Syntax.t * Tactic.t

--- a/src/syntax/resource.sig
+++ b/src/syntax/resource.sig
@@ -1,0 +1,7 @@
+signature RESOURCE =
+sig
+  datatype t = AUTO | ELIM | EQ_CD | INTRO
+
+  val toString : t -> string
+  val parse : t CharParser.charParser
+end

--- a/src/syntax/resource.sml
+++ b/src/syntax/resource.sml
@@ -1,0 +1,23 @@
+structure Resource :> RESOURCE =
+struct
+  datatype t = AUTO | ELIM | EQ_CD | INTRO
+
+  fun toString AUTO = "auto"
+    | toString ELIM = "elim"
+    | toString EQ_CD = "eq-cd"
+    | toString INTRO = "intro"
+
+  open ParserCombinators CharParser JonprlTokenParser
+  infix 2 return
+  infixr 1 ||
+
+  fun choices xs =
+    foldl (fn (p, p') => p || try p') (fail "unknown operator") xs
+
+  val parse =
+    choices
+      [string "auto" return AUTO,
+       string "elim" return ELIM,
+       string "eq-cd" return EQ_CD,
+       string "intro" return INTRO]
+end

--- a/src/syntax/sources.cm
+++ b/src/syntax/sources.cm
@@ -31,6 +31,9 @@ group is
   notation.sig
   notation.sml
 
+  resource.sig
+  resource.sml
+
   development_ast.sig
   development_ast.sml
 

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -32,10 +32,10 @@ struct
         an a (CEqRules.HypSubst (dir, index, domain))
       | INTRO ({term, rule, freshVariable, level}, a) =>
         an a (RefinerUtil.Intro {term = term,
-                             rule = rule,
-                             invertible = false,
-                             freshVariable = freshVariable,
-                             level = level})
+                                 rule = rule,
+                                 invertible = false,
+                                 freshVariable = freshVariable,
+                                 level = level} wld)
       | ELIM ({target, term, names}, a) =>
         an a (RefinerUtil.Elim {target = target, term = term, names = names} wld)
       | EQ_CD ({names, terms, level}, a) =>


### PR DESCRIPTION
_This closes #54_

This pull request adds resources to the 4 core built in tactics. Using this you can supply arbitrary tactics to be run whenever `auto`, `elim`, `eq-cd`, or `intro` runs. The only gotcha is that each tactic is run (in the order it's added) until one succeeds. Thus, if you add a hint that does nothing but always succeeds you can effectively disable the resource database! The easy way to solve this is just to add a `!{}` around such a tactic.
