### PR TITLE
Added bunion-eq-left/right to stdlib/tactics.jonprl

### DIFF
--- a/stdlib/tactics.jonprl
+++ b/stdlib/tactics.jonprl
@@ -10,3 +10,36 @@ Tactic squash-intro {
        }
   }
 }.
+
+Resource intro += {squash-intro}.
+
+|||
+Tactic bunion-eq-right {
+  @{ [|- =(M; N; bunion(L; R))] =>
+       csubst [ceq(M; lam(x. snd(x)) <inr(<>), M>)] [h.=(h;_;_)];
+       aux { unfold <snd>; reduce; auto };
+       csubst [ceq(N; lam(x. snd(x)) <inr(<>), N>)] [h.=(_;h;_)];
+       aux { unfold <snd>; reduce; auto };
+
+       unfold <bunion>; eq-cd; auto; reduce;
+       aux {
+         @{[H : unit + unit |- _] => elim <H>; thin <H>};
+         reduce; auto
+       }
+  }
+}.
+
+Tactic bunion-eq-left {
+  @{ [|- =(M; N; bunion(L; R))] =>
+       csubst [ceq(M; lam(x. snd(x)) <inl(<>), M>)] [h.=(h;_;_)];
+       aux { unfold <snd>; reduce; auto };
+       csubst [ceq(N; lam(x. snd(x)) <inl(<>), N>)] [h.=(_;h;_)];
+       aux { unfold <snd>; reduce; auto };
+
+       unfold <bunion>; eq-cd; auto; reduce;
+       aux {
+         @{[H : unit + unit |- _] => elim <H>; thin <H>};
+         reduce; auto
+       }
+  }
+}.


### PR DESCRIPTION
These are derived from the tactic Jon wrote for russell.jonprl. They're slightly different, the crux of the difference being that they try to go from `=(M; N; bunion(A; B))` to `=(M; N; A)` or `=(M; N; B)`. This requires that we be able to prove that `member(A; U{i})` and `member(B; U{i})` respectively.

I expect that as `inferLevel` (and `eq-cd` with it) gets smarter this will actually do the right thing in most of the cases we're interested in. For now I figure that this is useful in 90% of cases (`russell.jonprl` notably being the exception).
