### PR TITLE
Correctly handle wildcards so that unification works with binders

### DIFF
--- a/src/refiner/rules/ceq.fun
+++ b/src/refiner/rules/ceq.fun
@@ -92,9 +92,10 @@ struct
              SOME xC =>
              let
                val fvs = List.map #1 (Context.listItems H)
-               val meta = Meta.convertFree fvs (xC // M)
-               val solution = Unify.unify (Meta.convertFree fvs (xC // M), Meta.convert P)
-               val xC = applySolution solution (Meta.convertFree fvs xC)
+               val meta = convertToPattern (H, xC // M)
+               val solution = Unify.unify (meta, Meta.convert P)
+               val x \ C = out xC
+               val xC = x \\ applySolution solution (P, convertToPattern (H, C))
                val _ = unify P (xC // M)
              in
                xC // N

--- a/src/refiner/rules/eq.fun
+++ b/src/refiner/rules/eq.fun
@@ -61,10 +61,11 @@ struct
       val #[M,N,A] = Context.rebind H eq ^! EQ
       val xC = Context.rebind H xC
 
-      val fvs = List.map #1 (Context.listItems H)
-      val meta = Meta.convertFree fvs (xC // M)
+      val meta = convertToPattern (H, xC // M)
       val solution = Unify.unify (meta, Meta.convert P)
-      val xC = applySolution solution (Meta.convertFree fvs xC)
+
+      val x \ C = out xC
+      val xC = x \\ applySolution solution (P, convertToPattern (H, C))
 
       val (H', x, C) = ctxUnbind (H, A, xC)
       val k = case ok of SOME k => k | NONE => inferLevel (H', C)

--- a/src/refiner/rules/utils.sig
+++ b/src/refiner/rules/utils.sig
@@ -68,7 +68,10 @@ sig
     where type t = MetaAbt.t
     where type var = MetaAbt.Variable.t
 
-  val applySolution : Unify.solution -> MetaAbt.t -> term
+  val applySolution : Unify.solution -> (term * MetaAbt.t) -> term
+
+  (* Correctly handles wild cards *)
+  val convertToPattern : Sequent.Context.context * term -> MetaAbt.t
 
   structure Context : CONTEXT
 

--- a/src/refiner/sources.cm
+++ b/src/refiner/sources.cm
@@ -1,6 +1,7 @@
 group is
   ../syntax/sources.cm
   $libs/sml-abt/abt.cm
+  $libs/sml-abt/vector-lib/vector-lib.cm
   $libs/cmlib/cmlib.cm
   $libs/sml-telescopes/telescopes.cm
   $libs/sml-lcf/lcf.cm

--- a/src/refiner/unify_sequent.fun
+++ b/src/refiner/unify_sequent.fun
@@ -63,7 +63,7 @@ struct
              (Context.Syntax.freeVariables M)
              ctxVars
 
-      val wildVar = List.find (fn v => "_" = Variable.toString v) freeVars
+      val wildVars = List.filter (fn v => "_" = Variable.toString v) freeVars
       val wild = MetaAbt.into (MetaAbt.$ (MetaOperator.WILD, #[]))
       (* Assert that all free variables are ones we didn't mean to
        * bind to ones in the context already.
@@ -77,10 +77,10 @@ struct
                    (convert M)
                    freeVars
     in
-      case wildVar of
-          SOME v =>
-          substOperator (fn _ => wild) (MetaOperator.META v) cM
-        | NONE => cM
+      List.foldl
+        (fn (v, t) => substOperator (fn _ => wild) (MetaOperator.META v) t)
+        cM
+        wildVars
     end
 
   fun rebindPat {goal, hyps} =


### PR DESCRIPTION
This PR fixes how wild cards are handled in the patterns we use in things like `@{}`, and `*subst`.  Specifically, we now use the built in wild card feature in sml-abt-unify. This has the important advantage that `_` now can match things that mention bound variables, so the tactic

```
chyp-subst #n [h.spread(h; _._._)]
```

Previously this would fail if that term in `spread` mentioned either of those bound variables. I've extracted out the process of converting a term to such a pattern into `refiner/rules/utils.fun:convertToPattern`. However, no there's the problem that the solution is not going to tell us what to plug in for those wild cards. To handle this we supply `applySolution` with the actual goal. Now `applySolution` will walk both the pattern we're trying to convert and the original goal together. Every time we encounter a wild card, we just use whatever the goal said should be there. However, if they ever disagree on anything else we just resort to `Meta.unconvert`. This is a bit tricky, but worth it in my mind.
