### PR TITLE
Upgrade sml-telescopes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: sml
 before_install:
-  - sudo add-apt-repository -y ppa:hrzhu/smlnj-backport
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes smlnj
 install:

--- a/src/sources.cm
+++ b/src/sources.cm
@@ -2,7 +2,7 @@ group is
   ../lib/sml-abt/abt.cm
   ../lib/sml-lcf/lcf.cm
   ../lib/sml-conv/conv.cm
-  ../lib/sml-telescopes/telescopes.cm (bind:(anchor:libs value:../lib))
+  ../lib/sml-telescopes/telescopes.cm
   ../lib/sml-open-abt/open-abt.cm (bind:(anchor:libs value:../lib))
   ../lib/sml-parcom-wrapper/parcom.cm (bind:(anchor:libs value:../lib))
   ../lib/sml-abt-parser/abt-parser.cm (bind:(anchor:libs value:../lib))


### PR DESCRIPTION
The lib now manages its own dependencies, so no need for a path anchor.
