### PR TITLE
Simplified inconsistent DecideEq rule

### DIFF
--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -308,9 +308,8 @@ struct
         ORELSE
         (if not invertible then
              NatRules.RecEq (listAt (terms, 0), take2 names)
-               ORELSE_LAZY (fn _ => PlusRules.DecideEq (List.nth (terms, 0))
-                                                       (List.nth (terms, 1),
-                                                        List.nth (terms, 2),
+               ORELSE_LAZY (fn _ => PlusRules.DecideEq (List.nth (terms, 0),
+                                                        List.nth (terms, 1),
                                                         take3 names))
                ORELSE ProdRules.SpreadEq (listAt (terms, 0), listAt (terms, 1), take3 names)
                ORELSE NeighborhoodRules.IndEq (listAt (terms, 0), listAt (terms, 1), take3 names)

--- a/src/refiner/rules/plus.fun
+++ b/src/refiner/rules/plus.fun
@@ -94,7 +94,7 @@ struct
              | _ => raise Refine)
     end
 
-  fun DecideEq C (A, B, x) (_ |: H >> P) =
+  fun DecideEq (A, B, x) (_ |: H >> P) =
     let
       val #[M, N, T] = P ^! EQ
       val #[M', sL, tR] = M ^! DECIDE
@@ -109,12 +109,10 @@ struct
                   @@ (eq, C.`> EQ $$ #[M', C.`> INL $$ #[``s], C.`> PLUS $$ #[A, B]])
       val H't = H @@ (t, B)
                   @@ (eq, C.`> EQ $$ #[M', C.`> INR $$ #[``t], C.`> PLUS $$ #[A, B]])
-      val C's = subst1 C (C.`> INL $$ #[``s])
-      val C't = subst1 C (C.`> INR $$ #[``t])
     in
       [ MAIN |: H >> C.`> EQ $$ #[M', N', C.`> PLUS $$ #[A, B]]
-      , MAIN |: H's >> C.`> EQ $$ #[subst1 sL (``s), subst1 sL' (``s), C's]
-      , MAIN |: H't >> C.`> EQ $$ #[subst1 tR (``t), subst1 tR' (``t), C't]
+      , MAIN |: H's >> C.`> EQ $$ #[subst1 sL (``s), subst1 sL' (``s), T]
+      , MAIN |: H't >> C.`> EQ $$ #[subst1 tR (``t), subst1 tR' (``t), T]
       ] BY (fn [EqM, EqL, EqR] =>
                D.`> DECIDE_EQ $$ #[EqM, eq \\ (s \\ EqR), eq \\ (t \\ EqL)]
              | _ => raise Refine)

--- a/src/refiner/rules/plus.sig
+++ b/src/refiner/rules/plus.sig
@@ -40,7 +40,5 @@ sig
    *    H >> A ∈ U{k}
    *)
   val InrEq : Level.t option -> tactic
-  val DecideEq : term
-                 -> (term * term * (name * name * name) option)
-                 -> tactic
+  val DecideEq : (term * term * (name * name * name) option) -> tactic
 end


### PR DESCRIPTION
This is one fix for #233. Instead of taking this `C` parameter we don't do that and instead just force the user to prove that each branch is equal at `T`.

This should be fine though because we give them this assumption of equality so in theory they can use that to vary `T` depending on what branch they're proving things in. 
