### PR TITLE
Add support for new PRUNE tactical

### DIFF
--- a/src/parser/tactic_script.fun
+++ b/src/parser/tactic_script.fun
@@ -18,10 +18,7 @@ struct
   infixr 3 &&
   infixr 4 << >>
 
-  structure TP = TokenParser
-    (open JonprlLanguageDef
-     val reservedNames = ["refine"])
-  open TP
+  open JonprlTokenParser
 
   val pipe = symbol "|"
 
@@ -58,6 +55,7 @@ struct
       || $ (parseProgress w)
       || $ (parseOrelse w)
       || $ (parseComplete w)
+      || $ (parsePrune w)
       || parseId
       || parseFail
       || parseTrace
@@ -80,6 +78,11 @@ struct
     symbol "focus" && parseInt &&
     whiteSpace >> middle (symbol "#{") ($ (parseScript w)) (symbol "}")
     wth (fn (_, (i, t)) => (i, t))
+
+  and parsePrune w () =
+    symbol "prune" >>
+    whiteSpace >> middle (symbol "{") ($ (parseScript w)) (symbol "}")
+    wth PRUNE
 
   and parseTry w () =
     middle (symbol "?{") ($ (parseScript w)) (symbol "}")

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -18,14 +18,15 @@ functor RefinerUtil
       where type Sequent.sequent = Sequent.sequent) : REFINER_UTIL =
 struct
   structure Lcf = Lcf
-  structure Tacticals = ProgressTacticals(Lcf)
+  structure Tacticals = Tacticals(Lcf)
+  structure ProgressTacticals = ProgressTacticals(Lcf)
   open Conv Refiner
 
   structure Conversionals = Conversionals
     (structure Syntax = Syntax
      structure Conv = Conv)
 
-  open Tacticals Rules
+  open ProgressTacticals Tacticals Rules
   infix ORELSE ORELSE_LAZY THEN
 
   type intro_args =
@@ -58,8 +59,7 @@ struct
   val CEqRefl = CEqRules.Approx THEN ApproxRules.Refl
 
   local
-    structure Tacticals = Tacticals (Lcf)
-    open Tacticals Goal Sequent Syntax
+    open Goal Sequent Syntax
     infix THENL
     infix 3 >> infix 2 |:
     infix $

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -64,6 +64,7 @@ sig
       | LIMIT of t
       | ORELSE of t list * meta
       | THEN of then_tactic list
+      | PRUNE of t
       | ID of meta
       | FAIL of meta
       | TRACE of string * meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -62,6 +62,7 @@ struct
     | LIMIT of t
     | ORELSE of t list * meta
     | THEN of then_tactic list
+    | PRUNE of t
     | ID of meta
     | FAIL of meta
     | TRACE of string * meta

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -8,7 +8,7 @@ struct
   open Refiner.Rules
   open GeneralRules
 
-  structure T = ProgressTacticals(Lcf)
+  structure PT = ProgressTacticals(Lcf) and T = Tacticals(Lcf) and TT = TransformationalTacticals(Lcf)
   exception RemainingSubgoals = T.RemainingSubgoals
 
   fun an a t = AnnotatedLcf.annotate (a, t)
@@ -62,8 +62,8 @@ struct
       | ASSUME_HAS_VALUE ({name, level}, a) => an a (ApproxRules.AssumeHasValue (name, level))
       | EQ_EQ_BASE a => an a EqRules.EqBase
       | TRY tac => T.TRY (eval wld tac)
-      | LIMIT tac => T.LIMIT (eval wld tac)
-      | PROGRESS tac => T.PROGRESS (eval wld tac)
+      | LIMIT tac => PT.LIMIT (eval wld tac)
+      | PROGRESS tac => PT.PROGRESS (eval wld tac)
       | ORELSE (tacs, a) => an a (List.foldl T.ORELSE T.FAIL (map (eval wld) tacs))
       | THEN ts =>
         List.foldl
@@ -72,6 +72,7 @@ struct
             | (FOCUS (i, x), rest) => T.THENF (rest, i, eval wld x))
           T.ID
           ts
+      | PRUNE tac => TT.PRUNE (eval wld tac)
       | ID a => an a T.ID
       | FAIL a => an a T.FAIL
       | TRACE (msg, a) => an a (T.TRACE msg)


### PR DESCRIPTION
This adds support for the new `PRUNE` tactical that I added to the LCF library. It takes a tactic and prunes out the duplicate subgoals, propagating the evidence through the validation.

Also, one change in the LCF library is that the various signatures for tacticals don't include the `TACTICALS` signature, since you may want to use both `PROGRESS_TACTICALS` and (e.g.) `TRANSFORMATIONAL_TACTICALS` at the same time without duplicating the basic tacticals.
