### PR TITLE
Container improvements; add neighborhoods (i.e. finite approximations)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ test:
 	bin/jonprl example/russell.jonprl
 	bin/jonprl example/container.jonprl
 	bin/jonprl example/list.jonprl
+	bin/jonprl example/generalized-choice-sequences.jonprl
 
 clean:
 	rm -f bin/.heapimg.*

--- a/example/container.jonprl
+++ b/example/container.jonprl
@@ -19,8 +19,8 @@ Operator nat-decode : (0).
 Operator nat-code : ().
 [nat-code] =def= [{a : atom | nat-decode(a) ⇓}].
 
-Operator nat-con : ().
-[nat-con] =def= [x : nat-code ◃ nat-decode(x)].
+Operator nat-sig : ().
+[nat-sig] =def= [x : nat-code ◃ nat-decode(x)].
 
 Theorem nat-code-wf : [nat-code ∈ U{i}] {
   unfold <nat-code has-value>; auto
@@ -28,18 +28,30 @@ Theorem nat-code-wf : [nat-code ∈ U{i}] {
 
 Resource wf += { wf-lemma <nat-code-wf> }.
 
-Theorem nat-con-wf : [nat-con ∈ container] {
-  unfold <nat-con container make-container nat-code nat-decode has-value>; auto;
+Theorem nat-decode-wf : [{a:nat-code} nat-decode(a) ∈ U{i}] {
+  intro @i; auto;
+  unfold <nat-decode nat-code>; auto;
+  elim #1;
+  unfold <nat-decode>;
+  assert [bot ⇓];
+  aux { chyp-subst <- #4; auto };
+  bot-div #6
+}.
+
+Resource wf += { wf-lemma <nat-decode-wf> }.
+
+Theorem nat-sig-wf : [nat-sig ∈ container{i}] {
+  unfold <nat-sig nat-code nat-decode has-value>; auto;
   elim #1;
   assert [bot ⇓];
   aux {chyp-subst <- #4 [h. h ⇓]; auto;};
   bot-div #6
 }.
 
-Resource wf += { wf-lemma <nat-con-wf> }.
+Resource wf += { wf-lemma <nat-sig-wf> }.
 
 Operator nat' : ().
-[nat'] =def= [wtree(nat-con)].
+[nat'] =def= [wtree(nat-sig)].
 
 Theorem nat'-wf : [nat' ∈ U{i}] {
   unfold <nat'>; auto
@@ -49,12 +61,12 @@ Resource wf += { wf-lemma <nat'-wf> }.
 
 Theorem ze-code-wf : ["ze" ∈ nat-code] {
   unfold <nat-code has-value nat-decode>;
-  auto; reduce; auto
+  auto; reduce; auto ; auto
 }.
 
 Theorem su-code-wf : ["su" ∈ nat-code] {
   unfold <nat-code has-value nat-decode>;
-  auto; reduce; auto
+  auto; reduce; auto ; auto
 }.
 
 Resource wf += { wf-lemma <ze-code-wf> }.
@@ -62,16 +74,14 @@ Resource wf += { wf-lemma <su-code-wf> }.
 
 
 Operator ze : ().
-[ze] =def= ["ze" ^ <>].
+[ze] =def= [sup("ze" ^ <>)].
 
 Operator su : (0).
-[su(N)] =def= ["su" ^ N].
-
-Resource auto += { unfold <fst snd shape refinement nat-con> }.
+[su(N)] =def= [sup("su" ^ N)].
 
 Theorem ze-wf : [ze ∈ nat'] {
-  unfold <ze nat'>; auto;
-  unfold <nat-decode make-container>; reduce; auto
+  unfold <ze nat' nat-sig>; auto; reduce; auto;
+  unfold <nat-decode>; reduce; auto
 }.
 
 Resource wf += { wf-lemma <ze-wf> }.
@@ -79,25 +89,16 @@ Resource wf += { wf-lemma <ze-wf> }.
 Theorem su-wf : [{N:nat'} su(N) ∈ nat'] {
   intro @i; auto;
   unfold <su nat'>;
-  auto; reduce; auto;
-  unfold <make-container>;
-  reduce; auto
+  auto; reduce; auto; auto;
+  unfold <nat-sig>; reduce; auto
 }.
 
 Resource wf += { wf-lemma <su-wf> }.
 
-Theorem wtree-intro-test : [nat'] {
-  unfold <nat'>;
-  intro ["su"]; auto; reduce; auto;
-  unfold <make-container>; reduce; auto;
-  intro ["ze"]; reduce; auto; reduce; auto;
-  unfold <nat-decode>; reduce; auto
-}.
-
 Theorem nat'-elim-test : [nat' -> atom] {
   intro @i; auto;
   unfold <nat'>;
-  elim #1; auto; unfold <make-container>; reduce;
+  elim #1; unfold <nat-sig>; reduce;
   witness [a];
   unfold <nat-code>; auto
 }.

--- a/example/generalized-choice-sequences.jonprl
+++ b/example/generalized-choice-sequences.jonprl
@@ -1,0 +1,181 @@
+Infix 2 "∈" := member.
+Infix 100 "~" := ceq.
+Postfix 10 "⇓" := has-value.
+Prefix 50 "¬" := not.
+
+Operator top : ().
+[top] =def= [void => void].
+
+Theorem top-wf : [top ∈ U{i}] {
+  unfold <top>; auto
+}.
+
+Resource wf += { wf-lemma <top-wf> }.
+
+Operator ν : (1).
+[ν(x.F[x])] =def= [{n:nat} natrec(n; top; _.T.F[T])].
+
+Theorem ν-wf : [{F:U{i} -> U{i}} ν(x.F x) ∈ U{i}] {
+  auto; unfold <ν>; auto;
+}.
+
+||| generalized choice sequences
+Operator choice-sequence : (0).
+[choice-sequence(F)] =def= [ν(R.extension(F; R))].
+
+Theorem choice-sequence-wf : [{F:container{i}} choice-sequence(F) ∈ U{i}] {
+  auto; unfold <choice-sequence ν>; auto;
+  eq-cd [U{i} -> U{i}]; auto
+}.
+
+Resource wf += { wf-lemma <choice-sequence-wf> }.
+
+Operator hd : (0).
+[hd(α)] =def= [dom(α)].
+
+Operator tl : (0;0).
+[tl(α; p)] =def= [proj(α; p)].
+
+Theorem hd-wf : [{F:container{i}} {α:choice-sequence(F)} dom(α) ∈ dom(F)] {
+  auto; intro @i; auto;
+  unfold <choice-sequence ν hd>;
+  elim #1; reduce;
+  elim #4 [succ(zero)]; reduce; auto;
+  prune { hyp-subst <- #6 [h.=(dom(h); dom(h); _)]; auto };
+  @{ [H:extension(_;_) |- _] => elim <H>
+   }; reduce; auto
+}.
+
+Resource wf += { wf-lemma <hd-wf> }.
+
+Postfix 10 "♮" := neighborhoods.
+
+||| Brouwer's container
+Operator B : ().
+[B] =def= [x:nat <: unit].
+
+Theorem test : [<> ^ zero ^ succ(zero) ^ succ(succ(zero)) ∈ | B ♮|] {
+  unfold <neighborhoods B>;
+  *{ auto; reduce }
+}.
+
+
+Operator decidable : (0).
+[decidable(P)] =def= [P + ¬ P].
+
+Theorem implies-wf : [{P:U{i}} {Q:U{i}} implies(P; Q) ∈ U{i}] {
+  unfold <implies>; auto
+}.
+
+Resource wf += { wf-lemma <implies-wf> }.
+
+Theorem not-wf : [{P:U{i}} ¬ P ∈ U{i}] {
+  unfold <not>; auto
+}.
+
+Resource wf += { wf-lemma <not-wf> }.
+
+Theorem decidable-wf : [{P:U{i}} decidable(P) ∈ U{i}] {
+  unfold <decidable>;
+  auto
+}.
+
+Resource wf += { wf-lemma <decidable-wf> }.
+
+Operator prefixes : (0;0).
+Infix 10 "≼" := prefixes.
+
+[u ≼ v] =def= [neigh-ind(v; neigh-ind(u; unit; _._._.void); w.e.ih.ih)].
+
+Theorem prefixes-wf : [{F:container{i}} {u:|F ♮|} {v:|F ♮|} u ≼ v ∈ U{i}] {
+  auto; unfold <prefixes neighborhoods>; reduce; auto
+}.
+
+Resource wf += { wf-lemma <prefixes-wf> }.
+
+Operator spw-decidable : (0;0).
+[spw-decidable(F; S)] =def= [(u:|F ♮|) decidable(S u)].
+
+Operator spw-leaks-upwards : (0;0).
+[spw-leaks-upwards(F; S)] =def= [(u:|F ♮|) S u -> (e:proj(F ♮; u) -> |F|) * S (u ^ r. e r)].
+
+Operator spw-downward-closed : (0;0).
+[spw-downward-closed(F; S)] =def= [(v:|F ♮|) (u:{u : |F ♮| | u ≼ v}) S u -> S v].
+
+Theorem spw-decidable-wf : [{F:container{i}} {S:|F ♮| -> U{i}} spw-decidable(F; S) ∈ U{i}] {
+  unfold <spw-decidable neighborhoods>; reduce; auto;
+  elim #1; auto
+}.
+
+Theorem spw-leaks-upwards-wf : [{F:container{i}} {S:|F ♮| -> U{i}} spw-leaks-upwards(F; S) ∈ U{i}] {
+  unfold <spw-leaks-upwards neighborhoods>; reduce; auto;
+  elim #1; auto; reduce; auto;
+  elim #5; reduce; auto
+}.
+
+Theorem spw-downward-closed-wf : [{F:container{i}} {S:|F ♮| -> U{i}} spw-downward-closed(F; S) ∈ U{i}] {
+  auto; unfold <spw-downward-closed neighborhoods>; reduce; auto;
+  cut-lemma <prefixes-wf>;
+  elim #5 [F]; auto;
+  unfold <member neighborhoods>; reduce;
+  bhyp #6; auto;
+}.
+
+Resource wf += { wf-lemma <spw-decidable-wf> }.
+Resource wf += { wf-lemma <spw-leaks-upwards-wf> }.
+Resource wf += { wf-lemma <spw-downward-closed-wf> }.
+
+||| I can't use the word "spread" (because that's the name of the recursor for
+||| pairs), so I'll use the Dutch.
+
+Operator spreidingswet : (0;0).
+[spreidingswet(F; S)] =def= [
+  spw-decidable(F; S)
+    * spw-leaks-upwards(F; S)
+    * spw-downward-closed(F; S)
+    * S <>
+].
+
+Theorem spreidingswet-wf : [{F:container{i}} {S:|F ♮| -> U{i}} spreidingswet(F;S) ∈ U{i}] {
+  auto; *{ unfold <spreidingswet neighborhoods>; reduce; auto }
+}.
+
+Resource wf += { wf-lemma <spreidingswet-wf> }.
+
+Operator spreiding : (0).
+[spreiding(F)] =def= [{S:|F ♮| -> U{i} | spreidingswet(F; S)}].
+
+Theorem spreiding-wf : [{F:container{i}} spreiding(F) ∈ U{i'}] {
+  auto; unfold <spreiding neighborhoods>; reduce; auto;
+  [ elim #1 , cum @i ];
+  auto; unfold <neighborhoods>; reduce; auto
+}.
+
+Resource wf += { wf-lemma <spreiding-wf> }.
+
+Operator universal-spread : ().
+[universal-spread] =def= [lam(_.unit)].
+
+Theorem universal-spread-pre-wf : [{F:container{i}} universal-spread ∈ |F ♮| -> U{i}] {
+  auto; unfold <universal-spread neighborhoods>; auto;
+  elim #1; reduce; auto
+}.
+
+Resource wf += { wf-lemma <universal-spread-pre-wf> }.
+
+Theorem universal-spread-wf : [{F:container{i}} (s:|F|) universal-spread ∈ spreiding(F)] {
+  unfold <spreiding>; auto; aux { elim #1; reduce; auto };
+  eq-cd @i; ?{ !{ auto } };
+  unfold <spreidingswet>; auto;
+  unfold <neighborhoods>; reduce; auto;
+  unfold <universal-spread>; reduce; auto;
+  aux { elim #3; reduce; auto; elim #1; reduce; auto };
+  focus 0 #{ intro #0; auto };
+  intro @i; auto;
+  cut-lemma <prefixes-wf>;
+  elim #5 [F]; auto;
+  unfold <neighborhoods member>; reduce;
+  bhyp #6; auto
+}.
+
+Resource wf += { wf-lemma <universal-spread-wf> }.

--- a/example/list.jonprl
+++ b/example/list.jonprl
@@ -43,33 +43,30 @@ Theorem is-some-wf : [{A:U{i}} {M:A?} is-some(M) ∈ U{i}] {
 Resource wf += { wf-lemma <is-some-wf> }.
 
 ||| We go about defining inductive types by giving their constructors a
-||| signature as a "container", which is written "s : shape <: refinement[s]".
-||| The shape is the name of the constructor, and the type of refinements at a
+||| signature as a "container", which is written "s : shape <: position[s]".
+||| The shape is the name of the constructor, and the type of positions at a
 ||| shape s are all the tree branches that should grow from that node. If you
-||| think of a tree as a set of paths, then the refinements are the possible
+||| think of a tree as a set of paths, then the positions are the possible
 ||| upward moves that you may make at a point in the tree.
-Operator list-container : (0).
-[list-container(A)] =def= [a:A? <: is-some(a)].
+Operator list-sig : (0).
+[list-sig(A)] =def= [a:A? <: is-some(a)].
 
-Theorem list-container-wf : [{A:U{i}} list-container(A) ∈ container] {
-  auto; unfold <list-container make-container container>; auto;
-  eq-cd @i; auto;
+Theorem list-sig-wf : [{A:U{i}} list-sig(A) ∈ container{i}] {
+  auto; unfold <list-sig>; auto;
   cut-lemma <is-some-wf>;
   elim #3 [A]; auto; unfold <member>;
   bhyp #4; auto
 }.
 
-Resource wf += { wf-lemma <list-container-wf> }.
+Resource wf += { wf-lemma <list-sig-wf> }.
 
 ||| A list is the well-founded tree generated from the list container.
 Operator list : (0).
 Postfix 5 "list" := list.
-[A list] =def= [wtree(list-container(A))].
+[A list] =def= [wtree(list-sig(A))].
 
 Theorem list-wf : [{A:U{i}} A list ∈ U{i}] {
-  auto;
-  unfold <list make-container>;
-  auto; unfold <container>; auto;
+  auto; unfold <list>; auto;
   elim #2; reduce;
   auto
 }.
@@ -78,20 +75,19 @@ Resource wf += { wf-lemma <list-wf> }.
 
 ||| We can define the basic list constructors in terms of the primitive
 ||| constructors for well-founded trees. The expression means "s ^ r. T[r]"
-||| means, "begin a node at s, with subtrees T[r] for each refinement r"; when
-||| the refinements are not differentiated (as in our case, where there is at
-||| most one possible refinement), the notation "s ^ T" is supported.
+||| means, "begin a node at s, with subtrees T[r] for each position r"; when
+||| the positions are not differentiated (as in our case, where there is at
+||| most one possible position), the notation "s ^ T" is supported.
 Operator nil : ().
-[nil] =def= [none ^ <>].
+[nil] =def= [sup(none ^ <>)].
 
 Operator cons : (0;0).
-[cons(x; xs)] =def= [some(x) ^ xs].
+[cons(x; xs)] =def= [sup(some(x) ^ xs)].
 
 Infix -> 5 "#" := cons.
 
 Tactic list-wf-tac {
-  unfold <shape fst refinement snd list-container make-container>;
-  reduce; auto
+  unfold <list-sig>; reduce; auto
 }.
 
 Theorem nil-wf : [{A:U{i}} nil ∈ A list] {

--- a/example/nats.jonprl
+++ b/example/nats.jonprl
@@ -1,3 +1,6 @@
+Infix 2 "∈" := member.
+Postfix 10 "⇓" := has-value.
+
 Theorem natp-example : [nat] {
   witness [succ(zero)]; auto
 }.
@@ -51,3 +54,36 @@ Theorem add-commutes : [
   unfold <add>; elim #6 [n']; auto;
   hyp-subst → #8 [h.=(_; h; _)]; auto
 }.
+
+Theorem has-value-wf : [{M:base} M ⇓ ∈ U{i}] {
+  unfold <has-value>; auto
+}.
+
+Resource wf += { wf-lemma <has-value-wf> }.
+
+Operator pred : (0).
+[pred(n)] =def= [natrec(n; bot; m._.m)].
+
+Operator minus : (0;0).
+[minus(m; n)] =def= [
+  natrec(n; m; n'.ih. pred(ih))
+].
+
+Operator leq : (0;0).
+Infix 10 "≤" := leq.
+[m ≤ n] =def= [minus(n; m) ⇓].
+
+Theorem leq-wf : [{m:nat} {n:nat} (m ≤ n) ∈ U{i}] {
+  unfold <leq>; auto
+}.
+
+Resource wf += { wf-lemma <leq-wf> }.
+
+Operator upto : (0).
+[upto(i)] =def= [{j : nat | j ≤ i}].
+
+Theorem upto-wf : [{n:nat} upto(n) ∈ U{i}] {
+  unfold <upto>; auto
+}.
+
+Resource wf += { wf-lemma <upto-wf> }.

--- a/src/refiner/builtins.sml
+++ b/src/refiner/builtins.sml
@@ -140,32 +140,14 @@ struct
         `> IMPLIES $$ #[P, `> VOID $$ #[]]
       | _ => raise Conv)
 
-    val unfoldContainer =
-      makeConv CONTAINER (fn #[] =>
+    val unfoldContainerNeigh =
+      makeConv CONTAINER_NEIGH (fn #[F] =>
         let
-          val A = Variable.named "A"
-          val univ = `> (UNIV Level.base) $$ #[]
-          val x = Variable.named "a"
+          val u = Variable.named "u"
         in
-          `> PROD $$ #[univ, A \\ `> FUN $$ #[``A, x \\ univ]]
+          `> MAKE_CONTAINER $$ #[`> NEIGH $$ #[F], u \\ `> REFINEMENT $$ #[F, ``u]]
         end
       | _ => raise Conv)
-
-    val unfoldMakeContainer =
-      makeConv MAKE_CONTAINER (fn #[A,xB] =>
-        `> PAIR $$ #[A, `> LAM $$ #[xB]]
-      | _ => raise Conv)
-
-    val unfoldShape =
-      makeConv SHAPE (fn #[C] =>
-        `> FST $$ #[C]
-      | _ => raise Conv)
-
-    val unfoldRefinement =
-      makeConv REFINEMENT (fn #[C,s] =>
-        `> AP $$ #[`> SND $$ #[C], s]
-      | _ => raise Conv)
-
   in
     (* add definitions here via composition: unfoldX o unfoldY o unfoldZ... *)
     val definitions =
@@ -184,10 +166,7 @@ struct
       o unfoldVoid
       o unfoldHasValue
       o unfoldNot
-      o unfoldContainer
-      o unfoldMakeContainer
-      o unfoldShape
-      o unfoldRefinement
+      o unfoldContainerNeigh
   end
 
   val unfold = Dict.lookup (definitions Dict.empty)

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -25,6 +25,11 @@ struct
     | ATOM_EQ | TOKEN_EQ | MATCH_TOKEN_EQ of string vector | TEST_ATOM_EQ
     | TEST_ATOM_REDUCE_LEFT | TEST_ATOM_REDUCE_RIGHT
 
+
+    | CONTAINER_EQ | CONTAINER_MEM_EQ | CONTAINER_ELIM
+    | EXTENSION_EQ | EXTEND_EQ | EXTENSION_ELIM
+    | NEIGH_EQ | NEIGH_NIL_EQ | NEIGH_SNOC_EQ | NEIGH_ELIM | NEIGH_IND_EQ
+
     | WTREE_EQ | WTREE_MEM_EQ | WTREE_REC_EQ | WTREE_INTRO | WTREE_ELIM
 
     | LEMMA of {label : Label.t}
@@ -120,10 +125,24 @@ struct
        | SUBSET_ELIM => #[0,2]
        | SUBSET_MEMBER_EQ => #[0,0,1]
 
+       | CONTAINER_EQ => #[]
+       | CONTAINER_MEM_EQ => #[0,1]
+       | CONTAINER_ELIM => #[0,2]
+
+       | EXTENSION_EQ => #[0,0]
+       | EXTEND_EQ => #[0,1]
+       | EXTENSION_ELIM => #[0,2]
+
+       | NEIGH_EQ => #[0]
+       | NEIGH_NIL_EQ => #[0]
+       | NEIGH_SNOC_EQ => #[0,1]
+       | NEIGH_IND_EQ => #[0,0,3]
+       | NEIGH_ELIM => #[0,0,3]
+
        | WTREE_EQ => #[0]
        | WTREE_MEM_EQ => #[0,1]
        | WTREE_REC_EQ => #[3,0]
-       | WTREE_INTRO => #[0,0,1]
+       | WTREE_INTRO => #[0]
        | WTREE_ELIM => #[0,3]
 
        | FIAT => #[]
@@ -224,6 +243,21 @@ struct
        | IND_SUBSET_INTRO => "independent-subset-intro"
        | SUBSET_ELIM => "subset-elim"
        | SUBSET_MEMBER_EQ => "subset-member-eq"
+
+       | CONTAINER_EQ => "container-eq"
+       | CONTAINER_MEM_EQ => "container-mem-eq"
+       | CONTAINER_ELIM => "container-elim"
+
+       | EXTENSION_EQ => "extension-eq"
+       | EXTEND_EQ => "extend-eq"
+       | EXTENSION_ELIM => "extension-elim"
+
+       | NEIGH_EQ => "neigh-eq"
+       | NEIGH_NIL_EQ => "neigh-nil-eq"
+       | NEIGH_SNOC_EQ => "neigh-snoc-eq"
+       | NEIGH_IND_EQ => "neigh-ind-eq"
+       | NEIGH_ELIM => "neigh-elim"
+
 
        | WTREE_EQ => "wtree-eq"
        | WTREE_MEM_EQ => "wtree-mem-eq"

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -116,10 +116,35 @@ struct
        | SUCC_EQ $ _ => ax
        | NATREC_EQ $ _ => ax
 
+       | CONTAINER_EQ $ _ => ax
+       | CONTAINER_MEM_EQ $ _ => ax
+       | CONTAINER_ELIM $ #[R, xyD] =>
+           let
+             val v = Variable.named "v"
+           in
+             xyD // (`> DOM $$ #[R]) // (`> LAM $$ #[v \\ (`> PROJ $$ #[R, ``v])])
+           end
+
+       | EXTENSION_EQ $ _ => ax
+       | EXTEND_EQ $ _ => ax
+       | EXTENSION_ELIM $ #[R, xyD] =>
+           let
+             val v = Variable.named "v"
+           in
+             xyD // (`> DOM $$ #[R]) // (`> LAM $$ #[v \\ (`> PROJ $$ #[R, ``v])])
+           end
+
+       | NEIGH_EQ $ _ => ax
+       | NEIGH_NIL_EQ $ _ => ax
+       | NEIGH_SNOC_EQ $ _ => ax
+       | NEIGH_IND_EQ $ _ => ax
+       | NEIGH_ELIM $ #[N,nilCase,snocCase] =>
+           `> NEIGH_IND $$ #[N, extract nilCase, extract snocCase]
+
        | WTREE_EQ $ _ => ax
        | WTREE_MEM_EQ $ _ => ax
        | WTREE_REC_EQ $ _ => ax
-       | WTREE_INTRO $ #[s,_,xE] => `> SUP $$ #[s, extract xE]
+       | WTREE_INTRO $ #[D] => `> SUP $$ #[extract D]
        | WTREE_ELIM $ #[z, xyzD] => `> WTREE_REC $$ #[z, extract xyzD]
 
        | HYP_EQ $ _ => ax

--- a/src/refiner/level_solver.fun
+++ b/src/refiner/level_solver.fun
@@ -84,6 +84,7 @@ struct
   fun mapLevel f theta =
     case C.`<? theta of
          SOME (UNIV k) => C.`> (UNIV (Level.subst f k))
+       | SOME (CONTAINER k) => C.`> (CONTAINER (Level.subst f k))
        | _ =>
            (case D.`<? theta of
                  SOME (UNIV_EQ k) => D.`> (UNIV_EQ (Level.subst f k))
@@ -92,6 +93,7 @@ struct
   fun getLevelParameter theta =
     case C.`<? theta of
          SOME (UNIV k) => SOME k
+       | SOME (CONTAINER k) => SOME k
        | _ =>
            (case D.`<? theta of
                  SOME (UNIV_EQ k) => SOME k
@@ -100,6 +102,7 @@ struct
   fun eqModLevel (theta, theta') =
     case (C.`<? theta, C.`<? theta') of
          (SOME (UNIV _), SOME (UNIV _)) => true
+       | (SOME (CONTAINER _), SOME (CONTAINER _)) => true
        | _ =>
            (case (D.`<? theta, D.`<? theta') of
                  (SOME (UNIV_EQ _), SOME (UNIV_EQ _)) => true

--- a/src/refiner/refiner.fun
+++ b/src/refiner/refiner.fun
@@ -67,6 +67,10 @@ struct
     structure AtomRules = AtomRules(Utils)
     structure CEqRules = CEqRules(Utils)
     structure ApproxRules = ApproxRules(Utils)
+
+    structure ContainerRules = ContainerRules(Utils)
+    structure ContainerExtensionRules = ContainerExtensionRules(Utils)
+    structure NeighborhoodRules = NeighborhoodRules(Utils)
     structure WTreeRules = WTreeRules(Utils)
 
     (* BHyp gets its own special functor because it depends

--- a/src/refiner/refiner.sig
+++ b/src/refiner/refiner.sig
@@ -106,6 +106,22 @@ sig
       where type tactic = tactic
       where type hyp = hyp
 
+    structure ContainerRules : CONTAINER_RULES
+      where type tactic = tactic
+      where type hyp = hyp
+      where type name = name
+
+    structure ContainerExtensionRules : CONTAINER_EXTENSION_RULES
+      where type tactic = tactic
+      where type hyp = hyp
+      where type name = name
+
+    structure NeighborhoodRules : NEIGHBORHOOD_RULES
+      where type tactic = tactic
+      where type term = term
+      where type hyp = hyp
+      where type name = name
+
     structure WTreeRules : WTREE_RULES
       where type tactic = tactic
       where type term = term

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -121,7 +121,7 @@ struct
        ORELSE CEqRefl
        ORELSE ApproxRules.Refl
        ORELSE BaseRules.Intro
-       ORELSE_LAZY (fn _ => WTreeRules.Intro (valOf term, freshVariable))
+       ORELSE WTreeRules.Intro
        ORELSE
        (if not invertible then
             CEqRules.Struct
@@ -233,6 +233,9 @@ struct
         ORELSE_LAZY (fn _ => BaseRules.ElimEq (target, listAt (names, 0)))
         ORELSE_LAZY (fn _ => PlusRules.Elim (target, twoNames))
         ORELSE_LAZY (fn _ => ProdRules.Elim (target, twoNames))
+        ORELSE_LAZY (fn _ => ContainerRules.Elim (target, twoNames))
+        ORELSE_LAZY (fn _ => ContainerExtensionRules.Elim (target, twoNames))
+        ORELSE_LAZY (fn _ => NeighborhoodRules.Elim (target, threeNames))
         ORELSE_LAZY (fn _ => FunRules.Elim (target, valOf term, twoNames))
         ORELSE_LAZY (fn _ => ISectRules.Elim (target, valOf term, twoNames))
         ORELSE ImageRules.EqInd (target, fourNames)
@@ -273,10 +276,16 @@ struct
         ORELSE ISectRules.Eq freshVariable
         ORELSE ProdRules.Eq freshVariable
         ORELSE SubsetRules.Eq freshVariable
-        ORELSE ProdRules.PairEq (freshVariable, level)
+        ORELSE ProdRules.MemEq (freshVariable, level)
         ORELSE FunRules.LamEq (freshVariable, level)
         ORELSE SubsetRules.MemberEq (freshVariable, level)
         ORELSE ISectRules.MemberEq (freshVariable, level)
+        ORELSE ContainerRules.Eq
+        ORELSE ContainerRules.MemEq
+        ORELSE ContainerExtensionRules.Eq
+        ORELSE ContainerExtensionRules.MemEq
+        ORELSE NeighborhoodRules.Eq
+        ORELSE NeighborhoodRules.MemEq level
         ORELSE_LAZY (fn _ =>
           case terms of
                [M, N] => ISectRules.MemberCaseEq (SOME M, N)
@@ -304,6 +313,7 @@ struct
                                                         List.nth (terms, 2),
                                                         take3 names))
                ORELSE ProdRules.SpreadEq (listAt (terms, 0), listAt (terms, 1), take3 names)
+               ORELSE NeighborhoodRules.IndEq (listAt (terms, 0), listAt (terms, 1), take3 names)
                ORELSE FunRules.ApEq (listAt (terms, 0))
          else
              ID)

--- a/src/refiner/rules/container.fun
+++ b/src/refiner/rules/container.fun
@@ -1,0 +1,65 @@
+functor ContainerRules(Utils : RULES_UTIL) : CONTAINER_RULES =
+struct
+  open Utils
+  open Goal Sequent Syntax CttCalculus Derivation
+
+  infix $ \ BY ^!
+  infix 3 >>
+  infix 2 |:
+  infix 8 $$ // @@
+  infixr 8 \\
+
+  fun Eq (_ |: H >> P) =
+    let
+      val #[cont1,cont2,univ] = P ^! EQ
+      val (CONTAINER i, _) = asApp cont1
+      val (CONTAINER j, _) = asApp cont2
+      val true = i = j
+      val (UNIV k, _) = asApp univ
+      val true = k = Level.succ i
+    in
+      [] BY mkEvidence CONTAINER_EQ
+    end
+
+  fun MemEq (_ |: H >> P) =
+    let
+      val #[mkcont1, mkcont2, cont] = P ^! EQ
+      val (CONTAINER i, _) = asApp cont
+      val #[dom, xProj] = mkcont1 ^! MAKE_CONTAINER
+      val #[dom', yProj'] = mkcont1 ^! MAKE_CONTAINER
+      val (H', x, proj) = ctxUnbind (H, dom, xProj)
+      val proj' = yProj' // ``x
+      val univ = C.`> (UNIV i) $$ #[]
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[dom, dom', univ]
+      , MAIN |: H' >> C.`> EQ $$ #[proj, proj', univ]
+      ] BY (fn [D, E] => D.`> CONTAINER_MEM_EQ $$ #[D, x \\ E]
+             | _ => raise Refine)
+    end
+
+  fun Elim (hyp, onames) (_ |: H >> P) =
+    let
+      val z = eliminationTarget hyp (H >> P)
+      val (CONTAINER i, _) = asApp (Context.lookup H z)
+      val (s, t) =
+        case onames of
+             SOME names => names
+           | NONE =>
+               (Context.fresh (H, Variable.named "s"),
+                Context.fresh (H, Variable.named "t"))
+
+      val p = Context.fresh (H, Variable.named "p")
+      val st = C.`> MAKE_CONTAINER $$ #[``s, p \\ (C.`> AP $$ #[``t, ``p])]
+      val univ = C.`> (UNIV i) $$ #[]
+      val J =
+        Context.empty
+          @@ (s, univ)
+          @@ (t, C.`> FUN $$ #[``s, p \\ univ])
+      val H' = ctxSubst (Context.interposeAfter H (z, J)) st z
+    in
+      [ MAIN |: H' >> subst st z P
+      ] BY (fn [D] => D.`> CONTAINER_ELIM $$ #[``z, s \\ (t \\ D)]
+             | _ => raise Refine)
+    end
+
+end

--- a/src/refiner/rules/container.sig
+++ b/src/refiner/rules/container.sig
@@ -1,0 +1,10 @@
+signature CONTAINER_RULES =
+sig
+  type tactic
+  type hyp
+  type name
+
+  val Eq : tactic
+  val MemEq : tactic
+  val Elim : hyp * (name * name) option -> tactic
+end

--- a/src/refiner/rules/container_extension.fun
+++ b/src/refiner/rules/container_extension.fun
@@ -1,0 +1,63 @@
+functor ContainerExtensionRules(Utils : RULES_UTIL) : CONTAINER_EXTENSION_RULES =
+struct
+  open Utils
+  open Goal Sequent Syntax CttCalculus Derivation
+
+  infix $ \ BY ^!
+  infix 3 >>
+  infix 2 |:
+  infix 8 $$ // @@
+  infixr 8 \\
+
+  fun Eq (_ |: H >> P) =
+    let
+      val #[ext1, ext2, univ] = P ^! EQ
+      val (UNIV i, _) = asApp univ
+      val #[C1, X1] = ext1 ^! EXTENSION
+      val #[C2, X2] = ext2 ^! EXTENSION
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[C1, C2, C.`> (CONTAINER i) $$ #[]]
+      , MAIN |: H >> C.`> EQ $$ #[X1, X2, univ]
+      ] BY mkEvidence EXTENSION_EQ
+    end
+
+  fun MemEq (_ |: H >> P) =
+    let
+      val #[extend1, extend2, extension] = P ^! EQ
+      val #[C, X] = extension ^! EXTENSION
+      val #[d1, pX1] = extend1 ^! EXTEND
+      val #[d2, qX2] = extend1 ^! EXTEND
+      val dom = C.`> DOM $$ #[C]
+      val (H', p, X1) = ctxUnbind (H, dom, pX1)
+      val X2 = qX2 // ``p
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[d1, d2, dom]
+      , MAIN |: H' >> C.`> EQ $$ #[X1, X2, X]
+      ] BY (fn [D, E] => D.`> EXTEND_EQ $$ #[D, p \\ E]
+             | _ => raise Refine)
+    end
+
+  fun Elim (hyp, onames) (_ |: H >> P) =
+    let
+      val z = eliminationTarget hyp (H >> P)
+      val #[F, X] = Context.lookup H z ^! EXTENSION
+      val (s, t) =
+        case onames of
+             SOME names => names
+           | NONE =>
+               (Context.fresh (H, Variable.named "s"),
+                Context.fresh (H, Variable.named "t"))
+
+      val p = Context.fresh (H, Variable.named "p")
+      val st = C.`> EXTEND $$ #[``s, p \\ (C.`> AP $$ #[``t, ``p])]
+      val J =
+        Context.empty
+          @@ (s, C.`> DOM $$ #[F])
+          @@ (t, C.`> FUN $$ #[C.`> PROJ $$ #[F, ``s], p \\ X])
+      val H' = ctxSubst (Context.interposeAfter H (z, J)) st z
+    in
+      [ MAIN |: H' >> subst st z P
+      ] BY (fn [D] => D.`> EXTENSION_ELIM $$ #[``z, s \\ (t \\ D)]
+             | _ => raise Refine)
+    end
+end

--- a/src/refiner/rules/container_extension.sig
+++ b/src/refiner/rules/container_extension.sig
@@ -1,0 +1,10 @@
+signature CONTAINER_EXTENSION_RULES =
+sig
+  type tactic
+  type hyp
+  type name
+
+  val Eq : tactic
+  val MemEq : tactic
+  val Elim : hyp * (name * name) option -> tactic
+end

--- a/src/refiner/rules/neighborhood.fun
+++ b/src/refiner/rules/neighborhood.fun
@@ -1,0 +1,152 @@
+functor NeighborhoodRules(Utils : RULES_UTIL) : NEIGHBORHOOD_RULES =
+struct
+  open Utils
+  open Goal Sequent Syntax CttCalculus Derivation
+
+  infix $ \ BY ^!
+  infix 3 >>
+  infix 2 |:
+  infix 8 $$ // @@
+  infixr 8 \\
+
+  fun Eq (_ |: H >> P) =
+    let
+      val #[neigh1, neigh2, univ] = P ^! EQ
+      val (UNIV i, _) = asApp univ
+      val #[F] = neigh1 ^! NEIGH
+      val #[G] = neigh2 ^! NEIGH
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[F, G, C.`> (CONTAINER i) $$ #[]]
+      ] BY mkEvidence NEIGH_EQ
+    end
+
+
+  fun NilEq k (_ |: H >> P) =
+    let
+      val #[ax1, ax2, neigh] = P ^! EQ
+      val #[F] = neigh ^! NEIGH
+      val #[] = ax1 ^! AX
+      val #[] = ax2 ^! AX
+    in
+      [ AUX |: H >> C.`> MEM $$ #[F, C.`> (CONTAINER k) $$ #[]]
+      ] BY mkEvidence NEIGH_NIL_EQ
+    end
+
+  fun SnocEq k (_ |: H >> P) =
+    let
+      val #[ext1, ext2, neigh] = P ^! EQ
+      val #[F] = neigh ^! NEIGH
+      val #[U, rE] = ext1 ^! EXTEND
+      val #[U', rE'] = ext2 ^! EXTEND
+      val (H', r, E) = ctxUnbind (H, C.`> REFINEMENT $$ #[F, U], rE)
+      val E'= rE' // ``r
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[U, U', neigh]
+      , MAIN |: H' >> C.`> EQ $$ #[E, E', C.`> DOM $$ #[F]]
+      ] BY (fn [D, E] => D.`> NEIGH_SNOC_EQ $$ #[D, r \\ E]
+             | _ => raise Refine)
+    end
+
+  structure Tacticals = Tacticals (Lcf)
+  open Tacticals infix ORELSE
+
+  fun MemEq ok (goal as _ |: H >> P) =
+    let
+      val #[_, _, neigh] = P ^! EQ
+      val #[F] = neigh ^! NEIGH
+      val k = case ok of SOME k => k | NONE => inferLevel (H, F)
+    in
+      (NilEq k ORELSE SnocEq k) goal
+    end
+
+  fun Elim (hyp, onames) (_ |: H >> C) =
+    let
+      val z = eliminationTarget hyp (H >> C)
+      val #[F] = Context.lookup H z ^! NEIGH
+      val (u,e,ih) =
+        case onames of
+             SOME names => names
+           | NONE =>
+               (Context.fresh (H, Variable.named "u"),
+                Context.fresh (H, Variable.named "e"),
+                Context.fresh (H, Variable.named "ih"))
+
+      val r = Context.fresh (H, Variable.named "r")
+      val ax = C.`> AX $$ #[]
+      val snocu = C.`> EXTEND $$ #[``u, r \\ (C.`> AP $$ #[``e,``r])]
+
+      val J =
+        Context.empty
+          @@ (u, C.`> NEIGH $$ #[F])
+          @@ (e, C.`> FUN $$ #[C.`> REFINEMENT $$ #[F, ``u], r \\ (C.`> DOM $$ #[F])])
+          @@ (ih, subst (``u) z C)
+
+      val H' = Context.mapAfter u (Syntax.subst snocu z) (Context.interposeAfter H (z, J))
+    in
+      [ MAIN |: ctxSubst H ax z >> subst ax z C
+      , MAIN |: H' >> subst snocu z C
+      ] BY (fn [D,E] => D.`> NEIGH_ELIM $$ #[``z, D, u \\ (e \\ (ih \\ E))]
+             | _ => raise Refine)
+    end
+
+  fun IndEq (ozC, oF, onames) (_ |: H >> P) =
+    let
+      val #[ind1, ind2, A] = P ^! EQ
+      val #[N, nilCase, snocCase] = ind1 ^! NEIGH_IND
+      val #[N', nilCase', snocCase'] = ind1 ^! NEIGH_IND
+
+      val F =
+        case oF of
+             NONE =>
+             let
+               val #[F] = typeLub H (inferType (H, N)) (inferType (H, N')) ^! NEIGH
+             in
+               F
+             end
+           | SOME F=> Context.rebind H F
+
+      val neigh = C.`> NEIGH $$ #[F]
+
+      val zC =
+        (case ozC of
+             NONE =>
+             let
+               val z = Context.fresh (H, Variable.named "z")
+               val H' = H @@ (z, neigh)
+               val Cz =
+                 typeLub H'
+                   (inferType (H', C.`> NEIGH_IND $$ #[``z, nilCase, snocCase]))
+                   (inferType (H', C.`> NEIGH_IND $$ #[``z, nilCase', snocCase']))
+             in
+               z \\ Cz
+             end
+           | SOME zC => Context.rebind H zC)
+        handle _ => Variable.named "z" \\ A
+
+      val (u,e,ih) =
+        case onames of
+             SOME names => names
+           | NONE =>
+               (Context.fresh (H, Variable.named "u"),
+                Context.fresh (H, Variable.named "e"),
+                Context.fresh (H, Variable.named "ih"))
+
+      val r = Context.fresh (H, Variable.named "r")
+      val neigh = C.`> NEIGH $$ #[F]
+      val H' =
+        H @@ (u, neigh)
+          @@ (e, C.`> FUN $$ #[C.`> REFINEMENT $$ #[F, ``u], r \\ (C.`> DOM $$ #[F])])
+          @@ (ih, zC // ``u)
+
+      val snocSubst = (snocCase // ``u) // ``e // ``ih
+      val snocSubst' = (snocCase' // ``u) // ``e // ``ih
+      val snocu = C.`> EXTEND $$ #[``u, r \\ (C.`> AP $$ #[``e,``r])]
+    in
+      [ MAIN |: H >> C.`> EQ $$ #[N, N', neigh]
+      , MAIN |: H >> C.`> EQ $$ #[nilCase, nilCase', zC // (C.`> AX $$ #[])]
+      , MAIN |: H' >> C.`> EQ $$ #[snocSubst, snocSubst', zC // snocu]
+      ] BY (fn [N, D, E] => D.`> NEIGH_IND_EQ $$ #[N, D, u \\ e \\ ih \\ E]
+             | _ => raise Refine)
+    end
+end
+

--- a/src/refiner/rules/neighborhood.sig
+++ b/src/refiner/rules/neighborhood.sig
@@ -1,0 +1,13 @@
+signature NEIGHBORHOOD_RULES =
+sig
+  type tactic
+  type term
+  type hyp
+  type name
+
+  val Eq : tactic
+  val MemEq : Level.t option -> tactic
+
+  val Elim : hyp * (name * name * name) option -> tactic
+  val IndEq : term option * term option * (name * name * name) option -> tactic
+end

--- a/src/refiner/rules/prod.fun
+++ b/src/refiner/rules/prod.fun
@@ -60,7 +60,7 @@ struct
              | _ => raise Refine)
     end
 
-  fun PairEq (oz, ok) (_ |: H >> P) =
+  fun MemEq (oz, ok) (_ |: H >> P) =
     let
       val #[pair, pair', prod] = P ^! EQ
       val #[M, N] = pair ^! PAIR

--- a/src/refiner/rules/prod.sig
+++ b/src/refiner/rules/prod.sig
@@ -23,6 +23,6 @@ sig
    * H, z : (Σx:A)B[x], s : A, t : B[s], H'[<s,t>] >> P[<s,t>]
    *)
   val Elim : hyp * (name * name) option -> tactic
-  val PairEq : name option * Level.t option -> tactic
+  val MemEq : name option * Level.t option -> tactic
   val SpreadEq : term option * term option * (name * name * name) option -> tactic
 end

--- a/src/refiner/rules/utils.fun
+++ b/src/refiner/rules/utils.fun
@@ -173,6 +173,7 @@ struct
     fun inferLevel (H, P) =
       case project P of
            UNIV l $ _ => Level.succ l
+         | CONTAINER i $ #[] => Level.succ i
          | FUN $ #[A, xB] =>
            let
              val (H', x, B) = ctxUnbind (H, A, xB)

--- a/src/refiner/rules/wtree.sig
+++ b/src/refiner/rules/wtree.sig
@@ -9,6 +9,6 @@ sig
   val MemEq : tactic
   val RecEq : term option * term -> tactic
 
-  val Intro : term * name option -> tactic
+  val Intro : tactic
   val Elim : hyp * (name * name * name) option -> tactic
 end

--- a/src/refiner/small_step.fun
+++ b/src/refiner/small_step.fun
@@ -45,6 +45,29 @@ struct
         PAIR $ #[L, R] => (E // L) // R
       | _ => raise Stuck (SPREAD $$ #[P, E])
 
+  fun stepDomBeta F =
+    case project F of
+        MAKE_CONTAINER $ #[dom, xProj] => dom
+      | EXTEND $ #[dom, xProj] => dom
+      | _ => raise Stuck (DOM $$ #[F])
+
+  fun stepProjBeta (F, d) =
+    case project F of
+        MAKE_CONTAINER $ #[dom, xProj] => xProj // d
+      | EXTEND $ #[dom, xProj] => xProj // d
+      | _ => raise Stuck (PROJ $$ #[F, d])
+
+  fun stepRefinementBeta (F, u) =
+    case project u of
+        AX $ #[] => UNIT $$ #[]
+      | EXTEND $ #[v, pE] =>
+          let
+            val s = Variable.named "s"
+          in
+            FUN $$ #[REFINEMENT $$ #[F, v], s \\ PROJ $$ #[F, pE // ``s]]
+          end
+      | _ => raise Stuck (REFINEMENT $$ #[F, u])
+
   fun stepApBeta (F, A) =
     case project F of
         LAM $ #[B] => B // A
@@ -61,6 +84,16 @@ struct
          ZERO $ #[] => Z
        | SUCC $ #[N] => (xyS // N) // (NATREC $$ #[N, Z, xyS])
        | _ => raise Stuck (NATREC $$ #[M, Z, xyS])
+
+  fun stepNeighIndBeta (M, Z, xypS) =
+    case project M of
+         AX $ #[] => Z
+       | EXTEND $ #[U, rE] =>
+           let
+           in
+             xypS // U // (LAM $$ #[rE]) // (NEIGH_IND $$ #[U, Z, xypS])
+           end
+       | _ => raise Stuck (NEIGH_IND $$ #[M, Z, xypS])
 
   fun stepWTreeRecBeta (M, xyzD) =
     case project M of
@@ -113,6 +146,10 @@ struct
       | CEQUAL $ _ => CANON
       | WTREE $ _ => CANON
       | SUP $ _ => CANON
+      | CONTAINER _ $ _ => CANON
+      | MAKE_CONTAINER $ _ => CANON
+      | EXTEND $ _ => CANON
+      | NEIGH $ _ => CANON
       | AP $ #[L, R] =>
           (case step L of
               STEP L' => STEP (AP $$ #[L', R])
@@ -122,6 +159,21 @@ struct
           (case step P of
               STEP P' => STEP (SPREAD $$ #[P', E])
             | CANON => STEP (stepSpreadBeta (P, E))
+            | NEUTRAL => NEUTRAL)
+      | DOM $ #[F] =>
+          (case step F of
+              STEP F' => STEP (DOM $$ #[F'])
+            | CANON => STEP (stepDomBeta F)
+            | NEUTRAL => NEUTRAL)
+      | PROJ $ #[F, d] =>
+          (case step F of
+              STEP F' => STEP (PROJ $$ #[F', d])
+            | CANON => STEP (stepProjBeta (F, d))
+            | NEUTRAL => NEUTRAL)
+      | REFINEMENT $ #[F, u] =>
+          (case step u of
+              STEP u' => STEP (REFINEMENT $$ #[F, u'])
+            | CANON => STEP (stepRefinementBeta (F, u))
             | NEUTRAL => NEUTRAL)
       | FIX $ #[F] =>
           (case step F of
@@ -138,6 +190,11 @@ struct
               STEP S' => STEP (DECIDE $$ #[S', L, R])
             | CANON => STEP (stepDecideBeta (S, L, R))
             | NEUTRAL => NEUTRAL)
+      | NEIGH_IND $ #[M, Z, xypS] =>
+          (case step M of
+                STEP M' => STEP (NEIGH_IND $$ #[M', Z, xypS])
+              | CANON => STEP (stepNeighIndBeta (M, Z, xypS))
+              | NEUTRAL => NEUTRAL)
       | NATREC $ #[M, Z, xyS] =>
           (case step M of
                 STEP M' => STEP (NATREC $$ #[M', Z, xyS])

--- a/src/refiner/sources.cm
+++ b/src/refiner/sources.cm
@@ -71,6 +71,12 @@ group is
   rules/bhyp.fun
   rules/wtree.sig
   rules/wtree.fun
+  rules/container.sig
+  rules/container.fun
+  rules/container_extension.sig
+  rules/container_extension.fun
+  rules/neighborhood.sig
+  rules/neighborhood.fun
 
   refiner.fun
   refiner.sig

--- a/src/syntax/jonprl_language_def.sml
+++ b/src/syntax/jonprl_language_def.sml
@@ -10,7 +10,7 @@ struct
   val nestedComments = true
 
   val fancyChars =
-      "-'_ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσΤτΥυΦφΧχΨψΩω¬⊗⊕∫+-!@#$%^&*⇓↓↼⇀↽⇁↿↾⇃⇂≼≅≡≈~⇔∩∪⋃⋂`◃?"
+      "-'_ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσΤτΥυΦφΧχΨψΩω¬⊗⊕∫+-!@#$%^&*⇓↓↼⇀↽⇁↿↾⇃⇂≼≅≡≈~⇔∩∪⋃⋂`◃?♮"
 
   val identLetter = letter || oneOf (String.explode fancyChars) || digit
   val identStart = identLetter

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -21,7 +21,9 @@ struct
     | NAT | ZERO | SUCC | NATREC
     | CEQUAL | APPROX | BASE
     | ATOM | TOKEN of string | MATCH_TOKEN of string vector | TEST_ATOM
-    | CONTAINER | MAKE_CONTAINER | SHAPE | REFINEMENT | WTREE | SUP | WTREE_REC
+    | CONTAINER of Level.t | MAKE_CONTAINER | DOM | PROJ | EXTEND | EXTENSION
+    | NEIGH | REFINEMENT | NEIGH_IND | CONTAINER_NEIGH
+    | WTREE | SUP | WTREE_REC
     | SO_APPLY
 
   local
@@ -46,7 +48,9 @@ struct
        NAT, ZERO, SUCC, NATREC,
        ATOM, TOKEN "token",
        CEQUAL, APPROX, BASE,
-       CONTAINER, MAKE_CONTAINER, SHAPE, REFINEMENT, WTREE, SUP, WTREE_REC,
+       CONTAINER i, MAKE_CONTAINER, DOM, PROJ, NEIGH, REFINEMENT, CONTAINER_NEIGH, NEIGH_IND,
+       EXTENSION, EXTEND,
+       WTREE, SUP, WTREE_REC,
        SO_APPLY]
   end
 
@@ -104,13 +108,19 @@ struct
        | TEST_ATOM => #[0,0,0,0]
        | SO_APPLY => #[0,0]
 
-       | CONTAINER => #[]
-       | WTREE => #[0]
-       | SUP => #[0,1]
-       | WTREE_REC => #[0,3]
+       | CONTAINER _ => #[]
        | MAKE_CONTAINER => #[0,1]
-       | SHAPE => #[0]
+       | DOM => #[0]
+       | PROJ => #[0,0]
+       | EXTEND => #[0,1]
+       | EXTENSION => #[0,0]
+       | NEIGH => #[0]
        | REFINEMENT => #[0,0]
+       | NEIGH_IND => #[0,0,3]
+       | CONTAINER_NEIGH => #[0]
+       | WTREE => #[0]
+       | SUP => #[0]
+       | WTREE_REC => #[0,3]
 
   fun toString theta =
     case theta of
@@ -166,13 +176,19 @@ struct
              ^ "}"
            end
        | TEST_ATOM => "test_atom"
-       | CONTAINER => "container"
+       | CONTAINER i => "container{" ^ Level.toString i ^ "}"
        | MAKE_CONTAINER => "make-container"
-       | SHAPE => "shape"
-       | REFINEMENT => "refinement"
+       | DOM => "dom"
+       | PROJ => "proj"
        | WTREE => "wtree"
        | WTREE_REC => "wtree-rec"
        | SUP => "sup"
+       | EXTEND => "extend"
+       | EXTENSION => "extension"
+       | NEIGH => "neigh"
+       | REFINEMENT => "refinement"
+       | NEIGH_IND => "neigh-ind"
+       | CONTAINER_NEIGH => "neighborhoods"
        | SO_APPLY => "so_apply"
 end
 
@@ -197,6 +213,11 @@ struct
         >> braces Level.parse
         wth UNIV
 
+    val parseContainer : t charParser =
+      string "container"
+        >> braces Level.parse
+        wth CONTAINER
+
     fun choices xs =
       foldl (fn (p, p') => p || try p') (fail "unknown operator") xs
 
@@ -206,6 +227,7 @@ struct
     val parseOperator : t charParser =
       choices
         [parseUniv,
+         parseContainer,
          parseToken,
          string "atom" return ATOM,
          string "base" return BASE,
@@ -249,10 +271,15 @@ struct
          string "zero" return ZERO,
          string "succ" return SUCC,
          string "natrec" return NATREC,
-         string "container" return CONTAINER,
          string "make-container" return MAKE_CONTAINER,
-         string "shape" return SHAPE,
+         string "extend" return EXTEND,
+         string "extension" return EXTENSION,
+         string "dom" return DOM,
+         string "proj" return PROJ,
+         string "neigh" return NEIGH,
          string "refinement" return REFINEMENT,
+         string "neigh-ind" return NEIGH_IND,
+         string "neighborhoods" return CONTAINER_NEIGH,
          string "wtree" return WTREE,
          string "wtree-rec" return WTREE_REC,
          string "sup" return SUP]


### PR DESCRIPTION
- replaced a number of abstractions with primitives + rules, since they are nicer to work with
- added an operator on families that takes a container to its container of finite neighborhoods

Neighborhoods approximate non-wellfounded trees in the same way that lists approximate choice sequences; in fact, the neighborhoods for the container `x:Nat <: Unit` are precisely lists, and the non-wellfounded trees of this container are precisely Brouwer's choice sequences, namely, streams of natural numbers.

The point of all this stuff is to experiment with Brouwerian mathematics in a more general setting (see this blog post: http://www.jonmsterling.com/posts/2015-07-05-spreads-fans-and-bars-over-containers.html).

resolves #220 
