### PR TITLE
Added stopgap fix for #214

### DIFF
--- a/src/refiner/pattern_compiler.fun
+++ b/src/refiner/pattern_compiler.fun
@@ -59,6 +59,9 @@ struct
       end
      | _ => ([], M)
 
+  (* Undo all the second order applications around some term M,
+   * this is like unbindAll but for asInstantiate
+   *)
   fun unappAll M =
     case asInstantiate M of
         SOME (M', A) =>
@@ -69,6 +72,10 @@ struct
         end
       | NONE => ([], M)
 
+  (* Take a list of terms and return the list of underlying variables.
+   * Raise an invalid template exception if given anything other
+   * than variables.
+   *)
   fun asVars Ms =
     List.map (fn M =>
                 case out M of
@@ -105,7 +112,6 @@ struct
                      case out patTerm' of
                          `x => x
                        | _ => raise InvalidTemplate
-
                    (* Pattern and term must bind the same number of
                     * variables
                     *)
@@ -114,7 +120,7 @@ struct
                        then ()
                        else raise InvalidTemplate
                    (* A higher order pattern must bind a bunch of
-                    * vars and immediately instantiate them
+                    * vars and immediately instantiate them in order
                     *)
                    val () =
                      if EQUAL = List.collate Variable.compare

--- a/src/refiner/pattern_compiler.fun
+++ b/src/refiner/pattern_compiler.fun
@@ -26,7 +26,7 @@ struct
     datatype 'a point =
         GLOBAL of 'a
         (* A "global" point is the definition of a first-order variable *)
-      | LOCAL of 'a -> 'a
+      | LOCAL of 'a list -> 'a
         (* A "local" point is the definition of a second-order variable *)
 
     type 'a chart = 'a point dict
@@ -45,6 +45,37 @@ struct
   structure AbtUtil = AbtUtil(PatternTerm)
   open AbtUtil
   infix $ $$ \ \\
+
+  (* Undo all the bindings in M and return the new variables
+   * as a list along with the term under all the binders
+   *)
+  fun unbindAll M =
+    case out M of
+      x \ M' =>
+      let
+        val (xs, M'') = unbindAll M'
+      in
+        (x :: xs, M'')
+      end
+     | _ => ([], M)
+
+  fun unappAll M =
+    case asInstantiate M of
+        SOME (M', A) =>
+        let
+          val (xs, M'') = unappAll M'
+        in
+          (xs @ [A], M'')
+        end
+      | NONE => ([], M)
+
+  fun asVars Ms =
+    List.map (fn M =>
+                case out M of
+                    `x => x
+                  | _ => raise InvalidTemplate)
+             Ms
+
 
   fun computeChart (pat, N) : term Chart.chart =
     case (out pat, out N) of
@@ -66,16 +97,39 @@ struct
                   * right hand side shall be y.E. So we insert its second order
                   * substitution into the chart, i.e. Z !-> [y/x]F. *)
                | go (x \ M) (y \ N) R =
-                 (case PatternTerm.asInstantiate M of
-                       SOME (F,X) =>
-                         (case out F of
-                               `f =>
-                               if eq (``x,X) then
-                                 Chart.insert R f (Chart.LOCAL (fn Z => subst Z y N))
-                               else
-                                 raise InvalidTemplate
-                             | _ => raise InvalidTemplate)
-                     | NONE => raise InvalidTemplate)
+                 let
+                   val (patVars, patTerm) = unbindAll (x \\ M)
+                   val (termVars, termTerm) = unbindAll (y \\ N)
+                   val (patArgs, patTerm') = unappAll patTerm
+                   val patVar =
+                     case out patTerm' of
+                         `x => x
+                       | _ => raise InvalidTemplate
+
+                   (* Pattern and term must bind the same number of
+                    * variables
+                    *)
+                   val () =
+                       if List.length patVars = List.length termVars
+                       then ()
+                       else raise InvalidTemplate
+                   (* A higher order pattern must bind a bunch of
+                    * vars and immediately instantiate them
+                    *)
+                   val () =
+                     if EQUAL = List.collate Variable.compare
+                                             (patVars, asVars patArgs)
+                     then ()
+                     else raise InvalidTemplate
+
+                   fun computeSubst terms =
+                     List.foldl (fn ((v, t), e) => subst t v e)
+                                termTerm
+                                (ListPair.zipEq (termVars, terms))
+                 in
+                   Chart.insert R patVar (Chart.LOCAL computeSubst)
+                 end
+
                | go _ _ _ = raise InvalidTemplate
            in
              foldl (fn ((e,e'), R') => go (out e) (out e') R') Chart.empty zipped
@@ -97,8 +151,8 @@ struct
                let
                  val _ = if Operator.eq (Pop, Mop) then () else raise Conv
                  fun go H M =
-                   case PatternTerm.asInstantiate M of
-                        NONE =>
+                   case unappAll M of
+                        ([], _) =>
                           (* If we have not reached a second-order application,
                            * then proceed structurally *)
                           (case out M of
@@ -112,13 +166,13 @@ struct
                                    ``x
                                  else
                                    Chart.lookupGlobal chart x handle _ => ``x)
-                      | SOME (F,X) =>
+                      | (Xs, F) =>
                            (* If we have got a second-order application, then
                             * apply its substitution *)
                           let
                             val `f = out F
                           in
-                            Chart.lookupLocal chart f X
+                            Chart.lookupLocal chart f Xs
                           end
                in
                  go Set.empty definiens


### PR DESCRIPTION
So #214 noted a pretty annoying bug if you want to define operators with arities greater than 1. This PR fixes the bug, but not the general problem. You can now define patterns of like this

```
 Operator uhoh : (2).
 [uhoh(x.y.F[x][y])] =def= [F[unit][unit]].
```

which caused trouble before. However it only works if those higher arity operands bind `n` variables, then apply them in the order that they were bound. Anything else currently will fail to unfold.

This doesn't cause any loss of functionality so I think it's reasonable to merge this in to fix the bug until I get around to properly understanding higher order matching. Honestly though it may be sufficient just to stick with this.
