### PR TITLE
Fix functionality bug; change per type arity

### DIFF
--- a/example/foundations/excluded-middle-invalid.jonprl
+++ b/example/foundations/excluded-middle-invalid.jonprl
@@ -1,16 +1,13 @@
 ||| We can now demonstrate that the global principle of the excluded middle is
 ||| invalid.
-Theorem excluded-middle-invalid : [¬ ((A : U{i}) A decidable)] {
-  unfold <dec>; auto;
+Theorem excluded-middle-invalid : [¬ (A : U{i}) A decidable] {
+  unfold <not implies>; intro <universal-oracle> @i'; aux { unfold <dec>; auto };
 
-  ||| With our hypothesis, we can solve the halting problem
-  assert [(m : base) m ⇓ + ¬ m ⇓];
-  aux {
-    auto; elim #1 [m ⇓]; auto; unfold <not implies void>;
-    assumption
-  };
+ ||| With our hypothesis, we can solve the halting problem
+ assert [(m : base) m ⇓ decidable] <halting-oracle>;
+ aux { auto; elim <universal-oracle> [m ⇓]; auto };
 
-  ||| But we still can't solve the halting problem, contradiction.
-  cut-lemma <halting-problem-undecidable>; unfold <not implies dec>;
-  contradiction
+ ||| But we still can't solve the halting problem, contradiction.
+ cut-lemma <halting-problem-undecidable>;
+ contradiction
 }.

--- a/example/foundations/halting-problem.jonprl
+++ b/example/foundations/halting-problem.jonprl
@@ -8,11 +8,11 @@ Operator problem : (0).
 
 ||| This is just used in assert-opposite to deal with
 ||| the main proof obligations.
-Tactic t {
+Tactic assert-opposite-aux {
   unfold <problem>;
   step;
-  @{ [H : =(_; h; _) |- decide(h; _._; _._) ~ _] =>
-     hyp-subst ← <H> [h. decide(h; _._; _._) ~ _]
+  @{ [H : _ ~ h |- decide(h; _._; _._) ~ _] =>
+     chyp-subst <- <H>
    };
   auto; step; auto
 }.
@@ -21,56 +21,51 @@ Tactic t {
 ||| if it diverges, prove it's ax.
 Tactic assert-opposite {
   @{ [_ : M ⇓ |- _] =>
-     assert [M ~ bot]; aux {t}
-   | [_ : M ⇓ -> <> ≼ bot |- _] =>
-     assert [M ~ <>]; aux {t}
-   }
+     assert [M ~ bot]
+   | [_ : ¬ (M ⇓) |- _] =>
+     assert [M ~ <>]
+   }; aux { assert-opposite-aux }
 }.
 
-||| Given a hypothesis M ~ bot or M ~ <>, convert this into a hypothesis that ¬
-||| M ⇓ or M ⇓.
-Tactic derive-contra {
+||| Given a hypothesis M ~ bot or M ~ <>, convert this into a hypothesis that ¬ M ⇓ or M ⇓.
+Tactic derive-halting-statement {
   @{ [H : M ~ bot |- _] =>
      assert [¬ M ⇓];
      aux {
-       chyp-subst → <H> [h. ¬ h ⇓];
-       auto; bot-div #8
+       chyp-subst → <H>;
+       unfold <not implies>;
+       intro <bot-has-value> @i; aux { auto };
+       bot-div <bot-has-value>
      };
    | [H : M ~ <> |- _] =>
      assert [M ⇓];
      aux {
-       chyp-subst → <H> [h. h ⇓];
+       chyp-subst → <H>;
        auto; reduce; auto
      };
    }
 }.
 
 Theorem halting-problem-undecidable : [¬ ((m : base) m ⇓ decidable)] {
-  *{unfold <not implies dec>};
-  intro <p>; aux { auto };
+  unfold <not implies>;
+  intro <Ὁ-ΘΕΌΣ> @i; aux { auto };
 
-  pointwise-functionality <p> <a,b,q> ;auto;
-  thin <p>;
-  witness [<>]; unfold <member>; unhide #1; unhide #2; eq-cd;
+  ||| Approach the temple and address the god's earthly representative, the oracle
+  pointwise-functionality <Ὁ-ΘΕΌΣ> <oracle, _, oracle-wf>; aux { auto };
 
-  assert [
-    (y : (problem(a) problem(a)) ⇓ + (problem(a) problem(a) ⇓ -> <> ≼ bot))
-      * =(y; a (problem(a) problem(a)); (problem(a) problem(a)) ⇓ + (problem(a) problem(a) ⇓ -> <> ≼ bot))
-  ] <h>;
-
+  ||| Make a whole burnt offering, and ask the oracle concerning itself
+  assert [{y : (problem(oracle) problem(oracle)) ⇓ decidable | y ~ oracle (problem(oracle) problem(oracle))}] <H>;
   aux {
-    intro [a (problem(a) problem(a))];
-    [ auto; eq-cd [(m:base) m ⇓ + (m ⇓ -> <> ≼ bot)]; auto
-    , eq-cd [(m:base) m ⇓ + (m ⇓ -> <> ≼ bot)]; auto
-    , unfold <member>; eq-eq-base; auto; [ bunion-eq-left , bunion-eq-right ];
-      unfold <bunion>; eq-cd; auto; reduce; auto; break-plus; reduce;auto
-    ]
+    intro [oracle (problem(oracle) problem(oracle))] @i;
+    unfold <member>; auto;
+    eq-cd [(m:base) m ⇓ decidable]; auto;
   };
-  elim <h>;
 
-  ||| Ask whether or not problem(x) problem(x) terminates
-  elim <s>;
+  elim <H> <prophecy, prophecy-ceq>;
+
+  ||| Ask whether or not problem(oracle) problem(oracle) terminates
+  unfold <dec>; elim <prophecy>;
 
   ||| Show no matter the answer, we have a contradiction.
-  assert-opposite; derive-contra; contradiction
+  assert-opposite; derive-halting-statement; contradiction
 }.

--- a/example/foundations/halting-problem.jonprl
+++ b/example/foundations/halting-problem.jonprl
@@ -6,15 +6,6 @@
 Operator problem : (0).
 [problem(M)] =def= [lam(y. decide(M (y y); _. bot; _. <>))].
 
-Tactic contradiction {
-  unfold <not implies void>;
-  @{ [H : P -> <> ≼ bot, H' : P |- <> ≼ bot] =>
-       elim <H> [H'];
-       unfold <member>;
-       auto
-   }
-}.
-
 ||| This is just used in assert-opposite to deal with
 ||| the main proof obligations.
 Tactic t {
@@ -55,19 +46,26 @@ Tactic derive-contra {
 }.
 
 Theorem halting-problem-undecidable : [¬ ((m : base) m ⇓ decidable)] {
-  *{unfold <not implies dec>}; auto;
+  *{unfold <not implies dec>};
+  intro <p>; aux { auto };
 
-  pointwise-functionality <x>;auto;
-  thin <x>;
+  pointwise-functionality <p> <a,b,q> ;auto;
+  thin <p>;
   witness [<>]; unfold <member>; unhide #1; unhide #2; eq-cd;
 
-  assert [(y : has-value(problem(a) problem(a)) + (has-value(problem(a) problem(a)) -> approx(<>; bot)))
-          * =(y; a (problem(a) problem(a)); has-value(problem(a) problem(a)) + (has-value(problem(a) problem(a)) -> approx(<>; bot)))] <h>;
-  aux { intro [a (problem(a) problem(a))];
-        [ auto;eq-cd [(m:base) has-value(m) + (has-value(m) -> approx(<>; bot))]; auto
-        , eq-cd [(m:base) has-value(m) + (has-value(m) -> approx(<>; bot))]; auto
-        , unfold <member>; eq-eq-base;auto;[ bunion-eq-left , bunion-eq-right ];
-          unfold <bunion>;eq-cd;auto;reduce;auto;elim<x>;reduce;auto ] };
+  assert [
+    (y : (problem(a) problem(a)) ⇓ + (problem(a) problem(a) ⇓ -> <> ≼ bot))
+      * =(y; a (problem(a) problem(a)); (problem(a) problem(a)) ⇓ + (problem(a) problem(a) ⇓ -> <> ≼ bot))
+  ] <h>;
+
+  aux {
+    intro [a (problem(a) problem(a))];
+    [ auto; eq-cd [(m:base) m ⇓ + (m ⇓ -> <> ≼ bot)]; auto
+    , eq-cd [(m:base) m ⇓ + (m ⇓ -> <> ≼ bot)]; auto
+    , unfold <member>; eq-eq-base; auto; [ bunion-eq-left , bunion-eq-right ];
+      unfold <bunion>; eq-cd; auto; reduce; auto; break-plus; reduce;auto
+    ]
+  };
   elim <h>;
 
   ||| Ask whether or not problem(x) problem(x) terminates
@@ -75,5 +73,4 @@ Theorem halting-problem-undecidable : [¬ ((m : base) m ⇓ decidable)] {
 
   ||| Show no matter the answer, we have a contradiction.
   assert-opposite; derive-contra; contradiction
-
 }.

--- a/example/foundations/halting-problem.jonprl
+++ b/example/foundations/halting-problem.jonprl
@@ -43,7 +43,7 @@ Tactic derive-contra {
      assert [¬ M ⇓];
      aux {
        chyp-subst → <H> [h. ¬ h ⇓];
-       auto; bot-div #6
+       auto; bot-div #8
      };
    | [H : M ~ <> |- _] =>
      assert [M ⇓];
@@ -57,9 +57,23 @@ Tactic derive-contra {
 Theorem halting-problem-undecidable : [¬ ((m : base) m ⇓ decidable)] {
   *{unfold <not implies dec>}; auto;
 
+  pointwise-functionality <x>;auto;
+  thin <x>;
+  witness [<>]; unfold <member>; unhide #1; unhide #2; eq-cd;
+
+  assert [(y : has-value(problem(a) problem(a)) + (has-value(problem(a) problem(a)) -> approx(<>; bot)))
+          * =(y; a (problem(a) problem(a)); has-value(problem(a) problem(a)) + (has-value(problem(a) problem(a)) -> approx(<>; bot)))] <h>;
+  aux { intro [a (problem(a) problem(a))];
+        [ auto;eq-cd [(m:base) has-value(m) + (has-value(m) -> approx(<>; bot))]; auto
+        , eq-cd [(m:base) has-value(m) + (has-value(m) -> approx(<>; bot))]; auto
+        , unfold <member>; eq-eq-base;auto;[ bunion-eq-left , bunion-eq-right ];
+          unfold <bunion>;eq-cd;auto;reduce;auto;elim<x>;reduce;auto ] };
+  elim <h>;
+
   ||| Ask whether or not problem(x) problem(x) terminates
-  elim #1 [problem(x) problem(x)]; auto; elim #2;
+  elim <s>;
 
   ||| Show no matter the answer, we have a contradiction.
   assert-opposite; derive-contra; contradiction
+
 }.

--- a/example/foundations/prelude.jonprl
+++ b/example/foundations/prelude.jonprl
@@ -65,3 +65,17 @@ Theorem bisect-wf : [{A:U{i}} {B:U{i}} A ∩ B ∈ U{i}] {
 }.
 
 Resource wf += { wf-lemma <bisect-wf> }.
+
+Tactic bisect-induction-tac {
+  @{ [T : {b : unit + unit} decide(b; _.A; _.B) |- _] =>
+       elim <T> [inl(<>)];
+       main { elim <T> [ inr(<>) ] };
+       aux { auto };
+   }
+}.
+
+Tactic hyp-equand-eq-tac {
+  @{ [H : =(m; n; S) |- =(n; n; S)] =>
+      hyp-subst <- <H> [h.=(h; h; _)]; auto
+   }
+}.

--- a/example/foundations/prelude.jonprl
+++ b/example/foundations/prelude.jonprl
@@ -54,3 +54,14 @@ Tactic eq-base-tac {
        bunion-eq-right; unfold <bunion>
    }
 }.
+
+Operator bisect : (0;0).
+Infix -> 8 "∩" := bisect.
+[A ∩ B] =def= [{b:unit + unit} decide(b; _.A; _.B)].
+
+Theorem bisect-wf : [{A:U{i}} {B:U{i}} A ∩ B ∈ U{i}] {
+  unfold <bisect>; auto;
+  elim #3; reduce; auto
+}.
+
+Resource wf += { wf-lemma <bisect-wf> }.

--- a/example/foundations/prelude.jonprl
+++ b/example/foundations/prelude.jonprl
@@ -20,6 +20,12 @@ Theorem dec-wf : [{A : U{i}} A decidable ∈ U{i}] {
 Resource wf += {wf-lemma <dec-wf>}.
 Resource wf += {wf-lemma <has-value-wf>}.
 
+Theorem not-wf : [{A:U{i}} not(A) ∈ U{i}] {
+  unfold <not implies>; auto
+}.
+
+Resource wf += { wf-lemma <not-wf> }.
+
 Tactic break-plus {
   @{ [H : _ + _ |- _] => elim <H>; thin <H> }
 }.

--- a/example/foundations/prelude.jonprl
+++ b/example/foundations/prelude.jonprl
@@ -79,3 +79,12 @@ Tactic hyp-equand-eq-tac {
       hyp-subst <- <H> [h.=(h; h; _)]; auto
    }
 }.
+
+Tactic contradiction {
+  unfold <not implies void>;
+  @{ [H : P -> <> ≼ bot, H' : P |- <> ≼ bot] =>
+       elim <H> [H'];
+       unfold <member>;
+       auto
+   }
+}.

--- a/example/foundations/prelude.jonprl
+++ b/example/foundations/prelude.jonprl
@@ -33,6 +33,15 @@ Tactic bunion-eq-right {
   }
 }.
 
+Tactic bunion-eq-left {
+  @{ [|- =(M; N; L ∪ R)] =>
+       csubst [M ~ lam(x. snd(x)) <inl(<>), M>] [h.=(h;_;_)];
+       aux { unfold <snd>; reduce; auto };
+       csubst [N ~ lam(x. snd(x)) <inl(<>), N>] [h.=(_;h;_)];
+       aux { unfold <snd>; reduce; auto };
+  }
+}.
+
 Tactic eq-base-tac {
   @{ [|- =(=(M; N; A); =(M'; N'; A'); _)] =>
        eq-eq-base; auto;

--- a/example/foundations/russell.jonprl
+++ b/example/foundations/russell.jonprl
@@ -24,21 +24,6 @@ Theorem u-in-u-wf : [(U{i} ∈ U{i}) ∈ U{i'}] {
   unfold <member>; bhyp <eq-wf-base>; auto
 }.
 
-
-Tactic bisect-induction-tac {
-  @{ [T : {b : unit + unit} decide(b; _.A; _.B) |- _] =>
-       elim <T> [inl(<>)];
-       main { elim <T> [ inr(<>) ] };
-       aux { auto };
-   }
-}.
-
-Tactic hyp-equand-eq-tac {
-  @{ [H : =(m; n; S) |- =(n; n; S)] =>
-      hyp-subst <- <H> [h.=(h; h; _)]; auto
-   }
-}.
-
 Tactic dest-bisect {
   unfold <bisect member>;
   @{ [T : {b:unit + unit} decide(b; _.A; _.B) |- =(T; T; C)] =>
@@ -85,7 +70,7 @@ Theorem russell-property : [¬ (Russell ∈ Russell)] {
   unfold <not implies>;
   intro @i'; aux { wf-lemma <russell-property-type-wf> };
 
-  assert [(R:Russell) * R ~ Russell] <H>;
+  assert [{R:Russell | R ~ Russell}] <H>;
   aux { intro [Russell] @i; auto };
 
   elim <H> <russell-inh, russell-inh-eq-russell>;

--- a/example/foundations/russell.jonprl
+++ b/example/foundations/russell.jonprl
@@ -39,18 +39,29 @@ Theorem eq-wf-base : [{A:U{i}} {a:base} {b:base} =(a; b; A) ∈ U{i}] {
    }
 }.
 
-Tactic dest-bisect {
-  @{ [T : {b:unit + unit} decide(b; _.A; _.B) |- =(T; T; A)] =>
-       wf-lemma <eq-wf-base>; auto;
+Tactic bisect-induction-tac {
+  @{ [T : {b : unit + unit} decide(b; _.A; _.B) |- _] =>
        elim <T> [inl(<>)];
-       main { elim <T> [inr(<>)] };
-       aux { auto }; reduce; auto;
-       @{ [H : =(m; n; S) |- =(n; n; S)] =>
-           hyp-subst <- <H> [h.=(h; h; _)]; auto
-        }
+       main { elim <T> [ inr(<>) ] };
+       aux { auto };
    }
 }.
 
+Tactic hyp-equand-eq-tac {
+  @{ [H : =(m; n; S) |- =(n; n; S)] =>
+      hyp-subst <- <H> [h.=(h; h; _)]; auto
+   }
+}.
+
+Tactic dest-bisect {
+  unfold <bisect member>;
+  @{ [T : {b:unit + unit} decide(b; _.A; _.B) |- =(T; T; C)] =>
+       bisect-induction-tac;
+       wf-lemma <eq-wf-base>; auto;
+       reduce; auto;
+       hyp-equand-eq-tac
+   }
+}.
 
 Operator Russell : ().
 [Russell] =def= [{x : U{i} ∩ base | ¬ (x ∈ x)}].
@@ -75,28 +86,30 @@ Theorem Russell-in-base : [Russell ∈ base] {
 
 Resource wf += { wf-lemma <Russell-in-base> }.
 
+Theorem russell-property-type-wf : [(Russell ∈ Russell) ∈ U{i'}] {
+  assert [{A:U{i'}} {a:base} {b:base} =(a; b; A) ∈ U{i'}] <eq-wf-base>;
+  aux { lemma <eq-wf-base> };
+  unfold <member>; bhyp <eq-wf-base>;
+  auto
+}.
+
+Resource wf += { wf-lemma <russell-property-type-wf> }.
+
 Theorem russell-property : [¬ (Russell ∈ Russell)] {
-  unfold <not implies>; intro @i';
-  aux {
-    assert [{A:U{i'}} {a:base} {b:base} =(a; b; A) ∈ U{i'}] <eq-wf-base>;
-    aux { lemma <eq-wf-base> };
-    unfold <member>; bhyp <eq-wf-base>;
-    auto
-  };
+  unfold <not implies>;
+  intro @i'; aux { wf-lemma <russell-property-type-wf> };
 
-  assert [(R:Russell) * R ~ Russell];
+  assert [(R:Russell) * R ~ Russell] <H>;
   aux { intro [Russell] @i; auto };
-  elim #2;
-  unfold <Russell>;
-  elim #3;
 
-  assert [¬ ({x:U{i} ∩ base | ¬ (x ∈ x)} ∈ {x:U{i} ∩ base | ¬ (x ∈ x)})];
+  elim <H> <russell-inh, russell-inh-eq-russell>;
+  unfold <Russell>;
+  elim <russell-inh>;
+
+  assert [¬ (Russell ∈ Russell)]; unfold <Russell not implies>;
   aux {
-    chyp-subst <- #6;
-    unfold <not implies>;
-    intro @i;
-    aux { unfold <member bisect>; dest-bisect };
-    contradiction
+    chyp-subst <- <russell-inh-eq-russell>;
+    intro @i; aux { unfold <member>; dest-bisect };
   };
 
   contradiction
@@ -107,48 +120,27 @@ Theorem type-not-in-type : [¬ (U{i} ∈ U{i})] {
   unfold <not implies>;
   intro @i'; aux { wf-lemma <u-in-u-wf> };
 
-  assert [Russell ∈ U{i}] <russell-wf>;
+  assert [Russell ∈ U{i}] <russell-in-u0>;
   aux {
     unfold <member Russell not implies>;
     auto; unfold <member bisect>;
     dest-bisect
   };
 
+  assert [Russell ∈ Russell] <russell-in-russell>;
+  aux {
+    unfold <member Russell>; eq-cd @i;
+    aux {
+      unfold <member not implies bisect>;
+      eq-cd; ?{ !{ auto } };
+      dest-bisect
+    };
+  };
+
   cut-lemma <russell-property>;
-
-  assert [Russell ∈ Russell] <russell-wf>;
-  main { contradiction };
-
-  unfold <member Russell>; eq-cd @i;
-  aux {
-    unfold <member not implies bisect>;
-    eq-cd; ?{ !{ auto } };
-    dest-bisect
-  };
-
-  focus 0 #{
-    unfold <bisect>; auto; elim #4;
-    reduce; auto
-  };
-
-  unfold <not implies>; auto;
-  intro @i';
-  aux {
-    unfold <member bisect>; prune { eq-cd };
-    [ eq-cd; eq-cd; ?{ !{ auto } };
-      [ elim #4; reduce; auto
-      , cum @i; dest-bisect
-      ];
-    , eq-cd @i;
-      aux {
-        unfold <member>;
-        eq-cd @i; ?{ !{ auto } };
-        dest-bisect
-      }; auto;
-      elim #4; reduce; auto
-    ];
-  };
-
-  unfold <member>;
-  contradiction
+  unfold <Russell bisect>;
+  [ auto; break-plus; reduce; auto
+  , assumption
+  , contradiction
+  ]
 }.

--- a/example/foundations/russell.jonprl
+++ b/example/foundations/russell.jonprl
@@ -6,17 +6,6 @@
 ||| The well-formedness conditions in this proof are absolutely
 ||| killer and lead to most of the bloat in the proofs.
 
-Operator bisect : (0;0).
-Infix -> 8 "∩" := bisect.
-[A ∩ B] =def= [{b:unit + unit} decide(b; _.A; _.B)].
-
-Theorem bisect-wf : [{A:U{i}} {B:U{i}} A ∩ B ∈ U{i}] {
-  unfold <bisect>; auto;
-  elim #3; reduce; auto
-}.
-
-Resource wf += { wf-lemma <bisect-wf> }.
-
 Theorem eq-wf-base : [{A:U{i}} {a:base} {b:base} =(a; b; A) ∈ U{i}] {
   auto 0; aux { auto };
 

--- a/example/foundations/russell.jonprl
+++ b/example/foundations/russell.jonprl
@@ -1,13 +1,10 @@
-||| This is a proof that U{i} : U{i} is a contradiction in JonPRL.
+||| This is a proof that U{i} ∈ U{i} is a contradiction in JonPRL.
 ||| Proving this follows the reasoning from Russell's paradox: we
 ||| construct a type which contains all types that don't contain themselves
 ||| and show that *it* both is and isn't a member.
 |||
 ||| The well-formedness conditions in this proof are absolutely
 ||| killer and lead to most of the bloat in the proofs.
-
-Operator Russell : ().
-[Russell] =def= [{x : U{i} | ¬ (x ∈ x)}].
 
 Tactic impredicativity-wf-tac {
   unfold <member>; eq-base-tac;
@@ -19,59 +16,139 @@ Theorem u-in-u-wf : [(U{i} ∈ U{i}) ∈ U{i'}] {
   impredicativity-wf-tac
 }.
 
-Theorem type-not-in-type : [¬ (U{i} ∈ U{i})] {
-  unfold <not implies>; intro;
+Operator bisect : (0;0).
+Infix -> 8 "∩" := bisect.
+[A ∩ B] =def= [{b:unit + unit} decide(b; _.A; _.B)].
 
-  aux {lemma <u-in-u-wf>};
+Theorem bisect-wf : [{A:U{i}} {B:U{i}} A ∩ B ∈ U{i}] {
+  unfold <bisect>; auto;
+  elim #3; reduce; auto
+}.
 
-  ||| This can't really be a separate theorem since
-  ||| the well-formedness of Russells' set depends on
-  ||| U ∈ U
-  assert [Russell ∈ U{i}] <russell-wf>;
-  aux {
-    unfold <member Russell>; eq-cd; ?{assumption};
-    unfold <not implies>; eq-cd; auto;
-    impredicativity-wf-tac;
+Resource wf += { wf-lemma <bisect-wf> }.
+
+Theorem eq-wf-base : [{A:U{i}} {a:base} {b:base} =(a; b; A) ∈ U{i}] {
+  auto 0; aux { auto };
+
+  eq-base-tac; unfold <snd>; reduce;
+  @{ [|- =(m; m; image(_; _))] =>
+      csubst [m ~ (lam(p.snd(p)) <inr(<>), m>)]; unfold <snd>;
+      aux { reduce; auto };
+      auto; reduce; auto;
+      elim #4; reduce; auto
+   }
+}.
+
+Tactic dest-bisect {
+  @{ [T : {b:unit + unit} decide(b; _.A; _.B) |- =(T; T; A)] =>
+       wf-lemma <eq-wf-base>; auto;
+       elim <T> [inl(<>)];
+       main { elim <T> [inr(<>)] };
+       aux { auto }; reduce; auto;
+       @{ [H : =(m; n; S) |- =(n; n; S)] =>
+           hyp-subst <- <H> [h.=(h; h; _)]; auto
+        }
+   }
+}.
+
+
+Operator Russell : ().
+[Russell] =def= [{x : U{i} ∩ base | ¬ (x ∈ x)}].
+
+Theorem Russell-wf : [Russell ∈ U{i'}] {
+  unfold <Russell bisect not implies>;
+  auto 0; eq-cd;
+  eq-cd; ?{ !{ auto } };
+  focus 0 #{
+    elim #1; reduce; auto
   };
 
+  cum @i; dest-bisect
+}.
 
-  assert [(Russell ∈ Russell) ∈ U{i}] <russell-in-russell-wf>;
-  aux { impredicativity-wf-tac; cum @i; auto };
+Resource wf += { wf-lemma <Russell-wf> }.
 
-  ||| We can now start the proof.
-  assert [¬ (Russell ∈ Russell)] <russell-not-in-russell>;
+Theorem Russell-in-base : [Russell ∈ base] {
+  unfold <Russell bisect not implies>;
+  auto
+}.
+
+Resource wf += { wf-lemma <Russell-in-base> }.
+
+Theorem russell-property : [¬ (Russell ∈ Russell)] {
+  unfold <not implies>; intro @i';
   aux {
+    assert [{A:U{i'}} {a:base} {b:base} =(a; b; A) ∈ U{i'}] <eq-wf-base>;
+    aux { lemma <eq-wf-base> };
+    unfold <member>; bhyp <eq-wf-base>;
+    auto
+  };
+
+  assert [(R:Russell) * R ~ Russell];
+  aux { intro [Russell] @i; auto };
+  elim #2;
+  unfold <Russell>;
+  elim #3;
+
+  assert [¬ ({x:U{i} ∩ base | ¬ (x ∈ x)} ∈ {x:U{i} ∩ base | ¬ (x ∈ x)})];
+  aux {
+    chyp-subst <- #6;
     unfold <not implies>;
-    intro @i; aux {assumption};
-
-    assert [(R : Russell) * R ~ Russell];
-    aux {
-      intro [Russell] @i; auto
-    };
-
-    elim #5;
-    unfold <Russell>; elim #6;
-    assert [¬ ({x:U{i} | ¬ (x ∈ x)} ∈ {x:U{i} | ¬ (x ∈ x)})];
-    aux {
-      chyp-subst ← #9 [h. ¬ (h ∈ h)];
-      unfold <not implies>;
-      intro; aux { impredicativity-wf-tac };
-    };
-
+    intro @i;
+    aux { unfold <member bisect>; dest-bisect };
     contradiction
   };
 
-  assert [Russell ∈ Russell];
+  contradiction
+}.
+
+
+Theorem type-not-in-type : [¬ (U{i} ∈ U{i})] {
+  unfold <not implies>;
+  intro @i'; aux { wf-lemma <u-in-u-wf> };
+
+  assert [Russell ∈ U{i}] <russell-wf>;
   aux {
-    unfold <member Russell>; eq-cd;
-    unfold <member>;
-
-    ||| We've already done all the hard work of proving this
-    main {assumption};
-
-    unfold <not implies>; eq-cd; ?{!{auto}};
-    impredicativity-wf-tac;
+    unfold <member Russell not implies>;
+    auto; unfold <member bisect>;
+    dest-bisect
   };
 
+  cut-lemma <russell-property>;
+
+  assert [Russell ∈ Russell] <russell-wf>;
+  main { contradiction };
+
+  unfold <member Russell>; eq-cd @i;
+  aux {
+    unfold <member not implies bisect>;
+    eq-cd; ?{ !{ auto } };
+    dest-bisect
+  };
+
+  focus 0 #{
+    unfold <bisect>; auto; elim #4;
+    reduce; auto
+  };
+
+  unfold <not implies>; auto;
+  intro @i';
+  aux {
+    unfold <member bisect>; prune { eq-cd };
+    [ eq-cd; eq-cd; ?{ !{ auto } };
+      [ elim #4; reduce; auto
+      , cum @i; dest-bisect
+      ];
+    , eq-cd @i;
+      aux {
+        unfold <member>;
+        eq-cd @i; ?{ !{ auto } };
+        dest-bisect
+      }; auto;
+      elim #4; reduce; auto
+    ];
+  };
+
+  unfold <member>;
   contradiction
 }.

--- a/example/foundations/russell.jonprl
+++ b/example/foundations/russell.jonprl
@@ -6,16 +6,6 @@
 ||| The well-formedness conditions in this proof are absolutely
 ||| killer and lead to most of the bloat in the proofs.
 
-Tactic impredicativity-wf-tac {
-  unfold <member>; eq-base-tac;
-  eq-cd; ?{@{[|- =(_; _; base)] => auto}};
-  eq-cd @i'; ?{break-plus}; reduce; auto
-}.
-
-Theorem u-in-u-wf : [(U{i} ∈ U{i}) ∈ U{i'}] {
-  impredicativity-wf-tac
-}.
-
 Operator bisect : (0;0).
 Infix -> 8 "∩" := bisect.
 [A ∩ B] =def= [{b:unit + unit} decide(b; _.A; _.B)].
@@ -38,6 +28,13 @@ Theorem eq-wf-base : [{A:U{i}} {a:base} {b:base} =(a; b; A) ∈ U{i}] {
       elim #4; reduce; auto
    }
 }.
+
+Theorem u-in-u-wf : [(U{i} ∈ U{i}) ∈ U{i'}] {
+  assert [{A:U{i'}} {a:base} {b:base} =(a; b; A) ∈ U{i'}] <eq-wf-base>;
+  aux { lemma <eq-wf-base> };
+  unfold <member>; bhyp <eq-wf-base>; auto
+}.
+
 
 Tactic bisect-induction-tac {
   @{ [T : {b : unit + unit} decide(b; _.A; _.B) |- _] =>

--- a/example/foundations/undecidability-of-typing.jonprl
+++ b/example/foundations/undecidability-of-typing.jonprl
@@ -16,7 +16,7 @@ Theorem member-wf : [(a : base)(A : U{i}) member(member(a; A); U{i'})] {
 
 Resource wf += {wf-lemma <member-wf>}.
 
-Theorem typing-undecidable : [¬ ((A : U{i})(a : base) (a ∈ A) decidable)] {
+Theorem typing-undecidable-weak : [¬ ((A : U{i})(a : base) (a ∈ A) decidable)] {
   unfold <not implies dec>; intro;
   aux {
     ||| This has to be handled carefully so that we appeal to member-wf
@@ -35,7 +35,7 @@ Theorem typing-undecidable : [¬ ((A : U{i})(a : base) (a ∈ A) decidable)] {
   ||| this to decide the halting problem
   elim #1 [{m : base | m ⇓}]; auto;
 
-  assert [(m:base) dec(has-value(m))];
+  assert [(m:base) m ⇓ decidable];
   aux {
     ||| Ask whether the argument belong to the subset {m : base | m halts}
     auto; elim #2 [m]; auto; elim #5;
@@ -43,24 +43,24 @@ Theorem typing-undecidable : [¬ ((A : U{i})(a : base) (a ∈ A) decidable)] {
     ||| If it does, do a little jiggery-pokery to invert on m and get
     ||| access to that proof that m halts.
     focus 0 #{
-      assert [(x : {m : base | m ⇓}) * x ~ m]; aux {intro [m]; auto};
-      elim #8; chyp-subst ← #10 [h. has-value(h) + not(has-value(h))];
-      elim #9; intro #0; unfold <not implies>; auto;
+      assert [{n : {n : base | n ⇓} | n ~ m}] <H>; aux {intro [m]; auto};
+      elim <H> <H', is-eq>; chyp-subst ← <is-eq>;
+      elim <H'>; intro #0; unfold <not implies>; auto
     };
 
-    ||| If not, we have a proof that m ∈ {m : base | m halts} -> void,
+    ||| If not, we have a proof that m ∈ {m : base | m ⇓} -> void,
     ||| this means we have to do a little more work
-    assert [(x : {m : base | not(m ⇓)}) * x ~ m];
+    assert [(n : {m : base | ¬ m ⇓}) * n ~ m] <H>;
     aux {
       unfold <not implies>; intro [m]; auto;
       assert [=(m; m; {m : base | m ⇓})]; auto;
       contradiction
     };
-    elim #8; chyp-subst ← #10 [h. has-value(h) + not(has-value(h))];
-    elim #9; intro #1;
+    elim <H> <H', is-eq>; chyp-subst ← <is-eq>;
+    elim <H'>; intro #1;
     unfold <not implies>; auto; contradiction
   };
 
-  cut-lemma <halting-problem-undecidable>; unfold <not implies>;
+  cut-lemma <halting-problem-undecidable>;
   contradiction
 }.

--- a/example/per.jonprl
+++ b/example/per.jonprl
@@ -1,5 +1,5 @@
 Operator per-squash : (0).
-[per-squash(A)] =def= [per(lam(_.lam(_.A)))].
+[per-squash(A)] =def= [per(_._.A)].
 
 Theorem per-squash-wf : [{A:U{i}} member(per-squash(A); U{i})] {
   unfold <per-squash>; auto; reduce; auto
@@ -8,7 +8,7 @@ Theorem per-squash-wf : [{A:U{i}} member(per-squash(A); U{i})] {
 Theorem iff_squash : [{A:U{i}} iff(per-squash(A);squash(A))] {
  auto;
  [ unfold <per-squash>;auto;reduce;auto;
-   assert [=(x;x;per(lam(_.lam(_.A))))] <e>;[ auto; fail, id ];
+   assert [=(x;x;per(_._.A))] <e>;[ auto; fail, id ];
    elim <e>; reduce; [ id, auto; reduce; auto ];
    witness [<>];auto;
    unhide <y>;
@@ -31,21 +31,23 @@ Theorem quotient_wf: [
   auto;
   unfold <is-symmetric is-transitive>;
   auto;
-  unfold <quotient and>;auto;reduce;
-  [ eq-cd;
+  unfold <quotient and>;eq-cd;
+  [ unfold <member>; eq-cd;
     [ eq-base-tac;eq-cd;auto;reduce;auto;elim <x'''>;reduce;auto;fail
     , eq-cd;
       [ eq-base-tac;eq-cd;auto;reduce;auto;elim <x''''>;reduce;auto;fail
       , auto;fail
       ]
     ]
-  , eq-cd;
+  , unfold <member>; eq-cd;
     [ eq-base-tac;eq-cd;auto;reduce;auto;elim <x'''>;reduce;auto;fail
     , eq-cd;
       [ eq-base-tac;eq-cd;auto;reduce;auto;elim <x''''>;reduce;auto;fail
       , auto;fail
       ]
     ]
+  , auto
+  , auto
   , elim <z>; elim <t>;auto;
     elim #3 [x''];auto;
     elim #12 [y];auto;
@@ -56,6 +58,5 @@ Theorem quotient_wf: [
     elim #18 [y];auto;
     elim #20 [z];auto;
     elim #22 [t''];auto;
-    elim #24 [t'''];auto
-  ]
+    elim #24 [t'''];auto ]
 }.

--- a/example/synthetic-topology/sierpinski.jonprl
+++ b/example/synthetic-topology/sierpinski.jonprl
@@ -68,6 +68,7 @@ Operator Σ : ().
 Tactic Σ-wf-tac {
   unfold <Σ quotient and uiff Σ⊥ Σ⊤ member>; eq-cd;
   *{ eq-base-tac }; ?{ !{ auto } };
+  ?{ eq-cd; *{ eq-base-tac }; ?{ !{ auto } } };
   destruct-prods; auto;
   intro @i; auto;
   hyp-trans
@@ -81,37 +82,41 @@ Resource wf += { wf-lemma <Σ-wf> }.
 
 Theorem subtype-Σ : [(nat -> bool) ⊆r Σ] {
   unfold <subtype_rel id>; auto;
-  eq-cd @i; auto(*;
-  Σ-wf-tac*);
-  unfold <Σ quotient and uiff Σ⊥ Σ⊤ member>;(*eq-cd;
-  *{ eq-base-tac }; ?{ !{ auto } };
-  destruct-prods; auto;
-  intro @i; auto;
-  hyp-trans*)
+  eq-cd @i; auto;
+  Σ-wf-tac
 }.
 
-(*
+Theorem test : [ceq(lam(x.x);bot) -> unit] {
+ intro @i;[ , auto ];
+ @{ [H : ceq(lam(x.t);u) |- _] =>
+       assert [ceq(u;lam(x.t))] <eq>
+       }
+  
+}.
+
 ||| TODO: this is absolutely HORRID! Please improve this proof.
 Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
   cut-lemma <Σ-unequal-1>; unfold <uiff not implies>;
   elim #1 <_, t>; thin #2;
   intro <σ> @i; auto;
   intro <p> @i; aux { *{ eq-base-tac }; auto };
-  unfold <Σ quotient and uiff>; auto; reduce;
+  unfold <Σ quotient and uiff>;
+  eq-cd;
   *{ eq-base-tac }; ?{ !{ auto } };
+  ?{ eq-cd; *{ eq-base-tac }; ?{ !{ auto } } };
   prune {
     destruct-prods; auto;
     ?{ intro @i }; auto; ?{ hyp-trans }
   };
   @{ [H : per(x.y.R) |- _] =>
-       assert [=(H; H; per(x.y.R))] <eq>; aux { auto };
+       assert [=(H; H; per(x.y.R))] <eq>; aux {   (*auto*) };(*
        elim <eq> @i; reduce;
        destruct-prods;
        [ auto
        , *{ eq-base-tac }; auto
-       ]
+       ]*)
    };
-
+(*
   ext; auto; unfold <Σ⊥>;
 
   assert [{b:bool | =(b; σ x'; bool)}];
@@ -121,7 +126,6 @@ Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
     , eq-base-tac; auto
     ]
   };
-
 
   elim #13; unfold <bool>; elim #14;
   [ eq-cd [nat -> unit + unit] @i; auto;
@@ -146,5 +150,5 @@ Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
   , reduce; unfold <unit ff>; elim #15;
     hyp-subst <- #16 [h. =(h; _; _)]; auto;
   ]
-}.
 *)
+}.

--- a/example/synthetic-topology/sierpinski.jonprl
+++ b/example/synthetic-topology/sierpinski.jonprl
@@ -97,8 +97,8 @@ Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
     destruct-prods; auto;
     ?{ intro @i }; auto; ?{ hyp-trans }
   };
-  @{ [H : per(R) |- _] =>
-       assert [=(H; H; per(R))] <eq>; aux { auto };
+  @{ [H : per(x.y.R) |- _] =>
+       assert [=(H; H; per(x.y.R))] <eq>; aux { auto };
        elim <eq> @i; reduce;
        destruct-prods;
        [ auto

--- a/example/synthetic-topology/sierpinski.jonprl
+++ b/example/synthetic-topology/sierpinski.jonprl
@@ -86,14 +86,7 @@ Theorem subtype-Σ : [(nat -> bool) ⊆r Σ] {
   Σ-wf-tac
 }.
 
-Theorem test : [ceq(lam(x.x);bot) -> unit] {
- intro @i;[ , auto ];
- @{ [H : ceq(lam(x.t);u) |- _] =>
-       assert [ceq(u;lam(x.t))] <eq>
-       }
-  
-}.
-
+(*
 ||| TODO: this is absolutely HORRID! Please improve this proof.
 Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
   cut-lemma <Σ-unequal-1>; unfold <uiff not implies>;
@@ -152,3 +145,4 @@ Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
   ]
 *)
 }.
+*)

--- a/example/synthetic-topology/sierpinski.jonprl
+++ b/example/synthetic-topology/sierpinski.jonprl
@@ -66,7 +66,7 @@ Operator Σ : ().
 ].
 
 Tactic Σ-wf-tac {
-  unfold <Σ quotient and uiff Σ⊥ Σ⊤>; auto; reduce;
+  unfold <Σ quotient and uiff Σ⊥ Σ⊤ member>; eq-cd;
   *{ eq-base-tac }; ?{ !{ auto } };
   destruct-prods; auto;
   intro @i; auto;
@@ -81,10 +81,16 @@ Resource wf += { wf-lemma <Σ-wf> }.
 
 Theorem subtype-Σ : [(nat -> bool) ⊆r Σ] {
   unfold <subtype_rel id>; auto;
-  eq-cd @i; auto;
-  Σ-wf-tac
+  eq-cd @i; auto(*;
+  Σ-wf-tac*);
+  unfold <Σ quotient and uiff Σ⊥ Σ⊤ member>;(*eq-cd;
+  *{ eq-base-tac }; ?{ !{ auto } };
+  destruct-prods; auto;
+  intro @i; auto;
+  hyp-trans*)
 }.
 
+(*
 ||| TODO: this is absolutely HORRID! Please improve this proof.
 Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
   cut-lemma <Σ-unequal-1>; unfold <uiff not implies>;
@@ -141,3 +147,4 @@ Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
     hyp-subst <- #16 [h. =(h; _; _)]; auto;
   ]
 }.
+*)

--- a/example/synthetic-topology/sierpinski.jonprl
+++ b/example/synthetic-topology/sierpinski.jonprl
@@ -80,69 +80,7 @@ Theorem Σ-wf : [Σ ∈ U{i}] {
 
 Resource wf += { wf-lemma <Σ-wf> }.
 
+(* TODO: 
 Theorem subtype-Σ : [(nat -> bool) ⊆r Σ] {
-  unfold <subtype_rel id>; auto;
-  eq-cd @i; auto;
-  Σ-wf-tac
-}.
-
-(*
-||| TODO: this is absolutely HORRID! Please improve this proof.
-Theorem not-Σ⊤ : [{σ:Σ} (¬ =(σ; Σ⊤; Σ)) => =(σ; Σ⊥; Σ)] {
-  cut-lemma <Σ-unequal-1>; unfold <uiff not implies>;
-  elim #1 <_, t>; thin #2;
-  intro <σ> @i; auto;
-  intro <p> @i; aux { *{ eq-base-tac }; auto };
-  unfold <Σ quotient and uiff>;
-  eq-cd;
-  *{ eq-base-tac }; ?{ !{ auto } };
-  ?{ eq-cd; *{ eq-base-tac }; ?{ !{ auto } } };
-  prune {
-    destruct-prods; auto;
-    ?{ intro @i }; auto; ?{ hyp-trans }
-  };
-  @{ [H : per(x.y.R) |- _] =>
-       assert [=(H; H; per(x.y.R))] <eq>; aux {   (*auto*) };(*
-       elim <eq> @i; reduce;
-       destruct-prods;
-       [ auto
-       , *{ eq-base-tac }; auto
-       ]*)
-   };
-(*
-  ext; auto; unfold <Σ⊥>;
-
-  assert [{b:bool | =(b; σ x'; bool)}];
-  aux {
-    prune { intro [σ x'] @i; unfold <member> };
-    [ eq-cd [nat -> bool]; auto
-    , eq-base-tac; auto
-    ]
-  };
-
-  elim #13; unfold <bool>; elim #14;
-  [ eq-cd [nat -> unit + unit] @i; auto;
-    elim #5 [<>]; auto; reduce;
-    *{ eq-base-tac }; auto;
-    destruct-prods; auto;
-    @{ [H : =(M; N; P) => void, H' : =(N; M; P) |- _] =>
-          assert [=(M;N;P)] <S>; aux { symmetry; auto };
-          elim <H> [S]; auto
-     | [|- =(Σ⊤; Σ⊤; nat -> unit + unit)] => cut-lemma <Σ⊤-wf>; unfold <member bool>; auto
-     | [|- _] => id
-     };
-    ?{ hyp-trans };
-    assert [=(tt; ff; bool)];
-    aux {
-      unfold <tt unit bool>;
-      elim #15; hyp-subst -> #16 [h. =(h; _; _)];
-      unfold <unit ff>; auto;
-      hyp-subst -> #17 [h. =(h _; _; _)]; reduce; auto
-    };
-    auto
-  , reduce; unfold <unit ff>; elim #15;
-    hyp-subst <- #16 [h. =(h; _; _)]; auto;
-  ]
-*)
 }.
 *)

--- a/example/wip/brouwerian/prolegomenon.jonprl
+++ b/example/wip/brouwerian/prolegomenon.jonprl
@@ -74,8 +74,16 @@ Operator leq : (0;0).
 Infix 10 "≤" := leq.
 [m ≤ n] =def= [minus(n; m) ⇓].
 
+Theorem nat-subtype-base : [{n:nat} n ∈ base] {
+  auto; elim #1;
+  [ auto
+  , eq-cd; aux { auto };
+    cstruct; elim #3; auto
+  ]
+}.
+
 Theorem leq-wf : [{m:nat} {n:nat} (m ≤ n) ∈ U{i}] {
-  unfold <leq>; auto
+  unfold <leq minus>; auto; wf-lemma <nat-subtype-base>; auto
 }.
 
 Resource wf += { wf-lemma <leq-wf> }.
@@ -102,7 +110,8 @@ Operator is-finite : (0).
 [is-finite(A)] =def= [union(nat; n. {f : upto(n) -> A | surj(upto(n); A; f)})].
 
 Theorem is-finite-wf : [{A:U{i}} is-finite(A) ∈ U{i}] {
-  unfold <is-finite union>; auto;
+  unfold <is-finite union pi2>; auto;
+
 }.
 
 Resource wf += { wf-lemma <is-finite-wf> }.

--- a/src/parser/tactic_parser.fun
+++ b/src/parser/tactic_parser.fun
@@ -136,6 +136,11 @@ struct
     wth (fn SOME xs => xs
           | NONE => [])
 
+  val parse3Names =
+    opt (brackets (commaSep1 parseName))
+    wth (fn SOME [a,b,c] => SOME (a,b,c)
+          | _ => NONE)
+
   val parseElimArgs =
     fn w => parseHyp
       && opt (parseTm w)
@@ -272,6 +277,14 @@ struct
       wth (fn (name, hyp) => fn pos =>
              UNHIDE (hyp, {name = name, pos = pos}))
 
+  val parsePointwiseFunctionality : tactic_parser =
+    fn w => tactic "pointwise-functionality"
+      && parseHyp
+      && parse3Names
+      && opt parseLevel
+      wth (fn (name, (hyp,(names,lvl))) => fn pos =>
+              POINTWISE_FUNCTIONALITY ({target = hyp, names = names, level = lvl}, {name = name, pos = pos}))
+
   val parseWfLemma : tactic_parser =
     fn w => tactic "wf-lemma"
       && brackets (ParseSyntax.ParseOperator.parseOperator w)
@@ -310,6 +323,7 @@ struct
       || parseBHyp w
       || parseCutLemma w
       || parseUnhide w
+      || parsePointwiseFunctionality w
       || parseWfLemma w
       || parseUnfold w
       || parseWitness w

--- a/src/refiner/builtins.sml
+++ b/src/refiner/builtins.sml
@@ -144,10 +144,8 @@ struct
           val memy = `> MEM $$ #[``y, T]
           val rel  = (E // ``x) // ``y
           val exp  = `> AND $$ #[memx, `> AND $$ #[memy, rel]]
-          val lam1 = `> LAM $$ #[y \\ exp]
-          val lam2 = `> LAM $$ #[x \\ lam1]
         in
-          `> PER $$ #[lam2]
+          `> PER $$ #[x \\ (y \\ exp)]
         end
       | _ => raise Conv)
 

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -24,6 +24,7 @@ struct
     | PER_EQ | PER_MEM_EQ | PER_ELIM
 
     | UNHIDE
+    | POINTWISE_FUNCTIONALITY
 
     | ATOM_EQ | TOKEN_EQ | MATCH_TOKEN_EQ of string vector | TEST_ATOM_EQ
     | TEST_ATOM_REDUCE_LEFT | TEST_ATOM_REDUCE_RIGHT
@@ -78,6 +79,7 @@ struct
        | PER_ELIM => #[1,0]
 
        | UNHIDE => #[0]
+       | POINTWISE_FUNCTIONALITY => #[2,3]
 
        | ATOM_EQ => #[]
        | TOKEN_EQ => #[]
@@ -197,6 +199,7 @@ struct
        | PER_ELIM => "per-elim"
 
        | UNHIDE => "unhide"
+       | POINTWISE_FUNCTIONALITY => "pointwise-functionality"
 
        | ATOM_EQ => "atom-eq"
        | TOKEN_EQ => "token-eq"

--- a/src/refiner/derivation.sml
+++ b/src/refiner/derivation.sml
@@ -18,7 +18,8 @@ struct
     | CEQUAL_APPROX | CEQUAL_ELIM
     | APPROX_EQ | APPROX_MEMBER_EQ | APPROX_EXT_EQ | APPROX_REFL | APPROX_ELIM
     | BOTTOM_DIVERGES | ASSUME_HAS_VALUE
-    | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ
+    | BASE_EQ | BASE_INTRO | BASE_ELIM_EQ | BASE_MEMBER_EQ of int
+    | ATOM_SUBTYPE_BASE
 
     | IMAGE_EQ | IMAGE_MEM_EQ | IMAGE_ELIM | IMAGE_EQ_IND
     | PER_EQ | PER_MEM_EQ | PER_ELIM
@@ -67,7 +68,8 @@ struct
        | BASE_EQ => #[]
        | BASE_INTRO => #[]
        | BASE_ELIM_EQ => #[1]
-       | BASE_MEMBER_EQ => #[0]
+       | BASE_MEMBER_EQ n => Vector.tabulate (n + 1, fn _ => 0)
+       | ATOM_SUBTYPE_BASE => #[0]
 
        | IMAGE_EQ => #[0,0]
        | IMAGE_MEM_EQ => #[0,0]
@@ -187,7 +189,8 @@ struct
        | BASE_EQ => "base-eq"
        | BASE_INTRO => "base-intro"
        | BASE_ELIM_EQ => "base-elim-eq"
-       | BASE_MEMBER_EQ => "base-member-eq"
+       | BASE_MEMBER_EQ _ => "base-member-eq"
+       | ATOM_SUBTYPE_BASE => "atom-subtype-base"
 
        | IMAGE_EQ => "image-eq"
        | IMAGE_MEM_EQ => "image-mem-eq"

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -76,9 +76,11 @@ struct
        | UNHIDE $ _ => ax
 
        | POINTWISE_FUNCTIONALITY $ #[abD,_] =>
-           let val (a,bD) = unbind abD
-               val (b,D) = unbind bD
-           in ((a \\ (b \\ extract D)) // ax) // ax
+           let
+             val (a,bD) = unbind abD
+             val (b,D) = unbind bD
+           in
+             ((a \\ (b \\ extract D)) // ax) // ax
            end
 
        | ATOM_EQ $ _ => ax

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -41,7 +41,8 @@ struct
 
        | BASE_INTRO $ _ => ax
        | BASE_EQ $ _ => ax
-       | BASE_MEMBER_EQ $ _ => ax
+       | BASE_MEMBER_EQ _ $ _ => ax
+       | ATOM_SUBTYPE_BASE $ _ => ax
        | BASE_ELIM_EQ $ #[D] => extract (D // ax)
 
        | IMAGE_EQ $ _ => ax

--- a/src/refiner/extract.fun
+++ b/src/refiner/extract.fun
@@ -74,6 +74,12 @@ struct
 
        | UNHIDE $ _ => ax
 
+       | POINTWISE_FUNCTIONALITY $ #[abD,_] =>
+           let val (a,bD) = unbind abD
+               val (b,D) = unbind bD
+           in ((a \\ (b \\ extract D)) // ax) // ax
+           end
+
        | ATOM_EQ $ _ => ax
        | TOKEN_EQ $ _ => ax
        | MATCH_TOKEN_EQ toks $ Ds => ax

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -255,6 +255,26 @@ struct
                  (Development.lookupResource world Resource.ELIM)
     end
 
+  local
+      open Goal Sequent Syntax
+      infix 3 >> infix 2 |:
+      infix $
+  in
+  fun EqBase (goal as (_ |: H >> P)) =
+    (case out P of
+	 EQ $ #[M,N,U] =>
+	 (case out U of
+	      BASE $ _ =>
+	      (case out M of
+		   ` (v : Syntax.Variable.t) => BaseRules.AtomSubtypeBase
+		   (*(case out (Context.lookup H v) of
+			ATOM $ _ => BaseRules.AtomSubtypeBase
+		      | _ => raise Refine)*)
+		 | _ => BaseRules.MemberEq)
+	    | _ => raise Refine)
+       | _ => raise Refine) goal
+  end
+
   fun EqCD {names, level, invertible, terms} world =
     let
       val freshVariable = listAt (names, 0)
@@ -277,7 +297,7 @@ struct
         ORELSE PlusRules.InlEq level
         ORELSE PlusRules.InrEq level
         ORELSE BaseRules.Eq
-        ORELSE BaseRules.MemberEq
+        ORELSE EqBase
         ORELSE FunRules.Eq freshVariable
         ORELSE ISectRules.Eq freshVariable
         ORELSE ProdRules.Eq freshVariable

--- a/src/refiner/refiner_util.fun
+++ b/src/refiner/refiner_util.fun
@@ -15,7 +15,7 @@ functor RefinerUtil
       where type term = Syntax.t
       where type name = Syntax.Variable.t
       where type operator = Syntax.Operator.t
-      where type Sequent.sequent = Sequent.sequent) : REFINER_UTIL =
+      where Sequent = Sequent) : REFINER_UTIL =
 struct
   structure Lcf = Lcf
   structure Tacticals = Tacticals(Lcf)
@@ -256,23 +256,24 @@ struct
     end
 
   local
-      open Goal Sequent Syntax
-      infix 3 >> infix 2 |:
-      infix $
+    open Goal Sequent Syntax
+    infix 3 >> infix 2 |:
+    open CttCalculusInj CttCalculus CttCalculusView
+    infix $
   in
-  fun EqBase (goal as (_ |: H >> P)) =
-    (case out P of
-	 EQ $ #[M,N,U] =>
-	 (case out U of
-	      BASE $ _ =>
-	      (case out M of
-		   ` (v : Syntax.Variable.t) => BaseRules.AtomSubtypeBase
-		   (*(case out (Context.lookup H v) of
-			ATOM $ _ => BaseRules.AtomSubtypeBase
-		      | _ => raise Refine)*)
-		 | _ => BaseRules.MemberEq)
-	    | _ => raise Refine)
-       | _ => raise Refine) goal
+    fun EqBase (goal as (_ |: H >> P)) =
+      (case project P of
+           EQ $ #[M,N,U] =>
+           (case project U of
+                BASE $ _ =>
+                (case project M of
+                     ` v =>
+                       (case project (Context.lookup H v) of
+                            ATOM $ _ => BaseRules.AtomSubtypeBase
+                          | _ => raise Refine)
+                   | _ => BaseRules.MemberEq)
+              | _ => raise Refine)
+         | _ => raise Refine) goal
   end
 
   fun EqCD {names, level, invertible, terms} world =

--- a/src/refiner/rules/base.fun
+++ b/src/refiner/rules/base.fun
@@ -32,19 +32,21 @@ struct
     let
       val #[M, N, U] = P ^! EQ
       val #[] = U ^! BASE
-      fun pr a b = C.`> PAIR $$ #[a,b]
-      val _ =
-        List.app
-            (fn x => case asApp (Context.lookup H x) of
-		         (BASE, _) => ()
-		       | (ATOM, _) => ()
-		       | _ => raise Fail "Not a base type")
-            (freeVariables M @ freeVariables N)
-
+      val free = freeVariables M
+      val n = length free
+      val L = List.map (fn v => AUX |: H >> C.`> MEM $$ #[``v, U]) free
     in
-      [ MAIN |: H >> C.`> CEQUAL $$ #[M, N]
-      ] BY (fn [D] => D.`> BASE_MEMBER_EQ $$ #[D]
-           | _ => raise Refine)
+      ((MAIN |: H >> C.`> CEQUAL $$ #[M, N]) :: L)
+	  BY mkEvidence (BASE_MEMBER_EQ n)
+    end
+
+  fun AtomSubtypeBase (_ |: H >> P) =
+    let
+      val #[M, N, U] = P ^! EQ
+      val #[] = U ^! BASE
+    in
+      [MAIN |: H >> C.`> EQ $$ #[M, N, C.`> ATOM $$ #[]]]
+	  BY mkEvidence ATOM_SUBTYPE_BASE
     end
 
   fun ElimEq (hyp, z) (_ |: H >> P) =

--- a/src/refiner/rules/base.fun
+++ b/src/refiner/rules/base.fun
@@ -32,10 +32,19 @@ struct
     let
       val #[M, N, U] = P ^! EQ
       val #[] = U ^! BASE
+      fun pr a b = C.`> PAIR $$ #[a,b]
+      val _ =
+        List.app
+            (fn x => case asApp (Context.lookup H x) of
+		         (BASE, _) => ()
+		       | (ATOM, _) => ()
+		       | _ => raise Fail "Not a base type")
+            (freeVariables M @ freeVariables N)
+
     in
       [ MAIN |: H >> C.`> CEQUAL $$ #[M, N]
       ] BY (fn [D] => D.`> BASE_MEMBER_EQ $$ #[D]
-             | _ => raise Refine)
+           | _ => raise Refine)
     end
 
   fun ElimEq (hyp, z) (_ |: H >> P) =

--- a/src/refiner/rules/base.fun
+++ b/src/refiner/rules/base.fun
@@ -37,7 +37,7 @@ struct
       val L = List.map (fn v => AUX |: H >> C.`> MEM $$ #[``v, U]) free
     in
       ((MAIN |: H >> C.`> CEQUAL $$ #[M, N]) :: L)
-	  BY mkEvidence (BASE_MEMBER_EQ n)
+        BY mkEvidence (BASE_MEMBER_EQ n)
     end
 
   fun AtomSubtypeBase (_ |: H >> P) =
@@ -46,7 +46,7 @@ struct
       val #[] = U ^! BASE
     in
       [MAIN |: H >> C.`> EQ $$ #[M, N, C.`> ATOM $$ #[]]]
-	  BY mkEvidence ATOM_SUBTYPE_BASE
+        BY mkEvidence ATOM_SUBTYPE_BASE
     end
 
   fun ElimEq (hyp, z) (_ |: H >> P) =

--- a/src/refiner/rules/base.sig
+++ b/src/refiner/rules/base.sig
@@ -7,5 +7,6 @@ sig
   val Eq : tactic
   val Intro : tactic
   val MemberEq : tactic
+  val AtomSubtypeBase : tactic
   val ElimEq : hyp * name option -> tactic
 end

--- a/src/refiner/rules/general.fun
+++ b/src/refiner/rules/general.fun
@@ -55,43 +55,43 @@ struct
 
   fun PointwiseFunctionality (hyp, onames, ok) (T |: H >> P) =
     let
-	val (a,b,c) =
-            case onames of
-		SOME names => names
-              | NONE =>
-		(Context.fresh (H, Variable.named "a"),
-                 Context.fresh (H, Variable.named "b"),
-                 Context.fresh (H, Variable.named "c"))
-	val k = case ok of NONE => inferLevel (H, P) | SOME k => k
-	val z = eliminationTarget hyp (H >> P)
-	val A = Context.lookup H z
+      val (a,b,c) =
+          case onames of
+              SOME names => names
+            | NONE =>
+              (Context.fresh (H, Variable.named "a"),
+               Context.fresh (H, Variable.named "b"),
+               Context.fresh (H, Variable.named "c"))
+      val k = case ok of NONE => inferLevel (H, P) | SOME k => k
+      val z = eliminationTarget hyp (H >> P)
+      val A = Context.lookup H z
 
-	val base = C.`> BASE $$ #[]
+      val base = C.`> BASE $$ #[]
 
-	val mem  = C.`> MEM $$ #[``a, A]
-	val K1 = Context.insert Context.empty a Visibility.Hidden base
-	val K2 = Context.insert K1 c Visibility.Hidden mem
-	val H1 = Context.interposeAfter H (z, K2)
-	val H2 = Context.mapAfter c (fn t => subst (``a) z t) H1
-	val Pa = subst (``a) z P
+      val mem  = C.`> MEM $$ #[``a, A]
+      val K1 = Context.insert Context.empty a Visibility.Hidden base
+      val K2 = Context.insert K1 c Visibility.Hidden mem
+      val H1 = Context.interposeAfter H (z, K2)
+      val H2 = Context.mapAfter c (fn t => subst (``a) z t) H1
+      val Pa = subst (``a) z P
 
-	val eqv = C.`> EQ $$ #[``a, ``b, A]
-	val J1 = Context.insert Context.empty a Visibility.Visible base
-	val J2 = Context.insert J1 b Visibility.Visible base
-	val J3 = Context.insert J2 c Visibility.Visible eqv
-	val G1 = Context.interposeAfter H (z, J3)
-	val G2 = Context.mapAfter c (fn t => subst (``a) z t) G1
+      val eqv = C.`> EQ $$ #[``a, ``b, A]
+      val J1 = Context.insert Context.empty a Visibility.Visible base
+      val J2 = Context.insert J1 b Visibility.Visible base
+      val J3 = Context.insert J2 c Visibility.Visible eqv
+      val G1 = Context.interposeAfter H (z, J3)
+      val G2 = Context.mapAfter c (fn t => subst (``a) z t) G1
 
-	val uni  = C.`> (UNIV k) $$ #[]
-	val Pb = subst (``b) z P
-	val eq = C.`> EQ $$ #[Pa, Pb, uni]
+      val uni  = C.`> (UNIV k) $$ #[]
+      val Pb = subst (``b) z P
+      val eq = C.`> EQ $$ #[Pa, Pb, uni]
 
     in
-	[ T |: H2 >> Pa
-	, T |: G2 >> eq
-	] BY (fn [D, E] => D.`> POINTWISE_FUNCTIONALITY
-			     $$ #[a \\ (c \\ D), a \\ (b \\ (c \\ E))]
-	     | _ => raise Refine)
+        [ MAIN |: H2 >> Pa
+        , AUX |: G2 >> eq
+        ] BY (fn [D, E] => D.`> POINTWISE_FUNCTIONALITY
+                             $$ #[a \\ (c \\ D), a \\ (b \\ (c \\ E))]
+             | _ => raise Refine)
     end
 
   fun Hypothesis hyp (goal as _ |: S) = Hypothesis_ (eliminationTarget hyp S) goal

--- a/src/refiner/rules/general.fun
+++ b/src/refiner/rules/general.fun
@@ -53,6 +53,47 @@ struct
       [T |: K >> P] BY mkEvidence UNHIDE
     end
 
+  fun PointwiseFunctionality (hyp, onames, ok) (T |: H >> P) =
+    let
+	val (a,b,c) =
+            case onames of
+		SOME names => names
+              | NONE =>
+		(Context.fresh (H, Variable.named "a"),
+                 Context.fresh (H, Variable.named "b"),
+                 Context.fresh (H, Variable.named "c"))
+	val k = case ok of NONE => inferLevel (H, P) | SOME k => k
+	val z = eliminationTarget hyp (H >> P)
+	val A = Context.lookup H z
+
+	val base = C.`> BASE $$ #[]
+
+	val mem  = C.`> MEM $$ #[``a, A]
+	val K1 = Context.insert Context.empty a Visibility.Hidden base
+	val K2 = Context.insert K1 c Visibility.Hidden mem
+	val H1 = Context.interposeAfter H (z, K2)
+	val H2 = Context.mapAfter c (fn t => subst (``a) z t) H1
+	val Pa = subst (``a) z P
+
+	val eqv = C.`> EQ $$ #[``a, ``b, A]
+	val J1 = Context.insert Context.empty a Visibility.Visible base
+	val J2 = Context.insert J1 b Visibility.Visible base
+	val J3 = Context.insert J2 c Visibility.Visible eqv
+	val G1 = Context.interposeAfter H (z, J3)
+	val G2 = Context.mapAfter c (fn t => subst (``a) z t) G1
+
+	val uni  = C.`> (UNIV k) $$ #[]
+	val Pb = subst (``b) z P
+	val eq = C.`> EQ $$ #[Pa, Pb, uni]
+
+    in
+	[ T |: H2 >> Pa
+	, T |: G2 >> eq
+	] BY (fn [D, E] => D.`> POINTWISE_FUNCTIONALITY
+			     $$ #[a \\ (c \\ D), a \\ (b \\ (c \\ E))]
+	     | _ => raise Refine)
+    end
+
   fun Hypothesis hyp (goal as _ |: S) = Hypothesis_ (eliminationTarget hyp S) goal
 
   fun Assumption (goal as _ |: H >> P) =

--- a/src/refiner/rules/general.sig
+++ b/src/refiner/rules/general.sig
@@ -19,7 +19,15 @@ sig
   val Assert : term * name option -> tactic
   val Hypothesis : hyp -> tactic
   val HypEq : tactic
+
+  (* H, [z : A], J >> a = b in T
+   *   H, z : A, J >> a = b inT *)
   val Unhide : hyp -> tactic
+
+  (* H, z : A, J >> P
+   *   H, a : Base, c : a ∈ A >> P[z\a]
+   *   H, a : Base, b : Base, c : a = b ∈ A >> P[z\a] = P[z\b] ∈ U{k} *)
+  val PointwiseFunctionality : (hyp * (name * name * name) option * Level.t option) -> tactic
 
   (* Match a single branch of a [match goal]. This needs to
    * be primitive because it needs access to the structure of

--- a/src/refiner/rules/per.fun
+++ b/src/refiner/rules/per.fun
@@ -9,6 +9,10 @@ struct
   infix 8 $$ // @@
   infixr 8 \\
 
+  local
+      fun ap2 R u v = (R // u) // v
+  in
+
   fun Eq ow (_ |: H >> P) =
     let
       val #[M, N, U] = P ^! EQ
@@ -23,7 +27,6 @@ struct
                     Context.fresh (H, Variable.named "z"),
                     Context.fresh (H, Variable.named "u"),
                     Context.fresh (H, Variable.named "v"))
-      fun ap2 R a b = C.`> AP $$ #[C.`> AP $$ #[R, a], b]
       val bas = C.`> BASE $$ #[]
     in
       [ MAIN |: H @@ (x,bas) @@ (y,bas) >> C.`> MEM $$ #[ap2 R1 (``x) (``y), U]
@@ -51,7 +54,7 @@ struct
       val bas = C.`> BASE $$ #[]
     in
       [ MAIN |: H >> C.`> MEM $$ #[U, uni]
-      , MAIN |: H >> C.`> AP $$ #[C.`> AP $$ #[R, M], N]
+      , MAIN |: H >> ap2 R M N
       , MAIN |: H >> C.`> MEM $$ #[M, bas]
       , MAIN |: H >> C.`> MEM $$ #[N, bas]
       ] BY mkEvidence PER_MEM_EQ
@@ -68,14 +71,16 @@ struct
          | NONE => Context.fresh (H, Variable.named "y")
       val k = case ok of NONE => inferLevel (H, U) | SOME k => k
       val uni = C.`> (UNIV k) $$ #[]
-      val ap2 = C.`> AP $$ #[C.`> AP $$ #[R, M], N]
-      val K  = Context.insert Context.empty y Visibility.Hidden ap2
+      val rmn = ap2 R M N
+      val K  = Context.insert Context.empty y Visibility.Hidden rmn
       val H1 = Context.interposeAfter H (z, K)
     in
       [ MAIN |: H1 >> P
-      , MAIN |: H >> C.`> MEM $$ #[ap2, uni]
+      , MAIN |: H >> C.`> MEM $$ #[rmn, uni]
       ] BY (fn [D,E] => D.`> PER_ELIM $$ #[y \\ D, E]
              | _ => raise Refine)
     end
+
+  end
 
 end

--- a/src/refiner/rules/per.fun
+++ b/src/refiner/rules/per.fun
@@ -10,77 +10,75 @@ struct
   infixr 8 \\
 
   local
-      fun ap2 R u v = (R // u) // v
+    fun ap2 R u v = (R // u) // v
   in
 
-  fun Eq ow (_ |: H >> P) =
-    let
-      val #[M, N, U] = P ^! EQ
-      val #[R1] = M ^! PER
-      val #[R2] = N ^! PER
-      val (UNIV _, _) = asApp U
-      val (x,y,z,u,v) =
-       case ow of
-           SOME names => names
-         | NONE => (Context.fresh (H, Variable.named "x"),
-                    Context.fresh (H, Variable.named "y"),
-                    Context.fresh (H, Variable.named "z"),
-                    Context.fresh (H, Variable.named "u"),
-                    Context.fresh (H, Variable.named "v"))
-      val bas = C.`> BASE $$ #[]
-    in
-      [ MAIN |: H @@ (x,bas) @@ (y,bas) >> C.`> MEM $$ #[ap2 R1 (``x) (``y), U]
-      , MAIN |: H @@ (x,bas) @@ (y,bas) >> C.`> MEM $$ #[ap2 R2 (``x) (``y), U]
-      , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R1 (``x) (``y)) >> ap2 R2 (``x) (``y)
-      , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R2 (``x) (``y)) >> ap2 R1 (``x) (``y)
-      , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R1 (``x) (``y)) >> ap2 R1 (``y) (``x)
-      , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,bas) @@ (u,ap2 R1 (``x) (``y)) @@ (v,ap2 R1 (``y) (``z)) >> ap2 R1 (``x) (``z)
-      ] BY (fn [A,B,C,D,E,F] =>
-               D.`> PER_EQ $$ #[x \\ (y \\ A),
-                                x \\ (y \\ B),
-                                x \\ (y \\ (z \\ C)),
-                                x \\ (y \\ (z \\ D)),
-                                x \\ (y \\ (z \\ E)),
-                                x \\ (y \\ (z \\ (u \\ (v \\ F))))]
-           | _ => raise Refine)
-    end
-
-  fun MemEq ok (_ |: H >> P) =
-    let
-      val #[M, N, U] = P ^! EQ
-      val #[R] = U ^! PER
-      val k = case ok of NONE => inferLevel (H, U) | SOME k => k
-      val uni = C.`> (UNIV k) $$ #[]
-      val bas = C.`> BASE $$ #[]
-    in
-      [ MAIN |: H >> C.`> MEM $$ #[U, uni]
-      , MAIN |: H >> ap2 R M N
-      , MAIN |: H >> C.`> MEM $$ #[M, bas]
-      , MAIN |: H >> C.`> MEM $$ #[N, bas]
-      ] BY mkEvidence PER_MEM_EQ
-    end
-
-  fun Elim (hyp, ow, ok) (_ |: H >> P) =
-    let
-      val z = eliminationTarget hyp (H >> P)
-      val #[M,N,U] = Context.lookup H z ^! EQ
-      val #[R] = U ^! PER
-      val y =
-       case ow of
-           SOME names => names
-         | NONE => Context.fresh (H, Variable.named "y")
-      val k = case ok of NONE => inferLevel (H, U) | SOME k => k
-      val uni = C.`> (UNIV k) $$ #[]
-      val rmn = ap2 R M N
-      val K  = Context.insert Context.empty y Visibility.Hidden rmn
-      val H1 = Context.interposeAfter H (z, K)
-    in
-      [ MAIN |: H1 >> P
-      , MAIN |: H >> C.`> MEM $$ #[rmn, uni]
-      ] BY (fn [D,E] => D.`> PER_ELIM $$ #[y \\ D, E]
+    fun Eq ow (_ |: H >> P) =
+      let
+        val #[M, N, U] = P ^! EQ
+        val #[R1] = M ^! PER
+        val #[R2] = N ^! PER
+        val (UNIV _, _) = asApp U
+        val (x,y,z,u,v) =
+         case ow of
+             SOME names => names
+           | NONE => (Context.fresh (H, Variable.named "x"),
+                      Context.fresh (H, Variable.named "y"),
+                      Context.fresh (H, Variable.named "z"),
+                      Context.fresh (H, Variable.named "u"),
+                      Context.fresh (H, Variable.named "v"))
+        val bas = C.`> BASE $$ #[]
+      in
+        [ MAIN |: H @@ (x,bas) @@ (y,bas) >> C.`> MEM $$ #[ap2 R1 (``x) (``y), U]
+        , MAIN |: H @@ (x,bas) @@ (y,bas) >> C.`> MEM $$ #[ap2 R2 (``x) (``y), U]
+        , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R1 (``x) (``y)) >> ap2 R2 (``x) (``y)
+        , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R2 (``x) (``y)) >> ap2 R1 (``x) (``y)
+        , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,ap2 R1 (``x) (``y)) >> ap2 R1 (``y) (``x)
+        , MAIN |: H @@ (x,bas) @@ (y,bas) @@ (z,bas) @@ (u,ap2 R1 (``x) (``y)) @@ (v,ap2 R1 (``y) (``z)) >> ap2 R1 (``x) (``z)
+        ] BY (fn [A,B,C,D,E,F] =>
+                 D.`> PER_EQ $$ #[x \\ (y \\ A),
+                                  x \\ (y \\ B),
+                                  x \\ (y \\ (z \\ C)),
+                                  x \\ (y \\ (z \\ D)),
+                                  x \\ (y \\ (z \\ E)),
+                                  x \\ (y \\ (z \\ (u \\ (v \\ F))))]
              | _ => raise Refine)
-    end
+      end
 
+    fun MemEq ok (_ |: H >> P) =
+      let
+        val #[M, N, U] = P ^! EQ
+        val #[R] = U ^! PER
+        val k = case ok of NONE => inferLevel (H, U) | SOME k => k
+        val uni = C.`> (UNIV k) $$ #[]
+        val bas = C.`> BASE $$ #[]
+      in
+        [ MAIN |: H >> C.`> MEM $$ #[U, uni]
+        , MAIN |: H >> ap2 R M N
+        , MAIN |: H >> C.`> MEM $$ #[M, bas]
+        , MAIN |: H >> C.`> MEM $$ #[N, bas]
+        ] BY mkEvidence PER_MEM_EQ
+      end
+
+    fun Elim (hyp, ow, ok) (_ |: H >> P) =
+      let
+        val z = eliminationTarget hyp (H >> P)
+        val #[M,N,U] = Context.lookup H z ^! EQ
+        val #[R] = U ^! PER
+        val y =
+         case ow of
+             SOME names => names
+           | NONE => Context.fresh (H, Variable.named "y")
+        val k = case ok of NONE => inferLevel (H, U) | SOME k => k
+        val uni = C.`> (UNIV k) $$ #[]
+        val rmn = ap2 R M N
+        val K  = Context.insert Context.empty y Visibility.Hidden rmn
+        val H1 = Context.interposeAfter H (z, K)
+      in
+        [ MAIN |: H1 >> P
+        , MAIN |: H >> C.`> MEM $$ #[rmn, uni]
+        ] BY (fn [D,E] => D.`> PER_ELIM $$ #[y \\ D, E]
+               | _ => raise Refine)
+      end
   end
-
 end

--- a/src/refiner/rules/per.sig
+++ b/src/refiner/rules/per.sig
@@ -4,27 +4,27 @@ sig
   type hyp
   type name
 
-  (* H >> per(R1) = per(R2) ∈ U{k}
-   *   H, x : Base, y : Base >> R1 x y ∈ U{k}
-   *   H, x : Base, y : Base >> R2 x y ∈ U{k}
-   *   H, x : Base, y : Base, z : R1 x y >> R2 x y
-   *   H, x : Base, y : Base, z : R2 x y >> R1 x y
-   *   H, x : Base, y : Base, z : R1 x y >> R1 y x
-   *   H, x : Base, y : Base, z : Base, u : R1 x y, v : R1 y z >> R1 x z
+  (* H >> per(a,b.R1) = per(c,d.R2) ∈ U{k}
+   *   H, x : Base, y : Base >> R1[a\x,b\y] ∈ U{k}
+   *   H, x : Base, y : Base >> R2[c\x,d\y] ∈ U{k}
+   *   H, x : Base, y : Base, z : R1[a\x,b\y] >> R2[c\x,d\y]
+   *   H, x : Base, y : Base, z : R2[c\x,d\y] >> R1[a\x,b\y]
+   *   H, x : Base, y : Base, z : R1[a\x,b\y] >> R1[a\y,b\x]
+   *   H, x : Base, y : Base, z : Base, u : R1[a\x,b\y], v : R1[a\y,b\z] >> R1[a\x,b\z]
    *)
   val Eq    : (name * name * name * name * name) option -> tactic
 
-  (* H >> M = N ∈ per(R)
-   *   H >> per(R) ∈ U{k}
-   *   H >> R M N
+  (* H >> M = N ∈ per(a,b.R)
+   *   H >> per(a,b.R) ∈ U{k}
+   *   H >> R[a\M,b\N]
    *   H >> M ∈ Base
    *   H >> N ∈ Base
    *)
   val MemEq : Level.t option -> tactic
 
-  (* H, z : M = N ∈ per(R), J >> P
-   *   H, z : M = N ∈ per(R), [y : R M N], J >> P
-   *   H, z : M = N ∈ per(R), J >> R M N ∈ U{k}
+  (* H, z : M = N ∈ per(a,b.R), J >> P
+   *   H, z : M = N ∈ per(a,b.R), [y : R[a\M,b\N]], J >> P
+   *   H, z : M = N ∈ per(a,b.R), J >> R[a\M,b\N] ∈ U{k}
    *)
   val Elim  : hyp * name option * Level.t option -> tactic
 

--- a/src/syntax/jonprl_language_def.sml
+++ b/src/syntax/jonprl_language_def.sml
@@ -10,7 +10,7 @@ struct
   val nestedComments = true
 
   val fancyChars =
-      "-'_ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσΤτΥυΦφΧχΨψΩω¬⊗⊕∫+-!@#$%^&*⇓↓↼⇀↽⇁↿↾⇃⇂≼≅≡≈~⇔∩∪⋃⋂`◃?♮"
+      "-'_ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξὉΟΌοΠπΡρΣσΤτΥυΦφΧχΨψΩω¬⊗⊕∫+-!@#$%^&*⇓↓↼⇀↽⇁↿↾⇃⇂≼≅≡≈~⇔∩∪⋃⋂`◃?♮"
 
   val identLetter = letter || oneOf (String.explode fancyChars) || digit
   val identStart = identLetter

--- a/src/syntax/operator.sml
+++ b/src/syntax/operator.sml
@@ -84,7 +84,7 @@ struct
        | BUNION => #[0,0]
        | HASVALUE => #[0]
        | IMAGE => #[0,0]
-       | PER => #[0]
+       | PER => #[2]
        | QUOTIENT => #[0,2]
        | FIX => #[0]
        | CBV => #[0, 1]

--- a/src/syntax/tactic.sig
+++ b/src/syntax/tactic.sig
@@ -53,6 +53,9 @@ sig
       | CUT_LEMMA of operator * name option * meta
       | WF_LEMMA of operator * meta
       | UNHIDE of hyp * meta
+      | POINTWISE_FUNCTIONALITY of {target : hyp,
+				    names  : (name * name * name) option,
+				    level  : level option} * meta
       | SYMMETRY of meta
       | CEQUAL_SYM of meta
       | CEQUAL_STEP of meta

--- a/src/syntax/tactic.sml
+++ b/src/syntax/tactic.sml
@@ -51,6 +51,9 @@ struct
     | CUT_LEMMA of operator * name option * meta
     | WF_LEMMA of operator * meta
     | UNHIDE of hyp * meta
+    | POINTWISE_FUNCTIONALITY of {target : hyp,
+				  names  : (name * name * name) option,
+				  level  : level option} * meta
     | SYMMETRY of meta
     | CEQUAL_SYM of meta
     | CEQUAL_STEP of meta
@@ -174,6 +177,7 @@ struct
           | COMPLETE (t, meta) => COMPLETE (go t, meta)
           | BOTTOM_DIVERGES (h, meta) => BOTTOM_DIVERGES (applyHyp h, meta)
           | UNHIDE (h, meta) => UNHIDE (applyHyp h, meta)
+          | POINTWISE_FUNCTIONALITY ({target, names, level}, meta) => POINTWISE_FUNCTIONALITY ({target = applyHyp target, names = names, level = level}, meta)
 	  | ASSUME_HAS_VALUE ({name,level}, meta) => ASSUME_HAS_VALUE ({name = name, level = level}, meta)
           | HYPOTHESIS (h, meta) => HYPOTHESIS (applyHyp h, meta)
           | THIN (h, meta) => THIN (applyHyp h, meta)

--- a/src/tactic_eval.sml
+++ b/src/tactic_eval.sml
@@ -57,6 +57,7 @@ struct
       | CUT_LEMMA (theta, name, a) => an a (RefinerUtil.CutLemma (wld, theta, name))
       | WF_LEMMA (theta, a) => an a (RefinerUtil.WfLemma (wld, theta))
       | UNHIDE (hyp, a) => an a (RefinerUtil.Unhide hyp)
+      | POINTWISE_FUNCTIONALITY ({target,names,level}, a) => an a (PointwiseFunctionality (target, names, level))
       | SYMMETRY a => an a EqRules.Sym
       | CEQUAL_SYM a => an a CEqRules.Sym
       | CEQUAL_STEP a => an a CEqRules.Step


### PR DESCRIPTION
Thanks to @vrahli for putting this together. I'm opening the PR so that we have a more central way to discuss the changes. Summary:
1. Vincent has fixed #243. That's what happens when we just guess what a rule should be! :) In Nuprl, if you browse through the rules, you will see only `CallLisp` for this one, since it is not possible to express a variadic rule in Nuprl's rule calculus.
2. Vincent has resolved #241 (switching the `per` operator to have arity `(exp,exp.exp)exp` instead of `(exp)exp`). This is mostly a cosmetic change.
3. Vincent has added the Pointwise Functionality rule, which can be very useful.
4. I have fixed the proof that CTT is predicative (`russell.jonprl`). Vincent has fixed the halting problem proof. I've disabled some of the proofs in the synthetic topology development until I understand better how to reproduce them.
